### PR TITLE
Enhancing Java Recipe Instructions

### DIFF
--- a/java-recipes/README.md
+++ b/java-recipes/README.md
@@ -1,5 +1,5 @@
 <div align="center">
-<div><img src="../../assets/redis-logo.svg" style="width: 130px"> </div>
+<div><img src="../assets/redis-logo.svg" style="width: 130px" alt=""> </div>
 <h1>Redis AI Java Resources</h1>
 <div align="center">
 
@@ -15,69 +15,16 @@
 <div></div>
 <br>
 
-[**Notebooks**](#notebooks) | [**Applications**](#applications) | [**Example Applications**](#example-applications)
+[**Notebooks**](#notebooks) | [**Applications**](#applications) | [**Example Applications**](#example-notebooks--applications)
 
 </div>
 <br>
 
-## Setup
-
-This project uses Docker Compose to set up a complete environment for running Java-based AI applications with Redis. The environment includes:
-
-- A Jupyter Notebook server with Java kernel support
-- Redis Stack (includes Redis and RedisInsight)
-- Pre-installed dependencies for AI/ML workloads
-
-### Prerequisites
-
-- [Docker](https://docs.docker.com/get-docker/) and [Docker Compose](https://docs.docker.com/compose/install/)
-- OpenAI API key (for notebooks that use OpenAI services)
-
-### Environment Configuration
-
-1. Create a `.env` file in the project root with your OpenAI API key:
-
-```bash
-OPENAI_API_KEY=your_openai_api_key_here
-```
-
-## Running the Project
-
-1. Clone the repository (if you haven't already):
-
-   ```bash
-   git clone https://github.com/redis-developer/redis-ai-resources.git
-   cd redis-ai-resources/java-recipes
-   ```
-
-2. Start the Docker containers:
-
-   ```bash
-   docker-compose up -d
-   ```
-
-3. Access the Jupyter environment:
-   - Open your browser and navigate to [http://localhost:8888](http://localhost:8888)
-   - The token is usually shown in the docker-compose logs. You can view them with:
-
-     ```bash
-     docker-compose logs jupyter
-     ```
-
-4. Access RedisInsight:
-   - Open your browser and navigate to [http://localhost:8001](http://localhost:8001)
-   - Connect to Redis using the following details:
-     - Host: redis-java
-     - Port: 6379
-     - No password (unless configured)
-
-5. When finished, stop the containers:
-
-   ```bash
-   docker-compose down
-   ```
+There are two types of Java Recipes: Notebooks and Applications. Notebooks are interactive, self-contained examples in Jupyter format that let you explore AI concepts step by step that mix code, explanations, and output in one place. Applications, on the other hand, are full Spring Boot projects meant for building real-world systems. They show how to structure, run, and scale actual AI-powered apps using Redis, embedding models, and Spring AI in a production-like setup.
 
 ## Notebooks
+
+Notebooks require a Jupyter Notebook environment to run. Check out the [Setup Instructions & Implementation Details](./notebooks/README.md) for more details on how to set up your environment.
 
 | Notebook                                                                             | Description                                                                                                  |
 |--------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------|


### PR DESCRIPTION
- Fixing path to Redis logo
- Explaining that there are two types of demos: notebooks & applications and the differences between them. 
- Fixing anchor to notebooks & applications section
- Adding explanation under the notebooks section that a Jupyter environment must be running before running the notebooks and directing people to the endpoint where they learn how to do so. 