### PR TITLE
Fix spelling of 'multi' in project title

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ No faster way to get started than by diving in and playing around with a demo.
 | [Restaurant Discovery AI Agent](https://github.com/redis-developer/restaurant-discovery-ai-agent-demo) | An Agentic AI restaurant discovery platform that combines Redis's speed with LangGraph's intelligent workflow orchestration. Get personalized restaurant recommendations, make reservations, and get lightning-fast responses through semantic caching.                                                    |
 | [Podcast Chatbot with Agent Memory](https://github.com/redis-developer/podcast-chatbot-with-agent-memory-azure-demo) | A chatbot that discusses and recommends podcasts. Affectionately called Podbot, it demonstrates how to use Redis Agent Memory Server to build context-aware agents with Azure Managed Redis. |
 | [Car Dealership Assistant with Agent Memory](https://github.com/redis-developer/dealership-chatbot-agent-memory-demo) | A Car Dealership chatbot  with Redis Agent Memory Server, showcasing short-term and long-term memory. |
-| [Multi-Agent AI Text Adventure Game with Agent Memory and LangGraph.js](https://github.com/redis-developer/mulit-agent-ai-text-adventure-game-with-agent-memory-langgraph-js-azure) | A text-adventure game that demonstrates how to build a multi-agent AI workflows with LangGraph.js, Azure Managed Redis, and Agent Memory Server. |
+| [Multi-Agent AI Text Adventure Game with Agent Memory and LangGraph.js](https://github.com/redis-developer/multi-agent-ai-text-adventure-game-with-agent-memory-langgraph-js-azure) | A text-adventure game that demonstrates how to build a multi-agent AI workflows with LangGraph.js, Azure Managed Redis, and Agent Memory Server. |
 
 ## Recipes
 


### PR DESCRIPTION
Corrected the spelling of 'multi' in the project title for consistency.