### PR TITLE
fix: Resolve some failures in nightly tests

### DIFF
--- a/.github/ignore-notebooks.txt
+++ b/.github/ignore-notebooks.txt
@@ -15,3 +15,4 @@ spring_ai_redis_rag.ipynb
 1_semantic_classification.ipynb
 2_semantic_tool_calling.ipynb
 3_semantic_guardrails.ipynb
+04_langcache_semantic_caching.ipynb

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -87,7 +87,7 @@ jobs:
 
     services:
       redis:
-        image: redis:8.4
+        image: redis:8
         ports:
           - 6379:6379
 

--- a/python-recipes/RAG/01_redisvl.ipynb
+++ b/python-recipes/RAG/01_redisvl.ipynb
@@ -53,10 +53,10 @@
      "output_type": "stream",
      "text": [
       "Cloning into 'temp_repo'...\r\n",
-      "remote: Enumerating objects: 679, done.\u001b[K\r\n",
-      "remote: Counting objects: 100% (330/330), done.\u001b[Kjects:  82% (271/330)\u001b[K\r\n",
-      "remote: Compressing objects: 100% (214/214), done.\u001b[K\r\n",
-      "remote: Total 679 (delta 227), reused 148 (delta 115), pack-reused 349 (from 2)\u001b[K\r\n",
+      "remote: Enumerating objects: 679, done.\u001B[K\r\n",
+      "remote: Counting objects: 100% (330/330), done.\u001B[Kjects:  82% (271/330)\u001B[K\r\n",
+      "remote: Compressing objects: 100% (214/214), done.\u001B[K\r\n",
+      "remote: Total 679 (delta 227), reused 148 (delta 115), pack-reused 349 (from 2)\u001B[K\r\n",
       "Receiving objects: 100% (679/679), 57.80 MiB | 11.09 MiB/s, done.\r\n",
       "Resolving deltas: 100% (295/295), done.\r\n",
       "mv: rename temp_repo/python-recipes/RAG/resources to ./resources: Directory not empty\r\n"
@@ -99,15 +99,13 @@
      "output_type": "stream",
      "text": [
       "\r\n",
-      "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m A new release of pip is available: \u001b[0m\u001b[31;49m24.0\u001b[0m\u001b[39;49m -> \u001b[0m\u001b[32;49m25.0.1\u001b[0m\r\n",
-      "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m To update, run: \u001b[0m\u001b[32;49mpip install --upgrade pip\u001b[0m\r\n",
+      "\u001B[1m[\u001B[0m\u001B[34;49mnotice\u001B[0m\u001B[1;39;49m]\u001B[0m\u001B[39;49m A new release of pip is available: \u001B[0m\u001B[31;49m24.0\u001B[0m\u001B[39;49m -> \u001B[0m\u001B[32;49m25.0.1\u001B[0m\r\n",
+      "\u001B[1m[\u001B[0m\u001B[34;49mnotice\u001B[0m\u001B[1;39;49m]\u001B[0m\u001B[39;49m To update, run: \u001B[0m\u001B[32;49mpip install --upgrade pip\u001B[0m\r\n",
       "Note: you may need to restart the kernel to use updated packages.\n"
      ]
     }
    ],
-   "source": [
-    "%pip install -q \"redisvl>=0.6.0\" langchain-community pypdf sentence-transformers langchain openai pandas"
-   ]
+   "source": "%pip install -q \"redisvl>=0.6.0\" langchain-community pypdf sentence-transformers langchain openai pandas"
   },
   {
    "cell_type": "markdown",
@@ -249,7 +247,7 @@
     }
    ],
    "source": [
-    "from langchain.text_splitter import RecursiveCharacterTextSplitter\n",
+    "from langchain_text_splitters import RecursiveCharacterTextSplitter\n",
     "from langchain_community.document_loaders import PyPDFLoader\n",
     "\n",
     "# Load list of pdfs from a folder\n",

--- a/python-recipes/RAG/02_langchain.ipynb
+++ b/python-recipes/RAG/02_langchain.ipynb
@@ -1,1048 +1,1048 @@
 {
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "R2-i8jBl9GRH"
-      },
-      "source": [
-        "![Redis](https://redis.io/wp-content/uploads/2024/04/Logotype.svg?auto=webp&quality=85,75&width=120)\n",
-        "# RAG with LangChain\n",
-        "\n",
-        "This notebook uses [LangChain](https://python.langchain.com/docs/get_started/introduction) and [Redis](https://redis.com) to perform document + embdding indexing and semantic search tasks. It also shows how to integrate with an LLM like OpenAI's GPT models. See the full partner package source code [here](https://github.com/langchain-ai/langchain-redis/tree/main).\n",
-        "\n",
-        "## Let's Begin!\n",
-        "<a href=\"https://colab.research.google.com/github/redis-developer/redis-ai-resources/blob/main/python-recipes/RAG/02_langchain.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "ctOVb_LZ1vmk"
-      },
-      "source": [
-        "## Environment Setup\n",
-        "\n",
-        "### Pull Github Materials\n",
-        "Because you are likely running this notebook in **Google Colab**, we need to first\n",
-        "pull the necessary dataset and materials directly from GitHub. The following commands grab the material, move to root for colab, and clean up unneeded files.\n",
-        "\n",
-        "**If you are running this notebook locally**, FYI you may not need to perform this\n",
-        "step at all."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "UQezgPCG1vml",
-        "outputId": "97b9bc03-da1b-439a-c37b-be6fdb58ab21"
-      },
-      "outputs": [],
-      "source": [
-        "# NBVAL_SKIP\n",
-        "!git clone https://github.com/redis-developer/redis-ai-resources.git temp_repo\n",
-        "!mv temp_repo/python-recipes/RAG/resources .\n",
-        "!rm -rf temp_repo"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "9eieJowO1vmo"
-      },
-      "source": [
-        "### Install Python Dependencies"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 23,
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "B3v1wUzX1vmq",
-        "outputId": "84a3feff-e7c1-41ba-9ab1-8c975074552e"
-      },
-      "outputs": [
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "huggingface/tokenizers: The current process just got forked, after parallelism has already been used. Disabling parallelism to avoid deadlocks...\n",
-            "To disable this warning, you can either:\n",
-            "\t- Avoid using `tokenizers` before the fork if possible\n",
-            "\t- Explicitly set the environment variable TOKENIZERS_PARALLELISM=(true | false)\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "\n",
-            "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m A new release of pip is available: \u001b[0m\u001b[31;49m24.0\u001b[0m\u001b[39;49m -> \u001b[0m\u001b[32;49m25.0.1\u001b[0m\n",
-            "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m To update, run: \u001b[0m\u001b[32;49mpip install --upgrade pip\u001b[0m\n",
-            "Note: you may need to restart the kernel to use updated packages.\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "huggingface/tokenizers: The current process just got forked, after parallelism has already been used. Disabling parallelism to avoid deadlocks...\n",
-            "To disable this warning, you can either:\n",
-            "\t- Avoid using `tokenizers` before the fork if possible\n",
-            "\t- Explicitly set the environment variable TOKENIZERS_PARALLELISM=(true | false)\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "\n",
-            "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m A new release of pip is available: \u001b[0m\u001b[31;49m24.0\u001b[0m\u001b[39;49m -> \u001b[0m\u001b[32;49m25.0.1\u001b[0m\n",
-            "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m To update, run: \u001b[0m\u001b[32;49mpip install --upgrade pip\u001b[0m\n",
-            "Note: you may need to restart the kernel to use updated packages.\n"
-          ]
-        }
-      ],
-      "source": [
-        "%pip install -q redis \"unstructured[pdf]\" sentence-transformers langchain \n",
-        "%pip install -q langchain-community \"langchain-redis>=0.2.0\" langchain-huggingface langchain-openai"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "### Install Redis Stack\n",
-        "\n",
-        "Later in this tutorial, Redis will be used to store, index, and query vector\n",
-        "embeddings created from PDF document chunks. **We need to make sure we have a Redis\n",
-        "instance available.**"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "#### For Colab\n",
-        "Use the shell script below to download, extract, and install [Redis Stack](https://redis.io/docs/getting-started/install-stack/) directly from the Redis package archive."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "# NBVAL_SKIP\n",
-        "%%sh\n",
-        "curl -fsSL https://packages.redis.io/gpg | sudo gpg --dearmor -o /usr/share/keyrings/redis-archive-keyring.gpg\n",
-        "echo \"deb [signed-by=/usr/share/keyrings/redis-archive-keyring.gpg] https://packages.redis.io/deb $(lsb_release -cs) main\" | sudo tee /etc/apt/sources.list.d/redis.list\n",
-        "sudo apt-get update  > /dev/null 2>&1\n",
-        "sudo apt-get install redis-stack-server  > /dev/null 2>&1\n",
-        "redis-stack-server --daemonize yes"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "#### For Alternative Environments\n",
-        "There are many ways to get the necessary redis-stack instance running\n",
-        "1. On cloud, deploy a [FREE instance of Redis in the cloud](https://redis.com/try-free/). Or, if you have your\n",
-        "own version of Redis Enterprise running, that works too!\n",
-        "2. Per OS, [see the docs](https://redis.io/docs/latest/operate/oss_and_stack/install/install-stack/)\n",
-        "3. With docker: `docker run -d --name redis-stack-server -p 6379:6379 redis/redis-stack-server:latest`"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "### Define the Redis Connection URL\n",
-        "\n",
-        "By default this notebook connects to the local instance of Redis Stack. **If you have your own Redis Enterprise instance** - replace REDIS_PASSWORD, REDIS_HOST and REDIS_PORT values with your own."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 1,
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "import os\n",
-        "import warnings\n",
-        "warnings.filterwarnings('ignore')\n",
-        "\n",
-        "# Replace values below with your own if using Redis Cloud instance\n",
-        "REDIS_HOST = os.getenv(\"REDIS_HOST\", \"localhost\") # ex: \"redis-18374.c253.us-central1-1.gce.cloud.redislabs.com\"\n",
-        "REDIS_PORT = os.getenv(\"REDIS_PORT\", \"6379\")      # ex: 18374\n",
-        "REDIS_PASSWORD = os.getenv(\"REDIS_PASSWORD\", \"\")  # ex: \"1TNxTEdYRDgIDKM2gDfasupCADXXXX\"\n",
-        "\n",
-        "# If SSL is enabled on the endpoint, use rediss:// as the URL prefix\n",
-        "REDIS_URL = f\"redis://:{REDIS_PASSWORD}@{REDIS_HOST}:{REDIS_PORT}\""
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "## RAG with LangChain"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "7MaVqU8Y1vms"
-      },
-      "source": [
-        "### Dataset Preparation (PDF Documents)\n",
-        "\n",
-        "To best demonstrate Redis as a vector database layer, we will load a single\n",
-        "financial (10k filings) doc and preprocess it using some helpers from LangChain:\n",
-        "\n",
-        "- `UnstructuredFileLoader` is not the only document loader type that LangChain provides. Docs: https://python.langchain.com/docs/integrations/document_loaders/unstructured_file\n",
-        "- `RecursiveCharacterTextSplitter` is what we use to create smaller chunks of text from the doc. Docs: https://python.langchain.com/docs/modules/data_connection/document_transformers/text_splitters/recursive_text_splitter"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 2,
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "I7VS1bPr1vmt",
-        "outputId": "72299230-26c4-4d80-d61f-138616e2173b"
-      },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Listing available documents ... ['resources/nke-10k-2023.pdf', 'resources/amzn-10k-2023.pdf', 'resources/metrics_2500_0.csv', 'resources/jnj-10k-2023.pdf', 'resources/aapl-10k-2023.pdf', 'resources/testset_15.csv', 'resources/retrieval_basic_rag_test.csv', 'resources/2022-chevy-colorado-ebrochure.pdf', 'resources/nvd-10k-2023.pdf', 'resources/testset.csv', 'resources/msft-10k-2023.pdf', 'resources/propositions.json', 'resources/generation_basic_rag_test.csv']\n"
-          ]
-        }
-      ],
-      "source": [
-        "from langchain.text_splitter import RecursiveCharacterTextSplitter\n",
-        "from langchain.document_loaders import UnstructuredFileLoader\n",
-        "\n",
-        "# Load list of pdfs from a folder\n",
-        "data_path = \"resources/\"\n",
-        "docs = [os.path.join(data_path, file) for file in os.listdir(data_path)]\n",
-        "\n",
-        "print(\"Listing available documents ...\", docs)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 3,
-      "metadata": {},
-      "outputs": [
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "/var/folders/_g/rr4lnxxx1_z7m78lz89dhvsm0000gp/T/ipykernel_45325/1931079106.py:8: LangChainDeprecationWarning: The class `UnstructuredFileLoader` was deprecated in LangChain 0.2.8 and will be removed in 1.0. An updated version of the class exists in the :class:`~langchain-unstructured package and should be used instead. To use it run `pip install -U :class:`~langchain-unstructured` and import as `from :class:`~langchain_unstructured import UnstructuredLoader``.\n",
-            "  loader = UnstructuredFileLoader(\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Done preprocessing. Created 179 chunks of the original pdf resources/nke-10k-2023.pdf\n"
-          ]
-        }
-      ],
-      "source": [
-        "# pick out the Nike doc for this exercise\n",
-        "doc = [doc for doc in docs if \"nke\" in doc][0]\n",
-        "\n",
-        "# set up the file loader/extractor and text splitter to create chunks\n",
-        "text_splitter = RecursiveCharacterTextSplitter(\n",
-        "    chunk_size=2500, chunk_overlap=0\n",
-        ")\n",
-        "loader = UnstructuredFileLoader(\n",
-        "    doc, mode=\"single\", strategy=\"fast\"\n",
-        ")\n",
-        "\n",
-        "# extract, load, and make chunks\n",
-        "chunks = loader.load_and_split(text_splitter)\n",
-        "\n",
-        "print(\"Done preprocessing. Created\", len(chunks), \"chunks of the original pdf\", doc)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "96BzcyW31vmw"
-      },
-      "source": [
-        "### Initialize Embeddings Model\n",
-        "Here we will use LangChain's built in embedding engine so that it will work seemlessly with the LangChain VectorStore classes."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 4,
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 465,
-          "referenced_widgets": [
-            "e822a189950844309e630f3e428d5a9a",
-            "d3e5c2097a8e44f481e91646e0410e62",
-            "b1e8dcf4ead64c5b8155594fd1d20632",
-            "bd042dad15084b098dfbf7c9277d3581",
-            "54c512a0bb9f485a9612f088c717eec8",
-            "e769ce42211749599822ffc3a18e7292",
-            "0d6362898099436abb80e52eac043c4f",
-            "e3afaca826464f94b6b904e68c827cab",
-            "27ba4306f92c4d659cadcd5c1e0ab787",
-            "15378b3263a449fabf00643fdd23565e",
-            "aee906bc037849e2be3ac68955281892",
-            "2e3997001c494151829379467dde2182",
-            "0281867e8ce8433fb665e287505d0404",
-            "d6ff7f1d2a6b44ff829212b67613e03b",
-            "3402b3afe4304aec81a1e4389e2eafec",
-            "fc32fd51efd2488e9bff38274079d7e5",
-            "07a6bd4b6a484dbebda92c366f3a6740",
-            "13fb05f6cbe24acba47be67e8b0a69a6",
-            "3d30fc25d10e4ce18d50320a88b0a2ec",
-            "ebe649c53e4d48fda0d4ea9a46ec5613",
-            "843c2b0500ee4219841c959f3af20542",
-            "d84881099d4f4f1fa8a481ea9f9dafdd",
-            "04c8bb6bb7c8425b92e0f3fab63d8362",
-            "4d54077e8c38411080b1ef9bfb42e3f8",
-            "b8c9c7fb7b6e4dcfb717f96da1639553",
-            "52961d70221846f78523df1414eb3436",
-            "008e25d7de5e4e548d80be81e26bdb8f",
-            "b0d11b0e853740b7b8e49e5158c940e5",
-            "ac450c103bb44f549a7103f67634f9bf",
-            "99204cde99b348ccb4f45589802f5a38",
-            "2860317abc5b41fab94f8fefe9cb6b3b",
-            "30ebda1e38294648b014354009c17269",
-            "755e63baf4ad4a289fd756d662d9a0bf",
-            "723ef31f042343bd94217075e1857989",
-            "820afc900ef34cdc82f4e5d7c38fb67f",
-            "f06938274c0d4b4591b6cfa2e7a8d183",
-            "1ab52b039fdb4cab909eb439a4ea3524",
-            "d1e27bbac128455e9a0e959ba251eedd",
-            "ff4297f185ce4f2eaf340a422b721774",
-            "168314c6ae1044d6810def7ff06f80c2",
-            "dad25775795b46ec9e7bb788b1d25f82",
-            "4e74d1276be141c9b0f2601ce4c7246a",
-            "2dff47a7d6364e2ba73f057e9b17a705",
-            "f4b4bc8eeef84da2abcf1691e174a080",
-            "6dbbd3a5f81b46d99c9c897dba53d6a5",
-            "b63b4da89d0f45819ad0aead03833f4c",
-            "27725152494c4f0b85e48bf081113764",
-            "8d8356cdf3b54b2daa02fe6d06c2b372",
-            "e61f0ecfe4794a4d929b76b8a5434800",
-            "b1e6fa50486c4973b44b20e29c4837a9",
-            "5d3f0bfd81b34819a6edce0496958f5a",
-            "266abb8c7e064dbea106c6c2903404c3",
-            "59317d931ba14c409d7f9baae6b4b2fc",
-            "da5242e187fd4d6c950e7a75cebb33fa",
-            "a28d8e8eedf34026afe93d2105d7d779",
-            "b4683c36fb744ac18ed8f98f1d352d16",
-            "a68f0e29f8f745fab98bd16b4835956a",
-            "d7791474a31b4ef7bffecdd264cbd0a5",
-            "e49064443c9549ebb7a6d0710d2ad02e",
-            "ee0db8230ae64f1b94e246e2947682a3",
-            "cff28f0f731c48e88de8ccad15146e2f",
-            "af1f8d072046449d9437cb10ccdb2218",
-            "a1f692c86e6d4c668f31bcb4f4189f48",
-            "a8b7b5ad3c954b94bda03987653ce1c8",
-            "32a5f8335e3a4312aea8bb83505b4ed3",
-            "0d4624d3273d46268299e37d96c0d85d",
-            "7c1867628e4742868ba1e1fa322b948e",
-            "35e9d31c8cfb41199df0e4636537a9c0",
-            "f1fff6bb909d4fcbbe0a7582fe5a09d4",
-            "0b3b28fae35d497886c72e4222470629",
-            "bfd29912ee224c4e93ec37f545339586",
-            "d335cf6ac50b46f5a50870069a14a066",
-            "5b7765acd2024e04ba423edc346fe021",
-            "96c778b21e154c77952c3b6456831f6a",
-            "67730a22939d42db8894a633483fd412",
-            "c3e15e863ece4df88d1ad4fa4601fb43",
-            "ce7fbbb4b844429aa16d60c6524bb6ca",
-            "0d1bc800782745a9b89e93bb992e0ce0",
-            "369c5197fd23479c8aa79ac72cbea260",
-            "5317c63c5168499eb992b4d764761dfc",
-            "364519d35ab848199a6fb3e15906318a",
-            "8b7e8c8ff5f3478aa064f5b79ffaaadf",
-            "ccb27092ee314285add51fd91e5ca49d",
-            "61f3b41fdcf04cff88dd08b36a4a5f41",
-            "816a516fa90f43a18dfda92374c2f4ed",
-            "7d8e2e3c678642afba660b450d5f3201",
-            "872caf759d1f45439397ee35c8cf5dc0",
-            "74b0c9b3b9944eab80f16b2789d6c041",
-            "27b3516e55614d1e91ce4c87c022ee0a",
-            "3991f774ac7f492993002be26cd67f18",
-            "d6804472f88d4254925b7b006a97b2c8",
-            "e0cae801b89e43598bab0ce7f38d7042",
-            "09049b516bc545ea844a770021f6812a",
-            "6a3ae2fa53c942edbb1b29a86717ad89",
-            "3da15201c5da4e40b0b3ac999552723a",
-            "bda924a0e1364f89a7f6c9c5ceb03b62",
-            "7a83acfd4fb240c181f127fc7ee07d48",
-            "d6ebd756685b4a589332a3598a25cd89",
-            "f3d585528e6a4962bfb93afbe92b6312",
-            "879c273bd3924ec0acaec655a92350e0",
-            "744ba6e1b34e4883b49c138ab1bdbebc",
-            "d449ea30c72044f986ffc3e1f9a128d8",
-            "976d3f30f0654d48b096a5c39a8dece5",
-            "41685bf8cb4344368edf161b66ae15b2",
-            "7034b97b70c84a01a3d48e316814b555",
-            "39a239df60004a039de689a69c571afc",
-            "1b2f3f0c7afd419e88f061d0c3280989",
-            "701d2879a67c4b86b9f9de76ff675e7c",
-            "955d7c1b76b348549daceb8482a8e825",
-            "2d0a785ceb884a1f9ee020d22c987fa1",
-            "543e7442413d4035bb6949ccbab5cb6b",
-            "5d47f3871bf44a469dcfd0e456d3dae0",
-            "bbb1a53611e14dcb9b028fe82d71e317",
-            "0d31b15287954c3094750dd36a10d47a",
-            "9818040fcf844fd9b00cd0e438209d40",
-            "7c269846386c4f14bfafde1d5c0e871e",
-            "b11227ec73784e09871e0c25131b9f86",
-            "4083110114e3443c920cbeb8c396d4da",
-            "366cf22df75b42509e5610ff9c9b1d3d",
-            "ff231927834c41088becbe8f94f96f7b",
-            "6e3f1af22a534a7ebdb9752acb7f1b96",
-            "7a6e695c3dcf417f9f53ceb019e37111",
-            "5bf9cc6f60614542bf0628586b8560dd",
-            "d08483b9393840cfb36dd504514043c4",
-            "d36c28d414af4712b16a7f0543f61fc9",
-            "00b534687273409fbc18960bb7db0907",
-            "a27b96cc3ce944549ba2d26f5d7338c2",
-            "75f27178134f477db58ef7cfc487897b",
-            "e2816b9d2a21443c82b547466c3347d1",
-            "0a9b8aa436604adc85c1f9a86a9889a6",
-            "37e5517b0c7b45e0ad3366d4daf5b668",
-            "58f9c1e1f51f49c48c6dc6b441078218",
-            "a8114c2300b74599b0652601806b080e",
-            "e211cf2a0e6d4d1096bfb9dfaae00cbb",
-            "f63c59800b0845b8bc8d9c2cce8bafc0",
-            "1f7ba17ad64c4ab68fe963eaf7a1efa7",
-            "05d146ed0f084dac8845c32c4bb28cff",
-            "d05d9073ecd2434da541da9d71c3a907",
-            "52a56e10c8084ce999802b6db17ab78e",
-            "84e4dc1690b642b7b00f5e1cedff91e8",
-            "0ab7b921de994f6980493fb89d3b8572",
-            "6ff193e5c339435cba696e69b4a1ea20",
-            "7ebc91105d344011898341ce4f7edce0",
-            "ae72de3e05a4461d9c2b0c1f953894b2",
-            "69d7c03c926e441a9bccfbe86fd5731d",
-            "9e0ba3c3e2a84f43ae708c89203c814a",
-            "b2b8a580aa1944e6a00106f47070935c",
-            "cf7adc55be354c75b64d9a94285ea8f9",
-            "770d6b0784674359a669f3f1836a5876",
-            "c60fc7a6181a40d489ff43af79ff29b4",
-            "4ffcc071ec56449ba865c876bc5cff5c",
-            "a9c792cb80884e0899da0f40d9472e97",
-            "7ba192f9998e41b782db482b60655f86",
-            "737a0eaff10c4237a67cbd680160ee91"
-          ]
-        },
-        "id": "_h1e-L9yZfaY",
-        "outputId": "fd540dd7-a0aa-4827-e001-f6d4ef603c6a"
-      },
-      "outputs": [],
-      "source": [
-        "from langchain_huggingface import HuggingFaceEmbeddings\n",
-        "\n",
-        "embeddings = HuggingFaceEmbeddings(model_name=\"sentence-transformers/all-MiniLM-L6-v2\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "Qrj-jeGmBRTL"
-      },
-      "source": [
-        "## Vector Search with LangChain\n",
-        "### Create Redis vector store instance\n",
-        "\n",
-        "We also need to create a schema for the vector index so we can take advantage of the metadata along with the vectors.\n",
-        "\n",
-        "**Important Note**: LangChain does not support JSON data types yet. Only supports HASH for now. This update should be coming soon."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 5,
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "yY69FViAjNv1",
-        "outputId": "ab7b212b-3c55-44b1-cf72-6eb926cf302f"
-      },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "16:18:04 redisvl.index.index INFO   Index already exists, not overwriting.\n"
-          ]
-        }
-      ],
-      "source": [
-        "from langchain_redis import RedisVectorStore\n",
-        "\n",
-        "index_name = \"langchain_ex\"\n",
-        "\n",
-        "# construct the vector store class from texts and metadata\n",
-        "rds = RedisVectorStore.from_documents(\n",
-        "    chunks,\n",
-        "    embeddings,\n",
-        "    index_name=index_name,\n",
-        "    redis_url=REDIS_URL,\n",
-        "    metadata_schema=[\n",
-        "        {\n",
-        "            \"name\": \"source\",\n",
-        "            \"type\": \"text\"\n",
-        "        },\n",
-        "    ]\n",
-        ")"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 6,
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "gntcxF1P1vmx",
-        "outputId": "3bef4861-8778-4ab7-fb61-710aba655f2c"
-      },
-      "outputs": [
-        {
-          "data": {
-            "text/plain": [
-              "1123"
-            ]
-          },
-          "execution_count": 6,
-          "metadata": {},
-          "output_type": "execute_result"
-        }
-      ],
-      "source": [
-        "# access underlying redis client to see how many docs have been stores\n",
-        "rds._index.client.dbsize()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "61xV5qyp1vmy"
-      },
-      "source": [
-        "### Query the database\n",
-        "Now we can use the LangChain vector store class to perform similarity search operations on Redis"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 7,
-      "metadata": {
-        "id": "Gv6SxKOB1vmy"
-      },
-      "outputs": [],
-      "source": [
-        "from redisvl.query.filter import Text"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 8,
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "Q3pH3MPD1vmy",
-        "outputId": "2754347f-be31-4a38-d356-31ecc235ffe8"
-      },
-      "outputs": [
-        {
-          "data": {
-            "text/plain": [
-              "[(Document(metadata={'source': 'resources/nke-10k-2023.pdf'}, page_content=\"(Dollars in millions, except per share data)\\n\\nRevenues Cost of sales\\n\\nGross profit Gross margin\\n\\nDemand creation expense Operating overhead expense\\n\\nTotal selling and administrative expense % of revenues\\n\\nInterest expense (income), net\\n\\nOther (income) expense, net Income before income taxes\\n\\nIncome tax expense Effective tax rate\\n\\nNET INCOME Diluted earnings per common share\\n\\n$\\n\\n$ $\\n\\nFISCAL 2023\\n\\n51,217 28,925\\n\\n22,292\\n\\n43.5 %\\n\\n4,060 12,317\\n\\n16,377\\n\\n32.0 % (6)\\n\\n(280) 6,201\\n\\n1,131\\n\\n18.2 %\\n\\n5,070 3.23\\n\\n$\\n\\n$ $\\n\\nFISCAL 2022\\n\\n46,710 25,231\\n\\n21,479\\n\\n46.0 %\\n\\n3,850 10,954\\n\\n14,804\\n\\n31.7 % 205\\n\\n(181) 6,651\\n\\n605 9.1 %\\n\\n6,046 3.75\\n\\n% CHANGE\\n\\n10 % $ 15 %\\n\\n4 %\\n\\n5 % 12 %\\n\\n11 %\\n\\n—\\n\\n— -7 %\\n\\n87 %\\n\\n16 % $ -14 % $\\n\\nFISCAL 2021\\n\\n% CHANGE\\n\\n44,538 24,576\\n\\n5 % 3 %\\n\\n19,962\\n\\n8 %\\n\\n44.8 %\\n\\n3,114 9,911\\n\\n24 % 11 %\\n\\n13,025\\n\\n14 %\\n\\n29.2 % 262\\n\\n—\\n\\n14 6,661\\n\\n— 0 %\\n\\n934 14.0 %\\n\\n35 %\\n\\n5,727 3.56\\n\\n6 % 5 %\\n\\n2023 FORM 10-K 31\\n\\nTable of Contents\\n\\nCONSOLIDATED OPERATING RESULTS REVENUES\\n\\n(Dollars in millions)\\n\\nFISCAL 2023\\n\\nFISCAL 2022\\n\\n% CHANGE\\n\\n% CHANGE EXCLUDING CURRENCY (1) CHANGES\\n\\nFISCAL 2021\\n\\n% CHANGE\\n\\nNIKE, Inc. Revenues:\\n\\nNIKE Brand Revenues by:\\n\\nFootwear Apparel\\n\\n$\\n\\n33,135 $ 13,843\\n\\n29,143 13,567\\n\\n14 % 2 %\\n\\n20 % $ 8 %\\n\\n28,021 12,865\\n\\n4 % 5 %\\n\\nEquipment Global Brand Divisions\\n\\n(2)\\n\\nTotal NIKE Brand Revenues\\n\\n$\\n\\n1,727 58\\n\\n48,763 $\\n\\n1,624 102 44,436\\n\\n6 % -43 % 10 %\\n\\n13 % -43 % 16 % $\\n\\n1,382 25 42,293\\n\\n18 % 308 % 5 %\\n\\nConverse Corporate\\n\\n(3)\\n\\n2,427 27\\n\\n2,346 (72)\\n\\n3 % —\\n\\n8 % —\\n\\n2,205 40\\n\\n6 % —\\n\\nTOTAL NIKE, INC. REVENUES\\n\\n$\\n\\n51,217 $\\n\\n46,710\\n\\n10 %\\n\\n16 % $\\n\\n44,538\\n\\n5 %\\n\\nSupplemental NIKE Brand Revenues Details: NIKE Brand Revenues by:\\n\\nSales to Wholesale Customers\\n\\n$\\n\\n27,397 $\\n\\n25,608\\n\\n7 %\\n\\n14 % $\\n\\n25,898\\n\\n1 %\\n\\nSales through NIKE Direct Global Brand Divisions\\n\\n(2)\\n\\n21,308 58\\n\\n18,726 102\\n\\n14 % -43 %\\n\\n20 % -43 %\\n\\n16,370 25\\n\\n14 % 308 %\\n\\nTOTAL NIKE BRAND REVENUES (1) NIKE Brand Revenues on a Wholesale Equivalent Basis :\\n\\n$\\n\\n48,763 $\\n\\n44,436\\n\\n10 %\\n\\n16 % $\\n\\n42,293\\n\\n5 %\\n\\nSales to Wholesale Customers Sales from our Wholesale Operations to NIKE Direct Operations\\n\\nTOTAL NIKE BRAND WHOLESALE EQUIVALENT REVENUES NIKE Brand Wholesale Equivalent Revenues by:\\n\\n(1),(4)\\n\\n$\\n\\n$\\n\\n27,397 $ 12,730\\n\\n40,127 $\\n\\n25,608 10,543\\n\\n36,151\\n\\n7 % 21 %\\n\\n11 %\\n\\n14 % $ 27 %\\n\\n18 % $\\n\\n25,898 9,872\\n\\n35,770\\n\\n1 % 7 % 1 %\\n\\nMen's Women's NIKE Kids'\\n\\n$\\n\\n20,733 $ 8,606 5,038\\n\\n18,797 8,273 4,874\\n\\n10 % 4 % 3 %\\n\\n17 % $ 11 % 10 %\\n\\n18,391 8,225 4,882\\n\\n2 % 1 % 0 %\\n\\nJordan Brand (5) Others\\n\\n6,589 (839)\\n\\n5,122 (915)\\n\\n29 % 8 %\\n\\n35 % -3 %\"),\n",
-              "  0.499011814594),\n",
-              " (Document(metadata={'source': 'resources/nke-10k-2023.pdf'}, page_content=\"(Dollars in millions, except per share data)\\n\\nRevenues Cost of sales\\n\\nGross profit Gross margin\\n\\nDemand creation expense Operating overhead expense\\n\\nTotal selling and administrative expense % of revenues\\n\\nInterest expense (income), net\\n\\nOther (income) expense, net Income before income taxes\\n\\nIncome tax expense Effective tax rate\\n\\nNET INCOME Diluted earnings per common share\\n\\n$\\n\\n$ $\\n\\nFISCAL 2023\\n\\n51,217 28,925\\n\\n22,292\\n\\n43.5 %\\n\\n4,060 12,317\\n\\n16,377\\n\\n32.0 % (6)\\n\\n(280) 6,201\\n\\n1,131\\n\\n18.2 %\\n\\n5,070 3.23\\n\\n$\\n\\n$ $\\n\\nFISCAL 2022\\n\\n46,710 25,231\\n\\n21,479\\n\\n46.0 %\\n\\n3,850 10,954\\n\\n14,804\\n\\n31.7 % 205\\n\\n(181) 6,651\\n\\n605 9.1 %\\n\\n6,046 3.75\\n\\n% CHANGE\\n\\n10 % $ 15 %\\n\\n4 %\\n\\n5 % 12 %\\n\\n11 %\\n\\n—\\n\\n— -7 %\\n\\n87 %\\n\\n16 % $ -14 % $\\n\\nFISCAL 2021\\n\\n% CHANGE\\n\\n44,538 24,576\\n\\n5 % 3 %\\n\\n19,962\\n\\n8 %\\n\\n44.8 %\\n\\n3,114 9,911\\n\\n24 % 11 %\\n\\n13,025\\n\\n14 %\\n\\n29.2 % 262\\n\\n—\\n\\n14 6,661\\n\\n— 0 %\\n\\n934 14.0 %\\n\\n35 %\\n\\n5,727 3.56\\n\\n6 % 5 %\\n\\n2023 FORM 10-K 31\\n\\nTable of Contents\\n\\nCONSOLIDATED OPERATING RESULTS REVENUES\\n\\n(Dollars in millions)\\n\\nFISCAL 2023\\n\\nFISCAL 2022\\n\\n% CHANGE\\n\\n% CHANGE EXCLUDING CURRENCY (1) CHANGES\\n\\nFISCAL 2021\\n\\n% CHANGE\\n\\nNIKE, Inc. Revenues:\\n\\nNIKE Brand Revenues by:\\n\\nFootwear Apparel\\n\\n$\\n\\n33,135 $ 13,843\\n\\n29,143 13,567\\n\\n14 % 2 %\\n\\n20 % $ 8 %\\n\\n28,021 12,865\\n\\n4 % 5 %\\n\\nEquipment Global Brand Divisions\\n\\n(2)\\n\\nTotal NIKE Brand Revenues\\n\\n$\\n\\n1,727 58\\n\\n48,763 $\\n\\n1,624 102 44,436\\n\\n6 % -43 % 10 %\\n\\n13 % -43 % 16 % $\\n\\n1,382 25 42,293\\n\\n18 % 308 % 5 %\\n\\nConverse Corporate\\n\\n(3)\\n\\n2,427 27\\n\\n2,346 (72)\\n\\n3 % —\\n\\n8 % —\\n\\n2,205 40\\n\\n6 % —\\n\\nTOTAL NIKE, INC. REVENUES\\n\\n$\\n\\n51,217 $\\n\\n46,710\\n\\n10 %\\n\\n16 % $\\n\\n44,538\\n\\n5 %\\n\\nSupplemental NIKE Brand Revenues Details: NIKE Brand Revenues by:\\n\\nSales to Wholesale Customers\\n\\n$\\n\\n27,397 $\\n\\n25,608\\n\\n7 %\\n\\n14 % $\\n\\n25,898\\n\\n1 %\\n\\nSales through NIKE Direct Global Brand Divisions\\n\\n(2)\\n\\n21,308 58\\n\\n18,726 102\\n\\n14 % -43 %\\n\\n20 % -43 %\\n\\n16,370 25\\n\\n14 % 308 %\\n\\nTOTAL NIKE BRAND REVENUES (1) NIKE Brand Revenues on a Wholesale Equivalent Basis :\\n\\n$\\n\\n48,763 $\\n\\n44,436\\n\\n10 %\\n\\n16 % $\\n\\n42,293\\n\\n5 %\\n\\nSales to Wholesale Customers Sales from our Wholesale Operations to NIKE Direct Operations\\n\\nTOTAL NIKE BRAND WHOLESALE EQUIVALENT REVENUES NIKE Brand Wholesale Equivalent Revenues by:\\n\\n(1),(4)\\n\\n$\\n\\n$\\n\\n27,397 $ 12,730\\n\\n40,127 $\\n\\n25,608 10,543\\n\\n36,151\\n\\n7 % 21 %\\n\\n11 %\\n\\n14 % $ 27 %\\n\\n18 % $\\n\\n25,898 9,872\\n\\n35,770\\n\\n1 % 7 % 1 %\\n\\nMen's Women's NIKE Kids'\\n\\n$\\n\\n20,733 $ 8,606 5,038\\n\\n18,797 8,273 4,874\\n\\n10 % 4 % 3 %\\n\\n17 % $ 11 % 10 %\\n\\n18,391 8,225 4,882\\n\\n2 % 1 % 0 %\\n\\nJordan Brand (5) Others\\n\\n6,589 (839)\\n\\n5,122 (915)\\n\\n29 % 8 %\\n\\n35 % -3 %\"),\n",
-              "  0.499011814594),\n",
-              " (Document(metadata={'source': 'resources/nke-10k-2023.pdf'}, page_content=\"(Dollars in millions, except per share data)\\n\\nRevenues Cost of sales\\n\\nGross profit Gross margin\\n\\nDemand creation expense Operating overhead expense\\n\\nTotal selling and administrative expense % of revenues\\n\\nInterest expense (income), net\\n\\nOther (income) expense, net Income before income taxes\\n\\nIncome tax expense Effective tax rate\\n\\nNET INCOME Diluted earnings per common share\\n\\n$\\n\\n$ $\\n\\nFISCAL 2023\\n\\n51,217 28,925\\n\\n22,292\\n\\n43.5 %\\n\\n4,060 12,317\\n\\n16,377\\n\\n32.0 % (6)\\n\\n(280) 6,201\\n\\n1,131\\n\\n18.2 %\\n\\n5,070 3.23\\n\\n$\\n\\n$ $\\n\\nFISCAL 2022\\n\\n46,710 25,231\\n\\n21,479\\n\\n46.0 %\\n\\n3,850 10,954\\n\\n14,804\\n\\n31.7 % 205\\n\\n(181) 6,651\\n\\n605 9.1 %\\n\\n6,046 3.75\\n\\n% CHANGE\\n\\n10 % $ 15 %\\n\\n4 %\\n\\n5 % 12 %\\n\\n11 %\\n\\n—\\n\\n— -7 %\\n\\n87 %\\n\\n16 % $ -14 % $\\n\\nFISCAL 2021\\n\\n% CHANGE\\n\\n44,538 24,576\\n\\n5 % 3 %\\n\\n19,962\\n\\n8 %\\n\\n44.8 %\\n\\n3,114 9,911\\n\\n24 % 11 %\\n\\n13,025\\n\\n14 %\\n\\n29.2 % 262\\n\\n—\\n\\n14 6,661\\n\\n— 0 %\\n\\n934 14.0 %\\n\\n35 %\\n\\n5,727 3.56\\n\\n6 % 5 %\\n\\n2023 FORM 10-K 31\\n\\nTable of Contents\\n\\nCONSOLIDATED OPERATING RESULTS REVENUES\\n\\n(Dollars in millions)\\n\\nFISCAL 2023\\n\\nFISCAL 2022\\n\\n% CHANGE\\n\\n% CHANGE EXCLUDING CURRENCY (1) CHANGES\\n\\nFISCAL 2021\\n\\n% CHANGE\\n\\nNIKE, Inc. Revenues:\\n\\nNIKE Brand Revenues by:\\n\\nFootwear Apparel\\n\\n$\\n\\n33,135 $ 13,843\\n\\n29,143 13,567\\n\\n14 % 2 %\\n\\n20 % $ 8 %\\n\\n28,021 12,865\\n\\n4 % 5 %\\n\\nEquipment Global Brand Divisions\\n\\n(2)\\n\\nTotal NIKE Brand Revenues\\n\\n$\\n\\n1,727 58\\n\\n48,763 $\\n\\n1,624 102 44,436\\n\\n6 % -43 % 10 %\\n\\n13 % -43 % 16 % $\\n\\n1,382 25 42,293\\n\\n18 % 308 % 5 %\\n\\nConverse Corporate\\n\\n(3)\\n\\n2,427 27\\n\\n2,346 (72)\\n\\n3 % —\\n\\n8 % —\\n\\n2,205 40\\n\\n6 % —\\n\\nTOTAL NIKE, INC. REVENUES\\n\\n$\\n\\n51,217 $\\n\\n46,710\\n\\n10 %\\n\\n16 % $\\n\\n44,538\\n\\n5 %\\n\\nSupplemental NIKE Brand Revenues Details: NIKE Brand Revenues by:\\n\\nSales to Wholesale Customers\\n\\n$\\n\\n27,397 $\\n\\n25,608\\n\\n7 %\\n\\n14 % $\\n\\n25,898\\n\\n1 %\\n\\nSales through NIKE Direct Global Brand Divisions\\n\\n(2)\\n\\n21,308 58\\n\\n18,726 102\\n\\n14 % -43 %\\n\\n20 % -43 %\\n\\n16,370 25\\n\\n14 % 308 %\\n\\nTOTAL NIKE BRAND REVENUES (1) NIKE Brand Revenues on a Wholesale Equivalent Basis :\\n\\n$\\n\\n48,763 $\\n\\n44,436\\n\\n10 %\\n\\n16 % $\\n\\n42,293\\n\\n5 %\\n\\nSales to Wholesale Customers Sales from our Wholesale Operations to NIKE Direct Operations\\n\\nTOTAL NIKE BRAND WHOLESALE EQUIVALENT REVENUES NIKE Brand Wholesale Equivalent Revenues by:\\n\\n(1),(4)\\n\\n$\\n\\n$\\n\\n27,397 $ 12,730\\n\\n40,127 $\\n\\n25,608 10,543\\n\\n36,151\\n\\n7 % 21 %\\n\\n11 %\\n\\n14 % $ 27 %\\n\\n18 % $\\n\\n25,898 9,872\\n\\n35,770\\n\\n1 % 7 % 1 %\\n\\nMen's Women's NIKE Kids'\\n\\n$\\n\\n20,733 $ 8,606 5,038\\n\\n18,797 8,273 4,874\\n\\n10 % 4 % 3 %\\n\\n17 % $ 11 % 10 %\\n\\n18,391 8,225 4,882\\n\\n2 % 1 % 0 %\\n\\nJordan Brand (5) Others\\n\\n6,589 (839)\\n\\n5,122 (915)\\n\\n29 % 8 %\\n\\n35 % -3 %\"),\n",
-              "  0.499011814594),\n",
-              " (Document(metadata={'source': 'resources/nke-10k-2023.pdf'}, page_content=\"Tax (expense) benefit Gain (loss) net of tax\\n\\n5 (14)\\n\\n(9) 22\\n\\nTotal net gain (loss) reclassified for the period\\n\\n$\\n\\n463 $\\n\\n30\\n\\n2023 FORM 10-K 82\\n\\nTable of Contents\\n\\nNOTE 14 — REVENUES\\n\\nDISAGGREGATION OF REVENUES The following tables present the Company's Revenues disaggregated by reportable operating segment, major product line and distribution channel:\\n\\n(Dollars in millions)\\n\\nNORTH AMERICA\\n\\nEUROPE, MIDDLE EAST & AFRICA\\n\\nGREATER CHINA\\n\\nYEAR ENDED MAY 31, 2023 ASIA PACIFIC & LATIN (1)\\n\\nGLOBAL BRAND DIVISIONS\\n\\nTOTAL NIKE\\n\\nAMERICA\\n\\nBRAND CONVERSE CORPORATE\\n\\nTOTAL NIKE, INC.\\n\\nRevenues by: Footwear\\n\\n$\\n\\n14,897 $\\n\\n8,260 $\\n\\n5,435 $\\n\\n4,543 $\\n\\n— $\\n\\n33,135 $\\n\\n2,155 $\\n\\n— $\\n\\n35,290\\n\\nApparel Equipment Other\\n\\n5,947 764 —\\n\\n4,566 592 —\\n\\n1,666 147 —\\n\\n1,664 224 —\\n\\n— — 58\\n\\n13,843 1,727 58\\n\\n90 28 154\\n\\n— — 27\\n\\n13,933 1,755 239\\n\\nTOTAL REVENUES\\n\\n$\\n\\n21,608 $\\n\\n13,418 $\\n\\n7,248 $\\n\\n6,431 $\\n\\n58 $\\n\\n48,763 $\\n\\n2,427 $\\n\\n27 $\\n\\n51,217\\n\\nRevenues by:\\n\\nSales to Wholesale Customers Sales through Direct to Consumer\\n\\n$\\n\\n11,273 $ 10,335\\n\\n8,522 $ 4,896\\n\\n3,866 $ 3,382\\n\\n3,736 $ 2,695\\n\\n— $ —\\n\\n27,397 $ 21,308\\n\\n1,299 $ 974\\n\\n— $ —\\n\\n28,696 22,282\\n\\nOther\\n\\nTOTAL REVENUES\\n\\n$\\n\\n—\\n\\n21,608 $\\n\\n—\\n\\n13,418 $\\n\\n— 7,248 $\\n\\n— 6,431 $\\n\\n58 58 $\\n\\n58\\n\\n48,763 $\\n\\n154 2,427 $\\n\\n27 27 $\\n\\n239 51,217\\n\\n(1) Refer to Note 18 — Acquisitions and Divestitures for additional information on the transition of the Company's NIKE Brand businesses in its CASA territory to third-party distributors.\\n\\nYEAR ENDED MAY 31, 2022\\n\\n(Dollars in millions)\\n\\nNORTH AMERICA\\n\\nEUROPE, MIDDLE EAST & AFRICA\\n\\nGREATER CHINA\\n\\nASIA PACIFIC & LATIN AMERICA\\n\\nGLOBAL BRAND DIVISIONS\\n\\nTOTAL NIKE\\n\\nBRAND CONVERSE CORPORATE\\n\\nTOTAL NIKE, INC.\\n\\nRevenues by: Footwear Apparel\\n\\n$\\n\\n12,228 $ 5,492\\n\\n7,388 $ 4,527\\n\\n5,416 $ 1,938\\n\\n4,111 $ 1,610\\n\\n— $ —\\n\\n29,143 $ 13,567\\n\\n2,094 $ 103\\n\\n— $ —\\n\\n31,237 13,670\\n\\nEquipment Other\\n\\n633 —\\n\\n564 —\\n\\n193 —\\n\\n234 —\\n\\n— 102\\n\\n1,624 102\\n\\n26 123\\n\\n— (72)\\n\\n1,650 153\\n\\nTOTAL REVENUES Revenues by:\\n\\n$\\n\\n18,353 $\\n\\n12,479 $\\n\\n7,547 $\\n\\n5,955 $\\n\\n102 $\\n\\n44,436 $\\n\\n2,346 $\\n\\n(72) $\\n\\n46,710\\n\\nSales to Wholesale Customers Sales through Direct to Consumer Other\\n\\n$\\n\\n9,621 $ 8,732 —\\n\\n8,377 $ 4,102 —\\n\\n4,081 $ 3,466 —\\n\\n3,529 $ 2,426 —\\n\\n— $ — 102\\n\\n25,608 $ 18,726 102\\n\\n1,292 $ 931 123\\n\\n— $ — (72)\\n\\n26,900 19,657 153\\n\\nTOTAL REVENUES\\n\\n$\\n\\n18,353 $\\n\\n12,479 $\\n\\n7,547 $\\n\\n5,955 $\\n\\n102 $\\n\\n44,436 $\\n\\n2,346 $\\n\\n(72) $\\n\\n46,710\\n\\n2023 FORM 10-K 83\\n\\nTable of Contents\\n\\nYEAR ENDED MAY 31, 2021\\n\\n(Dollars in millions)\\n\\nNORTH AMERICA\\n\\nEUROPE, MIDDLE EAST & AFRICA\\n\\nGREATER CHINA\"),\n",
-              "  0.529603242874)]"
-            ]
-          },
-          "execution_count": 8,
-          "metadata": {},
-          "output_type": "execute_result"
-        }
-      ],
-      "source": [
-        "# basic \"top 4\" vector search on a given query\n",
-        "rds.similarity_search_with_score(query=\"Profit margins\", k=4)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 9,
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "od6Wqmya1vmy",
-        "outputId": "5dbac581-4a07-45b0-d630-995342e91dc7"
-      },
-      "outputs": [
-        {
-          "data": {
-            "text/plain": [
-              "[(Document(metadata={'source': 'resources/nke-10k-2023.pdf'}, page_content=\"(Dollars in millions, except per share data)\\n\\nRevenues Cost of sales\\n\\nGross profit Gross margin\\n\\nDemand creation expense Operating overhead expense\\n\\nTotal selling and administrative expense % of revenues\\n\\nInterest expense (income), net\\n\\nOther (income) expense, net Income before income taxes\\n\\nIncome tax expense Effective tax rate\\n\\nNET INCOME Diluted earnings per common share\\n\\n$\\n\\n$ $\\n\\nFISCAL 2023\\n\\n51,217 28,925\\n\\n22,292\\n\\n43.5 %\\n\\n4,060 12,317\\n\\n16,377\\n\\n32.0 % (6)\\n\\n(280) 6,201\\n\\n1,131\\n\\n18.2 %\\n\\n5,070 3.23\\n\\n$\\n\\n$ $\\n\\nFISCAL 2022\\n\\n46,710 25,231\\n\\n21,479\\n\\n46.0 %\\n\\n3,850 10,954\\n\\n14,804\\n\\n31.7 % 205\\n\\n(181) 6,651\\n\\n605 9.1 %\\n\\n6,046 3.75\\n\\n% CHANGE\\n\\n10 % $ 15 %\\n\\n4 %\\n\\n5 % 12 %\\n\\n11 %\\n\\n—\\n\\n— -7 %\\n\\n87 %\\n\\n16 % $ -14 % $\\n\\nFISCAL 2021\\n\\n% CHANGE\\n\\n44,538 24,576\\n\\n5 % 3 %\\n\\n19,962\\n\\n8 %\\n\\n44.8 %\\n\\n3,114 9,911\\n\\n24 % 11 %\\n\\n13,025\\n\\n14 %\\n\\n29.2 % 262\\n\\n—\\n\\n14 6,661\\n\\n— 0 %\\n\\n934 14.0 %\\n\\n35 %\\n\\n5,727 3.56\\n\\n6 % 5 %\\n\\n2023 FORM 10-K 31\\n\\nTable of Contents\\n\\nCONSOLIDATED OPERATING RESULTS REVENUES\\n\\n(Dollars in millions)\\n\\nFISCAL 2023\\n\\nFISCAL 2022\\n\\n% CHANGE\\n\\n% CHANGE EXCLUDING CURRENCY (1) CHANGES\\n\\nFISCAL 2021\\n\\n% CHANGE\\n\\nNIKE, Inc. Revenues:\\n\\nNIKE Brand Revenues by:\\n\\nFootwear Apparel\\n\\n$\\n\\n33,135 $ 13,843\\n\\n29,143 13,567\\n\\n14 % 2 %\\n\\n20 % $ 8 %\\n\\n28,021 12,865\\n\\n4 % 5 %\\n\\nEquipment Global Brand Divisions\\n\\n(2)\\n\\nTotal NIKE Brand Revenues\\n\\n$\\n\\n1,727 58\\n\\n48,763 $\\n\\n1,624 102 44,436\\n\\n6 % -43 % 10 %\\n\\n13 % -43 % 16 % $\\n\\n1,382 25 42,293\\n\\n18 % 308 % 5 %\\n\\nConverse Corporate\\n\\n(3)\\n\\n2,427 27\\n\\n2,346 (72)\\n\\n3 % —\\n\\n8 % —\\n\\n2,205 40\\n\\n6 % —\\n\\nTOTAL NIKE, INC. REVENUES\\n\\n$\\n\\n51,217 $\\n\\n46,710\\n\\n10 %\\n\\n16 % $\\n\\n44,538\\n\\n5 %\\n\\nSupplemental NIKE Brand Revenues Details: NIKE Brand Revenues by:\\n\\nSales to Wholesale Customers\\n\\n$\\n\\n27,397 $\\n\\n25,608\\n\\n7 %\\n\\n14 % $\\n\\n25,898\\n\\n1 %\\n\\nSales through NIKE Direct Global Brand Divisions\\n\\n(2)\\n\\n21,308 58\\n\\n18,726 102\\n\\n14 % -43 %\\n\\n20 % -43 %\\n\\n16,370 25\\n\\n14 % 308 %\\n\\nTOTAL NIKE BRAND REVENUES (1) NIKE Brand Revenues on a Wholesale Equivalent Basis :\\n\\n$\\n\\n48,763 $\\n\\n44,436\\n\\n10 %\\n\\n16 % $\\n\\n42,293\\n\\n5 %\\n\\nSales to Wholesale Customers Sales from our Wholesale Operations to NIKE Direct Operations\\n\\nTOTAL NIKE BRAND WHOLESALE EQUIVALENT REVENUES NIKE Brand Wholesale Equivalent Revenues by:\\n\\n(1),(4)\\n\\n$\\n\\n$\\n\\n27,397 $ 12,730\\n\\n40,127 $\\n\\n25,608 10,543\\n\\n36,151\\n\\n7 % 21 %\\n\\n11 %\\n\\n14 % $ 27 %\\n\\n18 % $\\n\\n25,898 9,872\\n\\n35,770\\n\\n1 % 7 % 1 %\\n\\nMen's Women's NIKE Kids'\\n\\n$\\n\\n20,733 $ 8,606 5,038\\n\\n18,797 8,273 4,874\\n\\n10 % 4 % 3 %\\n\\n17 % $ 11 % 10 %\\n\\n18,391 8,225 4,882\\n\\n2 % 1 % 0 %\\n\\nJordan Brand (5) Others\\n\\n6,589 (839)\\n\\n5,122 (915)\\n\\n29 % 8 %\\n\\n35 % -3 %\"),\n",
-              "  0.499011814594),\n",
-              " (Document(metadata={'source': 'resources/nke-10k-2023.pdf'}, page_content=\"(Dollars in millions, except per share data)\\n\\nRevenues Cost of sales\\n\\nGross profit Gross margin\\n\\nDemand creation expense Operating overhead expense\\n\\nTotal selling and administrative expense % of revenues\\n\\nInterest expense (income), net\\n\\nOther (income) expense, net Income before income taxes\\n\\nIncome tax expense Effective tax rate\\n\\nNET INCOME Diluted earnings per common share\\n\\n$\\n\\n$ $\\n\\nFISCAL 2023\\n\\n51,217 28,925\\n\\n22,292\\n\\n43.5 %\\n\\n4,060 12,317\\n\\n16,377\\n\\n32.0 % (6)\\n\\n(280) 6,201\\n\\n1,131\\n\\n18.2 %\\n\\n5,070 3.23\\n\\n$\\n\\n$ $\\n\\nFISCAL 2022\\n\\n46,710 25,231\\n\\n21,479\\n\\n46.0 %\\n\\n3,850 10,954\\n\\n14,804\\n\\n31.7 % 205\\n\\n(181) 6,651\\n\\n605 9.1 %\\n\\n6,046 3.75\\n\\n% CHANGE\\n\\n10 % $ 15 %\\n\\n4 %\\n\\n5 % 12 %\\n\\n11 %\\n\\n—\\n\\n— -7 %\\n\\n87 %\\n\\n16 % $ -14 % $\\n\\nFISCAL 2021\\n\\n% CHANGE\\n\\n44,538 24,576\\n\\n5 % 3 %\\n\\n19,962\\n\\n8 %\\n\\n44.8 %\\n\\n3,114 9,911\\n\\n24 % 11 %\\n\\n13,025\\n\\n14 %\\n\\n29.2 % 262\\n\\n—\\n\\n14 6,661\\n\\n— 0 %\\n\\n934 14.0 %\\n\\n35 %\\n\\n5,727 3.56\\n\\n6 % 5 %\\n\\n2023 FORM 10-K 31\\n\\nTable of Contents\\n\\nCONSOLIDATED OPERATING RESULTS REVENUES\\n\\n(Dollars in millions)\\n\\nFISCAL 2023\\n\\nFISCAL 2022\\n\\n% CHANGE\\n\\n% CHANGE EXCLUDING CURRENCY (1) CHANGES\\n\\nFISCAL 2021\\n\\n% CHANGE\\n\\nNIKE, Inc. Revenues:\\n\\nNIKE Brand Revenues by:\\n\\nFootwear Apparel\\n\\n$\\n\\n33,135 $ 13,843\\n\\n29,143 13,567\\n\\n14 % 2 %\\n\\n20 % $ 8 %\\n\\n28,021 12,865\\n\\n4 % 5 %\\n\\nEquipment Global Brand Divisions\\n\\n(2)\\n\\nTotal NIKE Brand Revenues\\n\\n$\\n\\n1,727 58\\n\\n48,763 $\\n\\n1,624 102 44,436\\n\\n6 % -43 % 10 %\\n\\n13 % -43 % 16 % $\\n\\n1,382 25 42,293\\n\\n18 % 308 % 5 %\\n\\nConverse Corporate\\n\\n(3)\\n\\n2,427 27\\n\\n2,346 (72)\\n\\n3 % —\\n\\n8 % —\\n\\n2,205 40\\n\\n6 % —\\n\\nTOTAL NIKE, INC. REVENUES\\n\\n$\\n\\n51,217 $\\n\\n46,710\\n\\n10 %\\n\\n16 % $\\n\\n44,538\\n\\n5 %\\n\\nSupplemental NIKE Brand Revenues Details: NIKE Brand Revenues by:\\n\\nSales to Wholesale Customers\\n\\n$\\n\\n27,397 $\\n\\n25,608\\n\\n7 %\\n\\n14 % $\\n\\n25,898\\n\\n1 %\\n\\nSales through NIKE Direct Global Brand Divisions\\n\\n(2)\\n\\n21,308 58\\n\\n18,726 102\\n\\n14 % -43 %\\n\\n20 % -43 %\\n\\n16,370 25\\n\\n14 % 308 %\\n\\nTOTAL NIKE BRAND REVENUES (1) NIKE Brand Revenues on a Wholesale Equivalent Basis :\\n\\n$\\n\\n48,763 $\\n\\n44,436\\n\\n10 %\\n\\n16 % $\\n\\n42,293\\n\\n5 %\\n\\nSales to Wholesale Customers Sales from our Wholesale Operations to NIKE Direct Operations\\n\\nTOTAL NIKE BRAND WHOLESALE EQUIVALENT REVENUES NIKE Brand Wholesale Equivalent Revenues by:\\n\\n(1),(4)\\n\\n$\\n\\n$\\n\\n27,397 $ 12,730\\n\\n40,127 $\\n\\n25,608 10,543\\n\\n36,151\\n\\n7 % 21 %\\n\\n11 %\\n\\n14 % $ 27 %\\n\\n18 % $\\n\\n25,898 9,872\\n\\n35,770\\n\\n1 % 7 % 1 %\\n\\nMen's Women's NIKE Kids'\\n\\n$\\n\\n20,733 $ 8,606 5,038\\n\\n18,797 8,273 4,874\\n\\n10 % 4 % 3 %\\n\\n17 % $ 11 % 10 %\\n\\n18,391 8,225 4,882\\n\\n2 % 1 % 0 %\\n\\nJordan Brand (5) Others\\n\\n6,589 (839)\\n\\n5,122 (915)\\n\\n29 % 8 %\\n\\n35 % -3 %\"),\n",
-              "  0.499011814594),\n",
-              " (Document(metadata={'source': 'resources/nke-10k-2023.pdf'}, page_content=\"(Dollars in millions, except per share data)\\n\\nRevenues Cost of sales\\n\\nGross profit Gross margin\\n\\nDemand creation expense Operating overhead expense\\n\\nTotal selling and administrative expense % of revenues\\n\\nInterest expense (income), net\\n\\nOther (income) expense, net Income before income taxes\\n\\nIncome tax expense Effective tax rate\\n\\nNET INCOME Diluted earnings per common share\\n\\n$\\n\\n$ $\\n\\nFISCAL 2023\\n\\n51,217 28,925\\n\\n22,292\\n\\n43.5 %\\n\\n4,060 12,317\\n\\n16,377\\n\\n32.0 % (6)\\n\\n(280) 6,201\\n\\n1,131\\n\\n18.2 %\\n\\n5,070 3.23\\n\\n$\\n\\n$ $\\n\\nFISCAL 2022\\n\\n46,710 25,231\\n\\n21,479\\n\\n46.0 %\\n\\n3,850 10,954\\n\\n14,804\\n\\n31.7 % 205\\n\\n(181) 6,651\\n\\n605 9.1 %\\n\\n6,046 3.75\\n\\n% CHANGE\\n\\n10 % $ 15 %\\n\\n4 %\\n\\n5 % 12 %\\n\\n11 %\\n\\n—\\n\\n— -7 %\\n\\n87 %\\n\\n16 % $ -14 % $\\n\\nFISCAL 2021\\n\\n% CHANGE\\n\\n44,538 24,576\\n\\n5 % 3 %\\n\\n19,962\\n\\n8 %\\n\\n44.8 %\\n\\n3,114 9,911\\n\\n24 % 11 %\\n\\n13,025\\n\\n14 %\\n\\n29.2 % 262\\n\\n—\\n\\n14 6,661\\n\\n— 0 %\\n\\n934 14.0 %\\n\\n35 %\\n\\n5,727 3.56\\n\\n6 % 5 %\\n\\n2023 FORM 10-K 31\\n\\nTable of Contents\\n\\nCONSOLIDATED OPERATING RESULTS REVENUES\\n\\n(Dollars in millions)\\n\\nFISCAL 2023\\n\\nFISCAL 2022\\n\\n% CHANGE\\n\\n% CHANGE EXCLUDING CURRENCY (1) CHANGES\\n\\nFISCAL 2021\\n\\n% CHANGE\\n\\nNIKE, Inc. Revenues:\\n\\nNIKE Brand Revenues by:\\n\\nFootwear Apparel\\n\\n$\\n\\n33,135 $ 13,843\\n\\n29,143 13,567\\n\\n14 % 2 %\\n\\n20 % $ 8 %\\n\\n28,021 12,865\\n\\n4 % 5 %\\n\\nEquipment Global Brand Divisions\\n\\n(2)\\n\\nTotal NIKE Brand Revenues\\n\\n$\\n\\n1,727 58\\n\\n48,763 $\\n\\n1,624 102 44,436\\n\\n6 % -43 % 10 %\\n\\n13 % -43 % 16 % $\\n\\n1,382 25 42,293\\n\\n18 % 308 % 5 %\\n\\nConverse Corporate\\n\\n(3)\\n\\n2,427 27\\n\\n2,346 (72)\\n\\n3 % —\\n\\n8 % —\\n\\n2,205 40\\n\\n6 % —\\n\\nTOTAL NIKE, INC. REVENUES\\n\\n$\\n\\n51,217 $\\n\\n46,710\\n\\n10 %\\n\\n16 % $\\n\\n44,538\\n\\n5 %\\n\\nSupplemental NIKE Brand Revenues Details: NIKE Brand Revenues by:\\n\\nSales to Wholesale Customers\\n\\n$\\n\\n27,397 $\\n\\n25,608\\n\\n7 %\\n\\n14 % $\\n\\n25,898\\n\\n1 %\\n\\nSales through NIKE Direct Global Brand Divisions\\n\\n(2)\\n\\n21,308 58\\n\\n18,726 102\\n\\n14 % -43 %\\n\\n20 % -43 %\\n\\n16,370 25\\n\\n14 % 308 %\\n\\nTOTAL NIKE BRAND REVENUES (1) NIKE Brand Revenues on a Wholesale Equivalent Basis :\\n\\n$\\n\\n48,763 $\\n\\n44,436\\n\\n10 %\\n\\n16 % $\\n\\n42,293\\n\\n5 %\\n\\nSales to Wholesale Customers Sales from our Wholesale Operations to NIKE Direct Operations\\n\\nTOTAL NIKE BRAND WHOLESALE EQUIVALENT REVENUES NIKE Brand Wholesale Equivalent Revenues by:\\n\\n(1),(4)\\n\\n$\\n\\n$\\n\\n27,397 $ 12,730\\n\\n40,127 $\\n\\n25,608 10,543\\n\\n36,151\\n\\n7 % 21 %\\n\\n11 %\\n\\n14 % $ 27 %\\n\\n18 % $\\n\\n25,898 9,872\\n\\n35,770\\n\\n1 % 7 % 1 %\\n\\nMen's Women's NIKE Kids'\\n\\n$\\n\\n20,733 $ 8,606 5,038\\n\\n18,797 8,273 4,874\\n\\n10 % 4 % 3 %\\n\\n17 % $ 11 % 10 %\\n\\n18,391 8,225 4,882\\n\\n2 % 1 % 0 %\\n\\nJordan Brand (5) Others\\n\\n6,589 (839)\\n\\n5,122 (915)\\n\\n29 % 8 %\\n\\n35 % -3 %\"),\n",
-              "  0.499011814594),\n",
-              " (Document(metadata={'source': 'resources/nke-10k-2023.pdf'}, page_content='From time to time, we may invest in technology, business infrastructure, new businesses or capabilities, product offering and manufacturing innovation and expansion of existing businesses, such as our NIKE Direct operations, which require substantial cash investments and management attention. We believe cost-effective investments are essential to business growth and profitability; however, significant investments are subject to typical risks and uncertainties inherent in developing a new business or expanding an existing business. The failure of any significant investment to provide expected returns or profitability could have a material adverse effect on our financial results and divert management attention from more profitable business operations. See also \"Our NIKE Direct operations have required and will continue to require a substantial investment and commitment of resources and are subject to numerous risks and uncertainties.\"\\n\\nThe sale of a large number of shares of common stock by our principal shareholder could depress the market price of our common stock.\\n\\nAs of June 30, 2023, Swoosh, LLC beneficially owned approximately 77% of our Class A Common Stock. If, on June 30, 2023, all of these shares were converted into Class B Common Stock, Swoosh, LLC\\'s commensurate ownership percentage of our Class B Common Stock would be approximately 16%. The shares are available for resale, subject to the requirements of the U.S. securities laws and the terms of the limited liability company agreement governing Swoosh, LLC. The sale or prospect of a sale of a substantial number of these shares could have an adverse effect on the market price of our common stock. Swoosh, LLC was formed by Philip H. Knight, our Chairman Emeritus, to hold the majority of his shares of Class A Common Stock. Mr. Knight does not have voting rights with respect to Swoosh, LLC, although Travis Knight, his son and a NIKE director, has a significant role in the management of the Class A Common Stock owned by Swoosh, LLC.\\n\\nChanges in our credit ratings or macroeconomic conditions may affect our liquidity, increasing borrowing costs and limiting our financing options.'),\n",
-              "  0.604557394981)]"
-            ]
-          },
-          "execution_count": 9,
-          "metadata": {},
-          "output_type": "execute_result"
-        }
-      ],
-      "source": [
-        "# vector search with metadata filtering\n",
-        "f = Text(\"text\") % \"profit\"\n",
-        "rds.similarity_search_with_score(query=\"Profit margins\", k=4, filter=f)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 10,
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "DT9sPHw51vmy",
-        "outputId": "7d2b8969-91b8-4ff7-81ba-9d0cb6280edc"
-      },
-      "outputs": [
-        {
-          "data": {
-            "text/plain": [
-              "[(Document(metadata={'source': 'resources/nke-10k-2023.pdf'}, page_content='As discussed in Note 15 — Operating Segments and Related Information in the accompanying Notes to the Consolidated Financial Statements, our operating segments are evidence of the structure of the Company\\'s internal organization. The NIKE Brand segments are defined by geographic regions for operations participating in NIKE Brand sales activity.\\n\\nThe breakdown of Revenues is as follows:\\n\\n(Dollars in millions)\\n\\nFISCAL 2023 FISCAL 2022\\n\\n% CHANGE\\n\\n% CHANGE EXCLUDING CURRENCY (1) CHANGES FISCAL 2021\\n\\n% CHANGE\\n\\nNorth America Europe, Middle East & Africa Greater China\\n\\n$\\n\\n21,608 $ 13,418 7,248\\n\\n18,353 12,479 7,547\\n\\n18 % 8 % -4 %\\n\\n18 % $ 21 % 4 %\\n\\n17,179 11,456 8,290\\n\\n7 % 9 % -9 %\\n\\nAsia Pacific & Latin America Global Brand Divisions\\n\\n(3)\\n\\n(2)\\n\\n6,431 58\\n\\n5,955 102\\n\\n8 % -43 %\\n\\n17 % -43 %\\n\\n5,343 25\\n\\n11 % 308 %\\n\\nTOTAL NIKE BRAND Converse\\n\\n$\\n\\n48,763 $ 2,427\\n\\n44,436 2,346\\n\\n10 % 3 %\\n\\n16 % $ 8 %\\n\\n42,293 2,205\\n\\n5 % 6 %\\n\\n(4)\\n\\nCorporate TOTAL NIKE, INC. REVENUES\\n\\n$\\n\\n27\\n\\n51,217 $\\n\\n(72) 46,710\\n\\n— 10 %\\n\\n— 16 % $\\n\\n40 44,538\\n\\n— 5 %\\n\\n(1) The percent change excluding currency changes represents a non-GAAP financial measure. For further information, see \"Use of Non-GAAP Financial Measures\".\\n\\n(2) For additional information on the transition of our NIKE Brand businesses within our CASA territory to a third-party distributor, see Note 18 — Acquisitions and Divestitures of the Notes to Consolidated\\n\\nFinancial Statements contained in Item 8 of this Annual Report.\\n\\n(3) Global Brand Divisions revenues include NIKE Brand licensing and other miscellaneous revenues that are not part of a geographic operating segment.\\n\\n(4) Corporate revenues primarily consist of foreign currency hedge gains and losses related to revenues generated by entities within the NIKE Brand geographic operating segments and Converse, but\\n\\nmanaged through our central foreign exchange risk management program.\\n\\nThe primary financial measure used by the Company to evaluate performance is Earnings Before Interest and Taxes (\"EBIT\"). As discussed in Note 15 — Operating Segments and Related Information in the accompanying Notes to the Consolidated Financial Statements, certain corporate costs are not included in EBIT.\\n\\nThe breakdown of EBIT is as follows:\\n\\n(Dollars in millions)\\n\\nFISCAL 2023\\n\\nFISCAL 2022\\n\\n% CHANGE\\n\\nFISCAL 2021\\n\\nNorth America Europe, Middle East & Africa Greater China\\n\\n$\\n\\n5,454 3,531 2,283\\n\\n$\\n\\n5,114 3,293 2,365\\n\\n7 % $ 7 % -3 %\\n\\n5,089 2,435 3,243\\n\\nAsia Pacific & Latin America Global Brand Divisions (1)'),\n",
-              "  0.233286499977),\n",
-              " (Document(metadata={'source': 'resources/nke-10k-2023.pdf'}, page_content='As discussed in Note 15 — Operating Segments and Related Information in the accompanying Notes to the Consolidated Financial Statements, our operating segments are evidence of the structure of the Company\\'s internal organization. The NIKE Brand segments are defined by geographic regions for operations participating in NIKE Brand sales activity.\\n\\nThe breakdown of Revenues is as follows:\\n\\n(Dollars in millions)\\n\\nFISCAL 2023 FISCAL 2022\\n\\n% CHANGE\\n\\n% CHANGE EXCLUDING CURRENCY (1) CHANGES FISCAL 2021\\n\\n% CHANGE\\n\\nNorth America Europe, Middle East & Africa Greater China\\n\\n$\\n\\n21,608 $ 13,418 7,248\\n\\n18,353 12,479 7,547\\n\\n18 % 8 % -4 %\\n\\n18 % $ 21 % 4 %\\n\\n17,179 11,456 8,290\\n\\n7 % 9 % -9 %\\n\\nAsia Pacific & Latin America Global Brand Divisions\\n\\n(3)\\n\\n(2)\\n\\n6,431 58\\n\\n5,955 102\\n\\n8 % -43 %\\n\\n17 % -43 %\\n\\n5,343 25\\n\\n11 % 308 %\\n\\nTOTAL NIKE BRAND Converse\\n\\n$\\n\\n48,763 $ 2,427\\n\\n44,436 2,346\\n\\n10 % 3 %\\n\\n16 % $ 8 %\\n\\n42,293 2,205\\n\\n5 % 6 %\\n\\n(4)\\n\\nCorporate TOTAL NIKE, INC. REVENUES\\n\\n$\\n\\n27\\n\\n51,217 $\\n\\n(72) 46,710\\n\\n— 10 %\\n\\n— 16 % $\\n\\n40 44,538\\n\\n— 5 %\\n\\n(1) The percent change excluding currency changes represents a non-GAAP financial measure. For further information, see \"Use of Non-GAAP Financial Measures\".\\n\\n(2) For additional information on the transition of our NIKE Brand businesses within our CASA territory to a third-party distributor, see Note 18 — Acquisitions and Divestitures of the Notes to Consolidated\\n\\nFinancial Statements contained in Item 8 of this Annual Report.\\n\\n(3) Global Brand Divisions revenues include NIKE Brand licensing and other miscellaneous revenues that are not part of a geographic operating segment.\\n\\n(4) Corporate revenues primarily consist of foreign currency hedge gains and losses related to revenues generated by entities within the NIKE Brand geographic operating segments and Converse, but\\n\\nmanaged through our central foreign exchange risk management program.\\n\\nThe primary financial measure used by the Company to evaluate performance is Earnings Before Interest and Taxes (\"EBIT\"). As discussed in Note 15 — Operating Segments and Related Information in the accompanying Notes to the Consolidated Financial Statements, certain corporate costs are not included in EBIT.\\n\\nThe breakdown of EBIT is as follows:\\n\\n(Dollars in millions)\\n\\nFISCAL 2023\\n\\nFISCAL 2022\\n\\n% CHANGE\\n\\nFISCAL 2021\\n\\nNorth America Europe, Middle East & Africa Greater China\\n\\n$\\n\\n5,454 3,531 2,283\\n\\n$\\n\\n5,114 3,293 2,365\\n\\n7 % $ 7 % -3 %\\n\\n5,089 2,435 3,243\\n\\nAsia Pacific & Latin America Global Brand Divisions (1)'),\n",
-              "  0.233286499977),\n",
-              " (Document(metadata={'source': 'resources/nke-10k-2023.pdf'}, page_content='As discussed in Note 15 — Operating Segments and Related Information in the accompanying Notes to the Consolidated Financial Statements, our operating segments are evidence of the structure of the Company\\'s internal organization. The NIKE Brand segments are defined by geographic regions for operations participating in NIKE Brand sales activity.\\n\\nThe breakdown of Revenues is as follows:\\n\\n(Dollars in millions)\\n\\nFISCAL 2023 FISCAL 2022\\n\\n% CHANGE\\n\\n% CHANGE EXCLUDING CURRENCY (1) CHANGES FISCAL 2021\\n\\n% CHANGE\\n\\nNorth America Europe, Middle East & Africa Greater China\\n\\n$\\n\\n21,608 $ 13,418 7,248\\n\\n18,353 12,479 7,547\\n\\n18 % 8 % -4 %\\n\\n18 % $ 21 % 4 %\\n\\n17,179 11,456 8,290\\n\\n7 % 9 % -9 %\\n\\nAsia Pacific & Latin America Global Brand Divisions\\n\\n(3)\\n\\n(2)\\n\\n6,431 58\\n\\n5,955 102\\n\\n8 % -43 %\\n\\n17 % -43 %\\n\\n5,343 25\\n\\n11 % 308 %\\n\\nTOTAL NIKE BRAND Converse\\n\\n$\\n\\n48,763 $ 2,427\\n\\n44,436 2,346\\n\\n10 % 3 %\\n\\n16 % $ 8 %\\n\\n42,293 2,205\\n\\n5 % 6 %\\n\\n(4)\\n\\nCorporate TOTAL NIKE, INC. REVENUES\\n\\n$\\n\\n27\\n\\n51,217 $\\n\\n(72) 46,710\\n\\n— 10 %\\n\\n— 16 % $\\n\\n40 44,538\\n\\n— 5 %\\n\\n(1) The percent change excluding currency changes represents a non-GAAP financial measure. For further information, see \"Use of Non-GAAP Financial Measures\".\\n\\n(2) For additional information on the transition of our NIKE Brand businesses within our CASA territory to a third-party distributor, see Note 18 — Acquisitions and Divestitures of the Notes to Consolidated\\n\\nFinancial Statements contained in Item 8 of this Annual Report.\\n\\n(3) Global Brand Divisions revenues include NIKE Brand licensing and other miscellaneous revenues that are not part of a geographic operating segment.\\n\\n(4) Corporate revenues primarily consist of foreign currency hedge gains and losses related to revenues generated by entities within the NIKE Brand geographic operating segments and Converse, but\\n\\nmanaged through our central foreign exchange risk management program.\\n\\nThe primary financial measure used by the Company to evaluate performance is Earnings Before Interest and Taxes (\"EBIT\"). As discussed in Note 15 — Operating Segments and Related Information in the accompanying Notes to the Consolidated Financial Statements, certain corporate costs are not included in EBIT.\\n\\nThe breakdown of EBIT is as follows:\\n\\n(Dollars in millions)\\n\\nFISCAL 2023\\n\\nFISCAL 2022\\n\\n% CHANGE\\n\\nFISCAL 2021\\n\\nNorth America Europe, Middle East & Africa Greater China\\n\\n$\\n\\n5,454 3,531 2,283\\n\\n$\\n\\n5,114 3,293 2,365\\n\\n7 % $ 7 % -3 %\\n\\n5,089 2,435 3,243\\n\\nAsia Pacific & Latin America Global Brand Divisions (1)'),\n",
-              "  0.233286499977),\n",
-              " (Document(metadata={'source': 'resources/nke-10k-2023.pdf'}, page_content=\"Tax (expense) benefit Gain (loss) net of tax\\n\\n5 (14)\\n\\n(9) 22\\n\\nTotal net gain (loss) reclassified for the period\\n\\n$\\n\\n463 $\\n\\n30\\n\\n2023 FORM 10-K 82\\n\\nTable of Contents\\n\\nNOTE 14 — REVENUES\\n\\nDISAGGREGATION OF REVENUES The following tables present the Company's Revenues disaggregated by reportable operating segment, major product line and distribution channel:\\n\\n(Dollars in millions)\\n\\nNORTH AMERICA\\n\\nEUROPE, MIDDLE EAST & AFRICA\\n\\nGREATER CHINA\\n\\nYEAR ENDED MAY 31, 2023 ASIA PACIFIC & LATIN (1)\\n\\nGLOBAL BRAND DIVISIONS\\n\\nTOTAL NIKE\\n\\nAMERICA\\n\\nBRAND CONVERSE CORPORATE\\n\\nTOTAL NIKE, INC.\\n\\nRevenues by: Footwear\\n\\n$\\n\\n14,897 $\\n\\n8,260 $\\n\\n5,435 $\\n\\n4,543 $\\n\\n— $\\n\\n33,135 $\\n\\n2,155 $\\n\\n— $\\n\\n35,290\\n\\nApparel Equipment Other\\n\\n5,947 764 —\\n\\n4,566 592 —\\n\\n1,666 147 —\\n\\n1,664 224 —\\n\\n— — 58\\n\\n13,843 1,727 58\\n\\n90 28 154\\n\\n— — 27\\n\\n13,933 1,755 239\\n\\nTOTAL REVENUES\\n\\n$\\n\\n21,608 $\\n\\n13,418 $\\n\\n7,248 $\\n\\n6,431 $\\n\\n58 $\\n\\n48,763 $\\n\\n2,427 $\\n\\n27 $\\n\\n51,217\\n\\nRevenues by:\\n\\nSales to Wholesale Customers Sales through Direct to Consumer\\n\\n$\\n\\n11,273 $ 10,335\\n\\n8,522 $ 4,896\\n\\n3,866 $ 3,382\\n\\n3,736 $ 2,695\\n\\n— $ —\\n\\n27,397 $ 21,308\\n\\n1,299 $ 974\\n\\n— $ —\\n\\n28,696 22,282\\n\\nOther\\n\\nTOTAL REVENUES\\n\\n$\\n\\n—\\n\\n21,608 $\\n\\n—\\n\\n13,418 $\\n\\n— 7,248 $\\n\\n— 6,431 $\\n\\n58 58 $\\n\\n58\\n\\n48,763 $\\n\\n154 2,427 $\\n\\n27 27 $\\n\\n239 51,217\\n\\n(1) Refer to Note 18 — Acquisitions and Divestitures for additional information on the transition of the Company's NIKE Brand businesses in its CASA territory to third-party distributors.\\n\\nYEAR ENDED MAY 31, 2022\\n\\n(Dollars in millions)\\n\\nNORTH AMERICA\\n\\nEUROPE, MIDDLE EAST & AFRICA\\n\\nGREATER CHINA\\n\\nASIA PACIFIC & LATIN AMERICA\\n\\nGLOBAL BRAND DIVISIONS\\n\\nTOTAL NIKE\\n\\nBRAND CONVERSE CORPORATE\\n\\nTOTAL NIKE, INC.\\n\\nRevenues by: Footwear Apparel\\n\\n$\\n\\n12,228 $ 5,492\\n\\n7,388 $ 4,527\\n\\n5,416 $ 1,938\\n\\n4,111 $ 1,610\\n\\n— $ —\\n\\n29,143 $ 13,567\\n\\n2,094 $ 103\\n\\n— $ —\\n\\n31,237 13,670\\n\\nEquipment Other\\n\\n633 —\\n\\n564 —\\n\\n193 —\\n\\n234 —\\n\\n— 102\\n\\n1,624 102\\n\\n26 123\\n\\n— (72)\\n\\n1,650 153\\n\\nTOTAL REVENUES Revenues by:\\n\\n$\\n\\n18,353 $\\n\\n12,479 $\\n\\n7,547 $\\n\\n5,955 $\\n\\n102 $\\n\\n44,436 $\\n\\n2,346 $\\n\\n(72) $\\n\\n46,710\\n\\nSales to Wholesale Customers Sales through Direct to Consumer Other\\n\\n$\\n\\n9,621 $ 8,732 —\\n\\n8,377 $ 4,102 —\\n\\n4,081 $ 3,466 —\\n\\n3,529 $ 2,426 —\\n\\n— $ — 102\\n\\n25,608 $ 18,726 102\\n\\n1,292 $ 931 123\\n\\n— $ — (72)\\n\\n26,900 19,657 153\\n\\nTOTAL REVENUES\\n\\n$\\n\\n18,353 $\\n\\n12,479 $\\n\\n7,547 $\\n\\n5,955 $\\n\\n102 $\\n\\n44,436 $\\n\\n2,346 $\\n\\n(72) $\\n\\n46,710\\n\\n2023 FORM 10-K 83\\n\\nTable of Contents\\n\\nYEAR ENDED MAY 31, 2021\\n\\n(Dollars in millions)\\n\\nNORTH AMERICA\\n\\nEUROPE, MIDDLE EAST & AFRICA\\n\\nGREATER CHINA\"),\n",
-              "  0.261225402355)]"
-            ]
-          },
-          "execution_count": 10,
-          "metadata": {},
-          "output_type": "execute_result"
-        }
-      ],
-      "source": [
-        "# vector search with combinations of metadata filtering\n",
-        "\n",
-        "f = (Text(\"text\") % \"profit\") | (Text(\"text\") % \"revenue\")\n",
-        "rds.similarity_search_with_score(query=\"Nike company revenue\", k=4, filter=f)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 11,
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "kIoGJOop1vmz",
-        "outputId": "9abbf5fd-77de-4094-a2e8-fba2fc5a3a05"
-      },
-      "outputs": [
-        {
-          "data": {
-            "text/plain": [
-              "[(Document(metadata={'source': 'resources/nke-10k-2023.pdf'}, page_content='As discussed in Note 15 — Operating Segments and Related Information in the accompanying Notes to the Consolidated Financial Statements, our operating segments are evidence of the structure of the Company\\'s internal organization. The NIKE Brand segments are defined by geographic regions for operations participating in NIKE Brand sales activity.\\n\\nThe breakdown of Revenues is as follows:\\n\\n(Dollars in millions)\\n\\nFISCAL 2023 FISCAL 2022\\n\\n% CHANGE\\n\\n% CHANGE EXCLUDING CURRENCY (1) CHANGES FISCAL 2021\\n\\n% CHANGE\\n\\nNorth America Europe, Middle East & Africa Greater China\\n\\n$\\n\\n21,608 $ 13,418 7,248\\n\\n18,353 12,479 7,547\\n\\n18 % 8 % -4 %\\n\\n18 % $ 21 % 4 %\\n\\n17,179 11,456 8,290\\n\\n7 % 9 % -9 %\\n\\nAsia Pacific & Latin America Global Brand Divisions\\n\\n(3)\\n\\n(2)\\n\\n6,431 58\\n\\n5,955 102\\n\\n8 % -43 %\\n\\n17 % -43 %\\n\\n5,343 25\\n\\n11 % 308 %\\n\\nTOTAL NIKE BRAND Converse\\n\\n$\\n\\n48,763 $ 2,427\\n\\n44,436 2,346\\n\\n10 % 3 %\\n\\n16 % $ 8 %\\n\\n42,293 2,205\\n\\n5 % 6 %\\n\\n(4)\\n\\nCorporate TOTAL NIKE, INC. REVENUES\\n\\n$\\n\\n27\\n\\n51,217 $\\n\\n(72) 46,710\\n\\n— 10 %\\n\\n— 16 % $\\n\\n40 44,538\\n\\n— 5 %\\n\\n(1) The percent change excluding currency changes represents a non-GAAP financial measure. For further information, see \"Use of Non-GAAP Financial Measures\".\\n\\n(2) For additional information on the transition of our NIKE Brand businesses within our CASA territory to a third-party distributor, see Note 18 — Acquisitions and Divestitures of the Notes to Consolidated\\n\\nFinancial Statements contained in Item 8 of this Annual Report.\\n\\n(3) Global Brand Divisions revenues include NIKE Brand licensing and other miscellaneous revenues that are not part of a geographic operating segment.\\n\\n(4) Corporate revenues primarily consist of foreign currency hedge gains and losses related to revenues generated by entities within the NIKE Brand geographic operating segments and Converse, but\\n\\nmanaged through our central foreign exchange risk management program.\\n\\nThe primary financial measure used by the Company to evaluate performance is Earnings Before Interest and Taxes (\"EBIT\"). As discussed in Note 15 — Operating Segments and Related Information in the accompanying Notes to the Consolidated Financial Statements, certain corporate costs are not included in EBIT.\\n\\nThe breakdown of EBIT is as follows:\\n\\n(Dollars in millions)\\n\\nFISCAL 2023\\n\\nFISCAL 2022\\n\\n% CHANGE\\n\\nFISCAL 2021\\n\\nNorth America Europe, Middle East & Africa Greater China\\n\\n$\\n\\n5,454 3,531 2,283\\n\\n$\\n\\n5,114 3,293 2,365\\n\\n7 % $ 7 % -3 %\\n\\n5,089 2,435 3,243\\n\\nAsia Pacific & Latin America Global Brand Divisions (1)'),\n",
-              "  0.233286499977),\n",
-              " (Document(metadata={'source': 'resources/nke-10k-2023.pdf'}, page_content='As discussed in Note 15 — Operating Segments and Related Information in the accompanying Notes to the Consolidated Financial Statements, our operating segments are evidence of the structure of the Company\\'s internal organization. The NIKE Brand segments are defined by geographic regions for operations participating in NIKE Brand sales activity.\\n\\nThe breakdown of Revenues is as follows:\\n\\n(Dollars in millions)\\n\\nFISCAL 2023 FISCAL 2022\\n\\n% CHANGE\\n\\n% CHANGE EXCLUDING CURRENCY (1) CHANGES FISCAL 2021\\n\\n% CHANGE\\n\\nNorth America Europe, Middle East & Africa Greater China\\n\\n$\\n\\n21,608 $ 13,418 7,248\\n\\n18,353 12,479 7,547\\n\\n18 % 8 % -4 %\\n\\n18 % $ 21 % 4 %\\n\\n17,179 11,456 8,290\\n\\n7 % 9 % -9 %\\n\\nAsia Pacific & Latin America Global Brand Divisions\\n\\n(3)\\n\\n(2)\\n\\n6,431 58\\n\\n5,955 102\\n\\n8 % -43 %\\n\\n17 % -43 %\\n\\n5,343 25\\n\\n11 % 308 %\\n\\nTOTAL NIKE BRAND Converse\\n\\n$\\n\\n48,763 $ 2,427\\n\\n44,436 2,346\\n\\n10 % 3 %\\n\\n16 % $ 8 %\\n\\n42,293 2,205\\n\\n5 % 6 %\\n\\n(4)\\n\\nCorporate TOTAL NIKE, INC. REVENUES\\n\\n$\\n\\n27\\n\\n51,217 $\\n\\n(72) 46,710\\n\\n— 10 %\\n\\n— 16 % $\\n\\n40 44,538\\n\\n— 5 %\\n\\n(1) The percent change excluding currency changes represents a non-GAAP financial measure. For further information, see \"Use of Non-GAAP Financial Measures\".\\n\\n(2) For additional information on the transition of our NIKE Brand businesses within our CASA territory to a third-party distributor, see Note 18 — Acquisitions and Divestitures of the Notes to Consolidated\\n\\nFinancial Statements contained in Item 8 of this Annual Report.\\n\\n(3) Global Brand Divisions revenues include NIKE Brand licensing and other miscellaneous revenues that are not part of a geographic operating segment.\\n\\n(4) Corporate revenues primarily consist of foreign currency hedge gains and losses related to revenues generated by entities within the NIKE Brand geographic operating segments and Converse, but\\n\\nmanaged through our central foreign exchange risk management program.\\n\\nThe primary financial measure used by the Company to evaluate performance is Earnings Before Interest and Taxes (\"EBIT\"). As discussed in Note 15 — Operating Segments and Related Information in the accompanying Notes to the Consolidated Financial Statements, certain corporate costs are not included in EBIT.\\n\\nThe breakdown of EBIT is as follows:\\n\\n(Dollars in millions)\\n\\nFISCAL 2023\\n\\nFISCAL 2022\\n\\n% CHANGE\\n\\nFISCAL 2021\\n\\nNorth America Europe, Middle East & Africa Greater China\\n\\n$\\n\\n5,454 3,531 2,283\\n\\n$\\n\\n5,114 3,293 2,365\\n\\n7 % $ 7 % -3 %\\n\\n5,089 2,435 3,243\\n\\nAsia Pacific & Latin America Global Brand Divisions (1)'),\n",
-              "  0.233286499977),\n",
-              " (Document(metadata={'source': 'resources/nke-10k-2023.pdf'}, page_content='As discussed in Note 15 — Operating Segments and Related Information in the accompanying Notes to the Consolidated Financial Statements, our operating segments are evidence of the structure of the Company\\'s internal organization. The NIKE Brand segments are defined by geographic regions for operations participating in NIKE Brand sales activity.\\n\\nThe breakdown of Revenues is as follows:\\n\\n(Dollars in millions)\\n\\nFISCAL 2023 FISCAL 2022\\n\\n% CHANGE\\n\\n% CHANGE EXCLUDING CURRENCY (1) CHANGES FISCAL 2021\\n\\n% CHANGE\\n\\nNorth America Europe, Middle East & Africa Greater China\\n\\n$\\n\\n21,608 $ 13,418 7,248\\n\\n18,353 12,479 7,547\\n\\n18 % 8 % -4 %\\n\\n18 % $ 21 % 4 %\\n\\n17,179 11,456 8,290\\n\\n7 % 9 % -9 %\\n\\nAsia Pacific & Latin America Global Brand Divisions\\n\\n(3)\\n\\n(2)\\n\\n6,431 58\\n\\n5,955 102\\n\\n8 % -43 %\\n\\n17 % -43 %\\n\\n5,343 25\\n\\n11 % 308 %\\n\\nTOTAL NIKE BRAND Converse\\n\\n$\\n\\n48,763 $ 2,427\\n\\n44,436 2,346\\n\\n10 % 3 %\\n\\n16 % $ 8 %\\n\\n42,293 2,205\\n\\n5 % 6 %\\n\\n(4)\\n\\nCorporate TOTAL NIKE, INC. REVENUES\\n\\n$\\n\\n27\\n\\n51,217 $\\n\\n(72) 46,710\\n\\n— 10 %\\n\\n— 16 % $\\n\\n40 44,538\\n\\n— 5 %\\n\\n(1) The percent change excluding currency changes represents a non-GAAP financial measure. For further information, see \"Use of Non-GAAP Financial Measures\".\\n\\n(2) For additional information on the transition of our NIKE Brand businesses within our CASA territory to a third-party distributor, see Note 18 — Acquisitions and Divestitures of the Notes to Consolidated\\n\\nFinancial Statements contained in Item 8 of this Annual Report.\\n\\n(3) Global Brand Divisions revenues include NIKE Brand licensing and other miscellaneous revenues that are not part of a geographic operating segment.\\n\\n(4) Corporate revenues primarily consist of foreign currency hedge gains and losses related to revenues generated by entities within the NIKE Brand geographic operating segments and Converse, but\\n\\nmanaged through our central foreign exchange risk management program.\\n\\nThe primary financial measure used by the Company to evaluate performance is Earnings Before Interest and Taxes (\"EBIT\"). As discussed in Note 15 — Operating Segments and Related Information in the accompanying Notes to the Consolidated Financial Statements, certain corporate costs are not included in EBIT.\\n\\nThe breakdown of EBIT is as follows:\\n\\n(Dollars in millions)\\n\\nFISCAL 2023\\n\\nFISCAL 2022\\n\\n% CHANGE\\n\\nFISCAL 2021\\n\\nNorth America Europe, Middle East & Africa Greater China\\n\\n$\\n\\n5,454 3,531 2,283\\n\\n$\\n\\n5,114 3,293 2,365\\n\\n7 % $ 7 % -3 %\\n\\n5,089 2,435 3,243\\n\\nAsia Pacific & Latin America Global Brand Divisions (1)'),\n",
-              "  0.233286499977),\n",
-              " (Document(metadata={'source': 'resources/nke-10k-2023.pdf'}, page_content=\"Tax (expense) benefit Gain (loss) net of tax\\n\\n5 (14)\\n\\n(9) 22\\n\\nTotal net gain (loss) reclassified for the period\\n\\n$\\n\\n463 $\\n\\n30\\n\\n2023 FORM 10-K 82\\n\\nTable of Contents\\n\\nNOTE 14 — REVENUES\\n\\nDISAGGREGATION OF REVENUES The following tables present the Company's Revenues disaggregated by reportable operating segment, major product line and distribution channel:\\n\\n(Dollars in millions)\\n\\nNORTH AMERICA\\n\\nEUROPE, MIDDLE EAST & AFRICA\\n\\nGREATER CHINA\\n\\nYEAR ENDED MAY 31, 2023 ASIA PACIFIC & LATIN (1)\\n\\nGLOBAL BRAND DIVISIONS\\n\\nTOTAL NIKE\\n\\nAMERICA\\n\\nBRAND CONVERSE CORPORATE\\n\\nTOTAL NIKE, INC.\\n\\nRevenues by: Footwear\\n\\n$\\n\\n14,897 $\\n\\n8,260 $\\n\\n5,435 $\\n\\n4,543 $\\n\\n— $\\n\\n33,135 $\\n\\n2,155 $\\n\\n— $\\n\\n35,290\\n\\nApparel Equipment Other\\n\\n5,947 764 —\\n\\n4,566 592 —\\n\\n1,666 147 —\\n\\n1,664 224 —\\n\\n— — 58\\n\\n13,843 1,727 58\\n\\n90 28 154\\n\\n— — 27\\n\\n13,933 1,755 239\\n\\nTOTAL REVENUES\\n\\n$\\n\\n21,608 $\\n\\n13,418 $\\n\\n7,248 $\\n\\n6,431 $\\n\\n58 $\\n\\n48,763 $\\n\\n2,427 $\\n\\n27 $\\n\\n51,217\\n\\nRevenues by:\\n\\nSales to Wholesale Customers Sales through Direct to Consumer\\n\\n$\\n\\n11,273 $ 10,335\\n\\n8,522 $ 4,896\\n\\n3,866 $ 3,382\\n\\n3,736 $ 2,695\\n\\n— $ —\\n\\n27,397 $ 21,308\\n\\n1,299 $ 974\\n\\n— $ —\\n\\n28,696 22,282\\n\\nOther\\n\\nTOTAL REVENUES\\n\\n$\\n\\n—\\n\\n21,608 $\\n\\n—\\n\\n13,418 $\\n\\n— 7,248 $\\n\\n— 6,431 $\\n\\n58 58 $\\n\\n58\\n\\n48,763 $\\n\\n154 2,427 $\\n\\n27 27 $\\n\\n239 51,217\\n\\n(1) Refer to Note 18 — Acquisitions and Divestitures for additional information on the transition of the Company's NIKE Brand businesses in its CASA territory to third-party distributors.\\n\\nYEAR ENDED MAY 31, 2022\\n\\n(Dollars in millions)\\n\\nNORTH AMERICA\\n\\nEUROPE, MIDDLE EAST & AFRICA\\n\\nGREATER CHINA\\n\\nASIA PACIFIC & LATIN AMERICA\\n\\nGLOBAL BRAND DIVISIONS\\n\\nTOTAL NIKE\\n\\nBRAND CONVERSE CORPORATE\\n\\nTOTAL NIKE, INC.\\n\\nRevenues by: Footwear Apparel\\n\\n$\\n\\n12,228 $ 5,492\\n\\n7,388 $ 4,527\\n\\n5,416 $ 1,938\\n\\n4,111 $ 1,610\\n\\n— $ —\\n\\n29,143 $ 13,567\\n\\n2,094 $ 103\\n\\n— $ —\\n\\n31,237 13,670\\n\\nEquipment Other\\n\\n633 —\\n\\n564 —\\n\\n193 —\\n\\n234 —\\n\\n— 102\\n\\n1,624 102\\n\\n26 123\\n\\n— (72)\\n\\n1,650 153\\n\\nTOTAL REVENUES Revenues by:\\n\\n$\\n\\n18,353 $\\n\\n12,479 $\\n\\n7,547 $\\n\\n5,955 $\\n\\n102 $\\n\\n44,436 $\\n\\n2,346 $\\n\\n(72) $\\n\\n46,710\\n\\nSales to Wholesale Customers Sales through Direct to Consumer Other\\n\\n$\\n\\n9,621 $ 8,732 —\\n\\n8,377 $ 4,102 —\\n\\n4,081 $ 3,466 —\\n\\n3,529 $ 2,426 —\\n\\n— $ — 102\\n\\n25,608 $ 18,726 102\\n\\n1,292 $ 931 123\\n\\n— $ — (72)\\n\\n26,900 19,657 153\\n\\nTOTAL REVENUES\\n\\n$\\n\\n18,353 $\\n\\n12,479 $\\n\\n7,547 $\\n\\n5,955 $\\n\\n102 $\\n\\n44,436 $\\n\\n2,346 $\\n\\n(72) $\\n\\n46,710\\n\\n2023 FORM 10-K 83\\n\\nTable of Contents\\n\\nYEAR ENDED MAY 31, 2021\\n\\n(Dollars in millions)\\n\\nNORTH AMERICA\\n\\nEUROPE, MIDDLE EAST & AFRICA\\n\\nGREATER CHINA\"),\n",
-              "  0.261225402355)]"
-            ]
-          },
-          "execution_count": 11,
-          "metadata": {},
-          "output_type": "execute_result"
-        }
-      ],
-      "source": [
-        "# filter results to a certain distance threshold\n",
-        "rds.similarity_search_with_score(query=\"Nike company revenue\", k=4, distance_threshold=0.3)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "XdzQa112Bf2b"
-      },
-      "source": [
-        "## RAG with LangChain\n",
-        "LangChain makes it easy to now take this vector store and build retireval augmented generation (RAG) applications over your data."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "collapsed": false,
-        "id": "CU2aFQPW1vmz"
-      },
-      "source": [
-        "### Initialize OpenAI\n",
-        "\n",
-        "You need to supply an OpenAI API key (starts with `sk-...`) when prompted. If the key is in your env -- great, otherwise enter it when prompted below. You can find your API key at https://platform.openai.com/account/api-keys"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 12,
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "GSpH-cur1vmz",
-        "outputId": "b00de5c7-1684-4e8e-c146-6d402910cdc5"
-      },
-      "outputs": [],
-      "source": [
-        "import getpass\n",
-        "from langchain_openai import ChatOpenAI\n",
-        "\n",
-        "llm = ChatOpenAI(openai_api_key=os.getenv(\"OPENAI_API_KEY\") or getpass.getpass(prompt=\"OpenAI API Key:\"))"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "-SQXQB-c1vmz"
-      },
-      "source": [
-        "### Setup prompt"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 13,
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "from langchain_core.output_parsers import StrOutputParser\n",
-        "from langchain_core.prompts import ChatPromptTemplate\n",
-        "from langchain_core.runnables import RunnablePassthrough\n",
-        "\n",
-        "prompt_template = \"\"\"\n",
-        "    Use the following pieces of context from financial 10k filings data to answer the user question at the end. \n",
-        "    If you don't know the answer, say that you don't know, don't try to make up an answer.\n",
-        "\n",
-        "    Context:\n",
-        "    ---------\n",
-        "    {context}\n",
-        "    ---------\n",
-        "    Question:\n",
-        "    {question}\n",
-        "    Answer:\n",
-        "\"\"\"\n",
-        "\n",
-        "def format_docs(docs):\n",
-        "    return \"\\n\\n\".join(doc.page_content for doc in docs)\n",
-        "\n",
-        "prompt = ChatPromptTemplate.from_template(prompt_template)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "xgEXBujxG1dO"
-      },
-      "source": [
-        "### Putting it all together\n",
-        "\n",
-        "This is where the Langchain brings all the components together in a form of a simple RAG application with the financial PDF document."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 14,
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "rag_chain = (\n",
-        "    {\n",
-        "        \"context\": rds.as_retriever() | format_docs,\n",
-        "        \"question\": RunnablePassthrough()\n",
-        "    }\n",
-        "    | prompt\n",
-        "    | llm\n",
-        "    | StrOutputParser()\n",
-        ")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "SURTtVbYBFGc"
-      },
-      "source": [
-        "### Finally - let's ask questions!\n",
-        "\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 15,
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 52
-        },
-        "id": "0JkswfOHZu9h",
-        "outputId": "813fffe6-3d8b-4df7-a035-c54e421c0856"
-      },
-      "outputs": [
-        {
-          "data": {
-            "text/plain": [
-              "\"Nike's revenue last year was $44,538 million, and this year it was $51,217 million.\""
-            ]
-          },
-          "execution_count": 15,
-          "metadata": {},
-          "output_type": "execute_result"
-        }
-      ],
-      "source": [
-        "query = \"What was Nike's revenue last year compared to this year??\"\n",
-        "rag_chain.invoke(query)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 16,
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 52
-        },
-        "id": "ZvioUduS1vm0",
-        "outputId": "a8ba0e5d-c06b-4848-d066-c26884b3caee"
-      },
-      "outputs": [
-        {
-          "data": {
-            "text/plain": [
-              "'The exact number of products Nike offers is not explicitly stated in the provided context. However, Nike is part of the athletic footwear, apparel, and equipment industry, which is highly competitive both in the United States and worldwide.'"
-            ]
-          },
-          "execution_count": 16,
-          "metadata": {},
-          "output_type": "execute_result"
-        }
-      ],
-      "source": [
-        "query = \"How many products does Nike offer? What is the industry that Nike is part of?\"\n",
-        "rag_chain.invoke(query)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 17,
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 35
-        },
-        "id": "Q9mE5z-61vm1",
-        "outputId": "e3860d3e-e68b-489b-9897-c7118377c7bb"
-      },
-      "outputs": [
-        {
-          "data": {
-            "text/plain": [
-              "'Based on the provided information, there is no specific mention or data that directly addresses the ethical practices of Nike as a company. Therefore, it is not possible to determine if Nike is an ethical company based on the provided context.'"
-            ]
-          },
-          "execution_count": 17,
-          "metadata": {},
-          "output_type": "execute_result"
-        }
-      ],
-      "source": [
-        "query = \"Is Nike an ethical company?\"\n",
-        "rag_chain.invoke(query)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "5itk4UPF1vm1"
-      },
-      "source": [
-        "## Cleanup\n",
-        "\n",
-        "Cleanup the index and data."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 18,
-      "metadata": {
-        "id": "DtZi-mQ61vm-"
-      },
-      "outputs": [
-        {
-          "ename": "ValueError",
-          "evalue": "REDIS_URL env var not set",
-          "output_type": "error",
-          "traceback": [
-            "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-            "\u001b[0;31mValueError\u001b[0m                                Traceback (most recent call last)",
-            "Cell \u001b[0;32mIn[18], line 3\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[38;5;28;01mfrom\u001b[39;00m \u001b[38;5;21;01mredisvl\u001b[39;00m\u001b[38;5;21;01m.\u001b[39;00m\u001b[38;5;21;01mindex\u001b[39;00m \u001b[38;5;28;01mimport\u001b[39;00m SearchIndex\n\u001b[0;32m----> 3\u001b[0m idx \u001b[38;5;241m=\u001b[39m \u001b[43mSearchIndex\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mfrom_existing\u001b[49m\u001b[43m(\u001b[49m\n\u001b[1;32m      4\u001b[0m \u001b[43m    \u001b[49m\u001b[43mindex_name\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m      5\u001b[0m \u001b[43m    \u001b[49m\u001b[43mredis_url\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mREDIS_URL\u001b[49m\n\u001b[1;32m      6\u001b[0m \u001b[43m)\u001b[49m\n\u001b[1;32m      8\u001b[0m idx\u001b[38;5;241m.\u001b[39mdelete()\n",
-            "File \u001b[0;32m~/.pyenv/versions/3.11.9/lib/python3.11/site-packages/redisvl/index/index.py:322\u001b[0m, in \u001b[0;36mSearchIndex.from_existing\u001b[0;34m(cls, name, redis_client, redis_url, **kwargs)\u001b[0m\n\u001b[1;32m    320\u001b[0m \u001b[38;5;28;01mtry\u001b[39;00m:\n\u001b[1;32m    321\u001b[0m     \u001b[38;5;28;01mif\u001b[39;00m redis_url:\n\u001b[0;32m--> 322\u001b[0m         redis_client \u001b[38;5;241m=\u001b[39m \u001b[43mRedisConnectionFactory\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mget_redis_connection\u001b[49m\u001b[43m(\u001b[49m\n\u001b[1;32m    323\u001b[0m \u001b[43m            \u001b[49m\u001b[43mredis_url\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mredis_url\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    324\u001b[0m \u001b[43m            \u001b[49m\u001b[43mrequired_modules\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mREQUIRED_MODULES_FOR_INTROSPECTION\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    325\u001b[0m \u001b[43m            \u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43mkwargs\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    326\u001b[0m \u001b[43m        \u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    327\u001b[0m     \u001b[38;5;28;01melif\u001b[39;00m redis_client:\n\u001b[1;32m    328\u001b[0m         RedisConnectionFactory\u001b[38;5;241m.\u001b[39mvalidate_sync_redis(\n\u001b[1;32m    329\u001b[0m             redis_client, required_modules\u001b[38;5;241m=\u001b[39mREQUIRED_MODULES_FOR_INTROSPECTION\n\u001b[1;32m    330\u001b[0m         )\n",
-            "File \u001b[0;32m~/.pyenv/versions/3.11.9/lib/python3.11/site-packages/redisvl/redis/connection.py:248\u001b[0m, in \u001b[0;36mRedisConnectionFactory.get_redis_connection\u001b[0;34m(url, required_modules, **kwargs)\u001b[0m\n\u001b[1;32m    224\u001b[0m \u001b[38;5;129m@staticmethod\u001b[39m\n\u001b[1;32m    225\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mget_redis_connection\u001b[39m(\n\u001b[1;32m    226\u001b[0m     url: Optional[\u001b[38;5;28mstr\u001b[39m] \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;01mNone\u001b[39;00m,\n\u001b[1;32m    227\u001b[0m     required_modules: Optional[List[Dict[\u001b[38;5;28mstr\u001b[39m, Any]]] \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;01mNone\u001b[39;00m,\n\u001b[1;32m    228\u001b[0m     \u001b[38;5;241m*\u001b[39m\u001b[38;5;241m*\u001b[39mkwargs,\n\u001b[1;32m    229\u001b[0m ) \u001b[38;5;241m-\u001b[39m\u001b[38;5;241m>\u001b[39m Redis:\n\u001b[1;32m    230\u001b[0m \u001b[38;5;250m    \u001b[39m\u001b[38;5;124;03m\"\"\"Creates and returns a synchronous Redis client.\u001b[39;00m\n\u001b[1;32m    231\u001b[0m \n\u001b[1;32m    232\u001b[0m \u001b[38;5;124;03m    Args:\u001b[39;00m\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    246\u001b[0m \u001b[38;5;124;03m        RedisModuleVersionError: If required Redis modules are not installed.\u001b[39;00m\n\u001b[1;32m    247\u001b[0m \u001b[38;5;124;03m    \"\"\"\u001b[39;00m\n\u001b[0;32m--> 248\u001b[0m     url \u001b[38;5;241m=\u001b[39m url \u001b[38;5;129;01mor\u001b[39;00m \u001b[43mget_address_from_env\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    249\u001b[0m     client \u001b[38;5;241m=\u001b[39m Redis\u001b[38;5;241m.\u001b[39mfrom_url(url, \u001b[38;5;241m*\u001b[39m\u001b[38;5;241m*\u001b[39mkwargs)\n\u001b[1;32m    251\u001b[0m     RedisConnectionFactory\u001b[38;5;241m.\u001b[39mvalidate_sync_redis(\n\u001b[1;32m    252\u001b[0m         client, required_modules\u001b[38;5;241m=\u001b[39mrequired_modules\n\u001b[1;32m    253\u001b[0m     )\n",
-            "File \u001b[0;32m~/.pyenv/versions/3.11.9/lib/python3.11/site-packages/redisvl/redis/connection.py:61\u001b[0m, in \u001b[0;36mget_address_from_env\u001b[0;34m()\u001b[0m\n\u001b[1;32m     55\u001b[0m \u001b[38;5;250m\u001b[39m\u001b[38;5;124;03m\"\"\"Get a redis connection from environment variables.\u001b[39;00m\n\u001b[1;32m     56\u001b[0m \n\u001b[1;32m     57\u001b[0m \u001b[38;5;124;03mReturns:\u001b[39;00m\n\u001b[1;32m     58\u001b[0m \u001b[38;5;124;03m    str: Redis URL\u001b[39;00m\n\u001b[1;32m     59\u001b[0m \u001b[38;5;124;03m\"\"\"\u001b[39;00m\n\u001b[1;32m     60\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mREDIS_URL\u001b[39m\u001b[38;5;124m\"\u001b[39m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;129;01min\u001b[39;00m os\u001b[38;5;241m.\u001b[39menviron:\n\u001b[0;32m---> 61\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mValueError\u001b[39;00m(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mREDIS_URL env var not set\u001b[39m\u001b[38;5;124m\"\u001b[39m)\n\u001b[1;32m     62\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m os\u001b[38;5;241m.\u001b[39menviron[\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mREDIS_URL\u001b[39m\u001b[38;5;124m\"\u001b[39m]\n",
-            "\u001b[0;31mValueError\u001b[0m: REDIS_URL env var not set"
-          ]
-        }
-      ],
-      "source": [
-        "from redisvl.index import SearchIndex\n",
-        "\n",
-        "idx = SearchIndex.from_existing(\n",
-        "    index_name,\n",
-        "    redis_url=REDIS_URL\n",
-        ")\n",
-        "\n",
-        "idx.delete()"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 19,
-      "metadata": {},
-      "outputs": [
-        {
-          "data": {
-            "text/plain": [
-              "'0.4.0'"
-            ]
-          },
-          "execution_count": 19,
-          "metadata": {},
-          "output_type": "execute_result"
-        }
-      ],
-      "source": [
-        "import redisvl\n",
-        "\n",
-        "redisvl.__version__"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 20,
-      "metadata": {},
-      "outputs": [
-        {
-          "data": {
-            "text/plain": [
-              "'5.2.1'"
-            ]
-          },
-          "execution_count": 20,
-          "metadata": {},
-          "output_type": "execute_result"
-        }
-      ],
-      "source": [
-        "import redis\n",
-        "\n",
-        "redis.__version__"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 21,
-      "metadata": {},
-      "outputs": [
-        {
-          "data": {
-            "text/plain": [
-              "'redis://:@localhost:6379'"
-            ]
-          },
-          "execution_count": 21,
-          "metadata": {},
-          "output_type": "execute_result"
-        }
-      ],
-      "source": [
-        "REDIS_URL"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {},
-      "outputs": [],
-      "source": []
-    }
-  ],
-  "metadata": {
-    "accelerator": "GPU",
-    "colab": {
-      "gpuType": "T4",
-      "provenance": []
-    },
-    "kernelspec": {
-      "display_name": "Python 3",
-      "name": "python3"
-    },
-    "language_info": {
-      "codemirror_mode": {
-        "name": "ipython",
-        "version": 3
-      },
-      "file_extension": ".py",
-      "mimetype": "text/x-python",
-      "name": "python",
-      "nbconvert_exporter": "python",
-      "pygments_lexer": "ipython3",
-      "version": "3.11.9"
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "R2-i8jBl9GRH"
+   },
+   "source": [
+    "![Redis](https://redis.io/wp-content/uploads/2024/04/Logotype.svg?auto=webp&quality=85,75&width=120)\n",
+    "# RAG with LangChain\n",
+    "\n",
+    "This notebook uses [LangChain](https://python.langchain.com/docs/get_started/introduction) and [Redis](https://redis.com) to perform document + embdding indexing and semantic search tasks. It also shows how to integrate with an LLM like OpenAI's GPT models. See the full partner package source code [here](https://github.com/langchain-ai/langchain-redis/tree/main).\n",
+    "\n",
+    "## Let's Begin!\n",
+    "<a href=\"https://colab.research.google.com/github/redis-developer/redis-ai-resources/blob/main/python-recipes/RAG/02_langchain.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 0
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "ctOVb_LZ1vmk"
+   },
+   "source": [
+    "## Environment Setup\n",
+    "\n",
+    "### Pull Github Materials\n",
+    "Because you are likely running this notebook in **Google Colab**, we need to first\n",
+    "pull the necessary dataset and materials directly from GitHub. The following commands grab the material, move to root for colab, and clean up unneeded files.\n",
+    "\n",
+    "**If you are running this notebook locally**, FYI you may not need to perform this\n",
+    "step at all."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "UQezgPCG1vml",
+    "outputId": "97b9bc03-da1b-439a-c37b-be6fdb58ab21"
+   },
+   "outputs": [],
+   "source": [
+    "# NBVAL_SKIP\n",
+    "!git clone https://github.com/redis-developer/redis-ai-resources.git temp_repo\n",
+    "!mv temp_repo/python-recipes/RAG/resources .\n",
+    "!rm -rf temp_repo"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "9eieJowO1vmo"
+   },
+   "source": [
+    "### Install Python Dependencies"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "B3v1wUzX1vmq",
+    "outputId": "84a3feff-e7c1-41ba-9ab1-8c975074552e"
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "huggingface/tokenizers: The current process just got forked, after parallelism has already been used. Disabling parallelism to avoid deadlocks...\n",
+      "To disable this warning, you can either:\n",
+      "\t- Avoid using `tokenizers` before the fork if possible\n",
+      "\t- Explicitly set the environment variable TOKENIZERS_PARALLELISM=(true | false)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "\u001B[1m[\u001B[0m\u001B[34;49mnotice\u001B[0m\u001B[1;39;49m]\u001B[0m\u001B[39;49m A new release of pip is available: \u001B[0m\u001B[31;49m24.0\u001B[0m\u001B[39;49m -> \u001B[0m\u001B[32;49m25.0.1\u001B[0m\n",
+      "\u001B[1m[\u001B[0m\u001B[34;49mnotice\u001B[0m\u001B[1;39;49m]\u001B[0m\u001B[39;49m To update, run: \u001B[0m\u001B[32;49mpip install --upgrade pip\u001B[0m\n",
+      "Note: you may need to restart the kernel to use updated packages.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "huggingface/tokenizers: The current process just got forked, after parallelism has already been used. Disabling parallelism to avoid deadlocks...\n",
+      "To disable this warning, you can either:\n",
+      "\t- Avoid using `tokenizers` before the fork if possible\n",
+      "\t- Explicitly set the environment variable TOKENIZERS_PARALLELISM=(true | false)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "\u001B[1m[\u001B[0m\u001B[34;49mnotice\u001B[0m\u001B[1;39;49m]\u001B[0m\u001B[39;49m A new release of pip is available: \u001B[0m\u001B[31;49m24.0\u001B[0m\u001B[39;49m -> \u001B[0m\u001B[32;49m25.0.1\u001B[0m\n",
+      "\u001B[1m[\u001B[0m\u001B[34;49mnotice\u001B[0m\u001B[1;39;49m]\u001B[0m\u001B[39;49m To update, run: \u001B[0m\u001B[32;49mpip install --upgrade pip\u001B[0m\n",
+      "Note: you may need to restart the kernel to use updated packages.\n"
+     ]
+    }
+   ],
+   "source": [
+    "%pip install -q redis \"unstructured[pdf]\" sentence-transformers langchain\n",
+    "%pip install -q langchain-community \"langchain-redis>=0.2.0\" langchain-huggingface langchain-openai"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Install Redis Stack\n",
+    "\n",
+    "Later in this tutorial, Redis will be used to store, index, and query vector\n",
+    "embeddings created from PDF document chunks. **We need to make sure we have a Redis\n",
+    "instance available.**"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### For Colab\n",
+    "Use the shell script below to download, extract, and install [Redis Stack](https://redis.io/docs/getting-started/install-stack/) directly from the Redis package archive."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# NBVAL_SKIP\n",
+    "%%sh\n",
+    "curl -fsSL https://packages.redis.io/gpg | sudo gpg --dearmor -o /usr/share/keyrings/redis-archive-keyring.gpg\n",
+    "echo \"deb [signed-by=/usr/share/keyrings/redis-archive-keyring.gpg] https://packages.redis.io/deb $(lsb_release -cs) main\" | sudo tee /etc/apt/sources.list.d/redis.list\n",
+    "sudo apt-get update  > /dev/null 2>&1\n",
+    "sudo apt-get install redis-stack-server  > /dev/null 2>&1\n",
+    "redis-stack-server --daemonize yes"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### For Alternative Environments\n",
+    "There are many ways to get the necessary redis-stack instance running\n",
+    "1. On cloud, deploy a [FREE instance of Redis in the cloud](https://redis.com/try-free/). Or, if you have your\n",
+    "own version of Redis Enterprise running, that works too!\n",
+    "2. Per OS, [see the docs](https://redis.io/docs/latest/operate/oss_and_stack/install/install-stack/)\n",
+    "3. With docker: `docker run -d --name redis-stack-server -p 6379:6379 redis/redis-stack-server:latest`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Define the Redis Connection URL\n",
+    "\n",
+    "By default this notebook connects to the local instance of Redis Stack. **If you have your own Redis Enterprise instance** - replace REDIS_PASSWORD, REDIS_HOST and REDIS_PORT values with your own."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import warnings\n",
+    "warnings.filterwarnings('ignore')\n",
+    "\n",
+    "# Replace values below with your own if using Redis Cloud instance\n",
+    "REDIS_HOST = os.getenv(\"REDIS_HOST\", \"localhost\") # ex: \"redis-18374.c253.us-central1-1.gce.cloud.redislabs.com\"\n",
+    "REDIS_PORT = os.getenv(\"REDIS_PORT\", \"6379\")      # ex: 18374\n",
+    "REDIS_PASSWORD = os.getenv(\"REDIS_PASSWORD\", \"\")  # ex: \"1TNxTEdYRDgIDKM2gDfasupCADXXXX\"\n",
+    "\n",
+    "# If SSL is enabled on the endpoint, use rediss:// as the URL prefix\n",
+    "REDIS_URL = f\"redis://:{REDIS_PASSWORD}@{REDIS_HOST}:{REDIS_PORT}\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## RAG with LangChain"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "7MaVqU8Y1vms"
+   },
+   "source": [
+    "### Dataset Preparation (PDF Documents)\n",
+    "\n",
+    "To best demonstrate Redis as a vector database layer, we will load a single\n",
+    "financial (10k filings) doc and preprocess it using some helpers from LangChain:\n",
+    "\n",
+    "- `UnstructuredFileLoader` is not the only document loader type that LangChain provides. Docs: https://python.langchain.com/docs/integrations/document_loaders/unstructured_file\n",
+    "- `RecursiveCharacterTextSplitter` is what we use to create smaller chunks of text from the doc. Docs: https://python.langchain.com/docs/modules/data_connection/document_transformers/text_splitters/recursive_text_splitter"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "I7VS1bPr1vmt",
+    "outputId": "72299230-26c4-4d80-d61f-138616e2173b"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Listing available documents ... ['resources/nke-10k-2023.pdf', 'resources/amzn-10k-2023.pdf', 'resources/metrics_2500_0.csv', 'resources/jnj-10k-2023.pdf', 'resources/aapl-10k-2023.pdf', 'resources/testset_15.csv', 'resources/retrieval_basic_rag_test.csv', 'resources/2022-chevy-colorado-ebrochure.pdf', 'resources/nvd-10k-2023.pdf', 'resources/testset.csv', 'resources/msft-10k-2023.pdf', 'resources/propositions.json', 'resources/generation_basic_rag_test.csv']\n"
+     ]
+    }
+   ],
+   "source": [
+    "from langchain_text_splitters import RecursiveCharacterTextSplitter\n",
+    "from langchain_community.document_loaders import UnstructuredFileLoader\n",
+    "\n",
+    "# Load list of pdfs from a folder\n",
+    "data_path = \"resources/\"\n",
+    "docs = [os.path.join(data_path, file) for file in os.listdir(data_path)]\n",
+    "\n",
+    "print(\"Listing available documents ...\", docs)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/var/folders/_g/rr4lnxxx1_z7m78lz89dhvsm0000gp/T/ipykernel_45325/1931079106.py:8: LangChainDeprecationWarning: The class `UnstructuredFileLoader` was deprecated in LangChain 0.2.8 and will be removed in 1.0. An updated version of the class exists in the :class:`~langchain-unstructured package and should be used instead. To use it run `pip install -U :class:`~langchain-unstructured` and import as `from :class:`~langchain_unstructured import UnstructuredLoader``.\n",
+      "  loader = UnstructuredFileLoader(\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Done preprocessing. Created 179 chunks of the original pdf resources/nke-10k-2023.pdf\n"
+     ]
+    }
+   ],
+   "source": [
+    "# pick out the Nike doc for this exercise\n",
+    "doc = [doc for doc in docs if \"nke\" in doc][0]\n",
+    "\n",
+    "# set up the file loader/extractor and text splitter to create chunks\n",
+    "text_splitter = RecursiveCharacterTextSplitter(\n",
+    "    chunk_size=2500, chunk_overlap=0\n",
+    ")\n",
+    "loader = UnstructuredFileLoader(\n",
+    "    doc, mode=\"single\", strategy=\"fast\"\n",
+    ")\n",
+    "\n",
+    "# extract, load, and make chunks\n",
+    "chunks = loader.load_and_split(text_splitter)\n",
+    "\n",
+    "print(\"Done preprocessing. Created\", len(chunks), \"chunks of the original pdf\", doc)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "96BzcyW31vmw"
+   },
+   "source": [
+    "### Initialize Embeddings Model\n",
+    "Here we will use LangChain's built in embedding engine so that it will work seemlessly with the LangChain VectorStore classes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 465,
+     "referenced_widgets": [
+      "e822a189950844309e630f3e428d5a9a",
+      "d3e5c2097a8e44f481e91646e0410e62",
+      "b1e8dcf4ead64c5b8155594fd1d20632",
+      "bd042dad15084b098dfbf7c9277d3581",
+      "54c512a0bb9f485a9612f088c717eec8",
+      "e769ce42211749599822ffc3a18e7292",
+      "0d6362898099436abb80e52eac043c4f",
+      "e3afaca826464f94b6b904e68c827cab",
+      "27ba4306f92c4d659cadcd5c1e0ab787",
+      "15378b3263a449fabf00643fdd23565e",
+      "aee906bc037849e2be3ac68955281892",
+      "2e3997001c494151829379467dde2182",
+      "0281867e8ce8433fb665e287505d0404",
+      "d6ff7f1d2a6b44ff829212b67613e03b",
+      "3402b3afe4304aec81a1e4389e2eafec",
+      "fc32fd51efd2488e9bff38274079d7e5",
+      "07a6bd4b6a484dbebda92c366f3a6740",
+      "13fb05f6cbe24acba47be67e8b0a69a6",
+      "3d30fc25d10e4ce18d50320a88b0a2ec",
+      "ebe649c53e4d48fda0d4ea9a46ec5613",
+      "843c2b0500ee4219841c959f3af20542",
+      "d84881099d4f4f1fa8a481ea9f9dafdd",
+      "04c8bb6bb7c8425b92e0f3fab63d8362",
+      "4d54077e8c38411080b1ef9bfb42e3f8",
+      "b8c9c7fb7b6e4dcfb717f96da1639553",
+      "52961d70221846f78523df1414eb3436",
+      "008e25d7de5e4e548d80be81e26bdb8f",
+      "b0d11b0e853740b7b8e49e5158c940e5",
+      "ac450c103bb44f549a7103f67634f9bf",
+      "99204cde99b348ccb4f45589802f5a38",
+      "2860317abc5b41fab94f8fefe9cb6b3b",
+      "30ebda1e38294648b014354009c17269",
+      "755e63baf4ad4a289fd756d662d9a0bf",
+      "723ef31f042343bd94217075e1857989",
+      "820afc900ef34cdc82f4e5d7c38fb67f",
+      "f06938274c0d4b4591b6cfa2e7a8d183",
+      "1ab52b039fdb4cab909eb439a4ea3524",
+      "d1e27bbac128455e9a0e959ba251eedd",
+      "ff4297f185ce4f2eaf340a422b721774",
+      "168314c6ae1044d6810def7ff06f80c2",
+      "dad25775795b46ec9e7bb788b1d25f82",
+      "4e74d1276be141c9b0f2601ce4c7246a",
+      "2dff47a7d6364e2ba73f057e9b17a705",
+      "f4b4bc8eeef84da2abcf1691e174a080",
+      "6dbbd3a5f81b46d99c9c897dba53d6a5",
+      "b63b4da89d0f45819ad0aead03833f4c",
+      "27725152494c4f0b85e48bf081113764",
+      "8d8356cdf3b54b2daa02fe6d06c2b372",
+      "e61f0ecfe4794a4d929b76b8a5434800",
+      "b1e6fa50486c4973b44b20e29c4837a9",
+      "5d3f0bfd81b34819a6edce0496958f5a",
+      "266abb8c7e064dbea106c6c2903404c3",
+      "59317d931ba14c409d7f9baae6b4b2fc",
+      "da5242e187fd4d6c950e7a75cebb33fa",
+      "a28d8e8eedf34026afe93d2105d7d779",
+      "b4683c36fb744ac18ed8f98f1d352d16",
+      "a68f0e29f8f745fab98bd16b4835956a",
+      "d7791474a31b4ef7bffecdd264cbd0a5",
+      "e49064443c9549ebb7a6d0710d2ad02e",
+      "ee0db8230ae64f1b94e246e2947682a3",
+      "cff28f0f731c48e88de8ccad15146e2f",
+      "af1f8d072046449d9437cb10ccdb2218",
+      "a1f692c86e6d4c668f31bcb4f4189f48",
+      "a8b7b5ad3c954b94bda03987653ce1c8",
+      "32a5f8335e3a4312aea8bb83505b4ed3",
+      "0d4624d3273d46268299e37d96c0d85d",
+      "7c1867628e4742868ba1e1fa322b948e",
+      "35e9d31c8cfb41199df0e4636537a9c0",
+      "f1fff6bb909d4fcbbe0a7582fe5a09d4",
+      "0b3b28fae35d497886c72e4222470629",
+      "bfd29912ee224c4e93ec37f545339586",
+      "d335cf6ac50b46f5a50870069a14a066",
+      "5b7765acd2024e04ba423edc346fe021",
+      "96c778b21e154c77952c3b6456831f6a",
+      "67730a22939d42db8894a633483fd412",
+      "c3e15e863ece4df88d1ad4fa4601fb43",
+      "ce7fbbb4b844429aa16d60c6524bb6ca",
+      "0d1bc800782745a9b89e93bb992e0ce0",
+      "369c5197fd23479c8aa79ac72cbea260",
+      "5317c63c5168499eb992b4d764761dfc",
+      "364519d35ab848199a6fb3e15906318a",
+      "8b7e8c8ff5f3478aa064f5b79ffaaadf",
+      "ccb27092ee314285add51fd91e5ca49d",
+      "61f3b41fdcf04cff88dd08b36a4a5f41",
+      "816a516fa90f43a18dfda92374c2f4ed",
+      "7d8e2e3c678642afba660b450d5f3201",
+      "872caf759d1f45439397ee35c8cf5dc0",
+      "74b0c9b3b9944eab80f16b2789d6c041",
+      "27b3516e55614d1e91ce4c87c022ee0a",
+      "3991f774ac7f492993002be26cd67f18",
+      "d6804472f88d4254925b7b006a97b2c8",
+      "e0cae801b89e43598bab0ce7f38d7042",
+      "09049b516bc545ea844a770021f6812a",
+      "6a3ae2fa53c942edbb1b29a86717ad89",
+      "3da15201c5da4e40b0b3ac999552723a",
+      "bda924a0e1364f89a7f6c9c5ceb03b62",
+      "7a83acfd4fb240c181f127fc7ee07d48",
+      "d6ebd756685b4a589332a3598a25cd89",
+      "f3d585528e6a4962bfb93afbe92b6312",
+      "879c273bd3924ec0acaec655a92350e0",
+      "744ba6e1b34e4883b49c138ab1bdbebc",
+      "d449ea30c72044f986ffc3e1f9a128d8",
+      "976d3f30f0654d48b096a5c39a8dece5",
+      "41685bf8cb4344368edf161b66ae15b2",
+      "7034b97b70c84a01a3d48e316814b555",
+      "39a239df60004a039de689a69c571afc",
+      "1b2f3f0c7afd419e88f061d0c3280989",
+      "701d2879a67c4b86b9f9de76ff675e7c",
+      "955d7c1b76b348549daceb8482a8e825",
+      "2d0a785ceb884a1f9ee020d22c987fa1",
+      "543e7442413d4035bb6949ccbab5cb6b",
+      "5d47f3871bf44a469dcfd0e456d3dae0",
+      "bbb1a53611e14dcb9b028fe82d71e317",
+      "0d31b15287954c3094750dd36a10d47a",
+      "9818040fcf844fd9b00cd0e438209d40",
+      "7c269846386c4f14bfafde1d5c0e871e",
+      "b11227ec73784e09871e0c25131b9f86",
+      "4083110114e3443c920cbeb8c396d4da",
+      "366cf22df75b42509e5610ff9c9b1d3d",
+      "ff231927834c41088becbe8f94f96f7b",
+      "6e3f1af22a534a7ebdb9752acb7f1b96",
+      "7a6e695c3dcf417f9f53ceb019e37111",
+      "5bf9cc6f60614542bf0628586b8560dd",
+      "d08483b9393840cfb36dd504514043c4",
+      "d36c28d414af4712b16a7f0543f61fc9",
+      "00b534687273409fbc18960bb7db0907",
+      "a27b96cc3ce944549ba2d26f5d7338c2",
+      "75f27178134f477db58ef7cfc487897b",
+      "e2816b9d2a21443c82b547466c3347d1",
+      "0a9b8aa436604adc85c1f9a86a9889a6",
+      "37e5517b0c7b45e0ad3366d4daf5b668",
+      "58f9c1e1f51f49c48c6dc6b441078218",
+      "a8114c2300b74599b0652601806b080e",
+      "e211cf2a0e6d4d1096bfb9dfaae00cbb",
+      "f63c59800b0845b8bc8d9c2cce8bafc0",
+      "1f7ba17ad64c4ab68fe963eaf7a1efa7",
+      "05d146ed0f084dac8845c32c4bb28cff",
+      "d05d9073ecd2434da541da9d71c3a907",
+      "52a56e10c8084ce999802b6db17ab78e",
+      "84e4dc1690b642b7b00f5e1cedff91e8",
+      "0ab7b921de994f6980493fb89d3b8572",
+      "6ff193e5c339435cba696e69b4a1ea20",
+      "7ebc91105d344011898341ce4f7edce0",
+      "ae72de3e05a4461d9c2b0c1f953894b2",
+      "69d7c03c926e441a9bccfbe86fd5731d",
+      "9e0ba3c3e2a84f43ae708c89203c814a",
+      "b2b8a580aa1944e6a00106f47070935c",
+      "cf7adc55be354c75b64d9a94285ea8f9",
+      "770d6b0784674359a669f3f1836a5876",
+      "c60fc7a6181a40d489ff43af79ff29b4",
+      "4ffcc071ec56449ba865c876bc5cff5c",
+      "a9c792cb80884e0899da0f40d9472e97",
+      "7ba192f9998e41b782db482b60655f86",
+      "737a0eaff10c4237a67cbd680160ee91"
+     ]
+    },
+    "id": "_h1e-L9yZfaY",
+    "outputId": "fd540dd7-a0aa-4827-e001-f6d4ef603c6a"
+   },
+   "outputs": [],
+   "source": [
+    "from langchain_huggingface import HuggingFaceEmbeddings\n",
+    "\n",
+    "embeddings = HuggingFaceEmbeddings(model_name=\"sentence-transformers/all-MiniLM-L6-v2\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "Qrj-jeGmBRTL"
+   },
+   "source": [
+    "## Vector Search with LangChain\n",
+    "### Create Redis vector store instance\n",
+    "\n",
+    "We also need to create a schema for the vector index so we can take advantage of the metadata along with the vectors.\n",
+    "\n",
+    "**Important Note**: LangChain does not support JSON data types yet. Only supports HASH for now. This update should be coming soon."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "yY69FViAjNv1",
+    "outputId": "ab7b212b-3c55-44b1-cf72-6eb926cf302f"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "16:18:04 redisvl.index.index INFO   Index already exists, not overwriting.\n"
+     ]
+    }
+   ],
+   "source": [
+    "from langchain_redis import RedisVectorStore\n",
+    "\n",
+    "index_name = \"langchain_ex\"\n",
+    "\n",
+    "# construct the vector store class from texts and metadata\n",
+    "rds = RedisVectorStore.from_documents(\n",
+    "    chunks,\n",
+    "    embeddings,\n",
+    "    index_name=index_name,\n",
+    "    redis_url=REDIS_URL,\n",
+    "    metadata_schema=[\n",
+    "        {\n",
+    "            \"name\": \"source\",\n",
+    "            \"type\": \"text\"\n",
+    "        },\n",
+    "    ]\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "gntcxF1P1vmx",
+    "outputId": "3bef4861-8778-4ab7-fb61-710aba655f2c"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "1123"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# access underlying redis client to see how many docs have been stores\n",
+    "rds._index.client.dbsize()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "61xV5qyp1vmy"
+   },
+   "source": [
+    "### Query the database\n",
+    "Now we can use the LangChain vector store class to perform similarity search operations on Redis"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "id": "Gv6SxKOB1vmy"
+   },
+   "outputs": [],
+   "source": [
+    "from redisvl.query.filter import Text"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "Q3pH3MPD1vmy",
+    "outputId": "2754347f-be31-4a38-d356-31ecc235ffe8"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[(Document(metadata={'source': 'resources/nke-10k-2023.pdf'}, page_content=\"(Dollars in millions, except per share data)\\n\\nRevenues Cost of sales\\n\\nGross profit Gross margin\\n\\nDemand creation expense Operating overhead expense\\n\\nTotal selling and administrative expense % of revenues\\n\\nInterest expense (income), net\\n\\nOther (income) expense, net Income before income taxes\\n\\nIncome tax expense Effective tax rate\\n\\nNET INCOME Diluted earnings per common share\\n\\n$\\n\\n$ $\\n\\nFISCAL 2023\\n\\n51,217 28,925\\n\\n22,292\\n\\n43.5 %\\n\\n4,060 12,317\\n\\n16,377\\n\\n32.0 % (6)\\n\\n(280) 6,201\\n\\n1,131\\n\\n18.2 %\\n\\n5,070 3.23\\n\\n$\\n\\n$ $\\n\\nFISCAL 2022\\n\\n46,710 25,231\\n\\n21,479\\n\\n46.0 %\\n\\n3,850 10,954\\n\\n14,804\\n\\n31.7 % 205\\n\\n(181) 6,651\\n\\n605 9.1 %\\n\\n6,046 3.75\\n\\n% CHANGE\\n\\n10 % $ 15 %\\n\\n4 %\\n\\n5 % 12 %\\n\\n11 %\\n\\n—\\n\\n— -7 %\\n\\n87 %\\n\\n16 % $ -14 % $\\n\\nFISCAL 2021\\n\\n% CHANGE\\n\\n44,538 24,576\\n\\n5 % 3 %\\n\\n19,962\\n\\n8 %\\n\\n44.8 %\\n\\n3,114 9,911\\n\\n24 % 11 %\\n\\n13,025\\n\\n14 %\\n\\n29.2 % 262\\n\\n—\\n\\n14 6,661\\n\\n— 0 %\\n\\n934 14.0 %\\n\\n35 %\\n\\n5,727 3.56\\n\\n6 % 5 %\\n\\n2023 FORM 10-K 31\\n\\nTable of Contents\\n\\nCONSOLIDATED OPERATING RESULTS REVENUES\\n\\n(Dollars in millions)\\n\\nFISCAL 2023\\n\\nFISCAL 2022\\n\\n% CHANGE\\n\\n% CHANGE EXCLUDING CURRENCY (1) CHANGES\\n\\nFISCAL 2021\\n\\n% CHANGE\\n\\nNIKE, Inc. Revenues:\\n\\nNIKE Brand Revenues by:\\n\\nFootwear Apparel\\n\\n$\\n\\n33,135 $ 13,843\\n\\n29,143 13,567\\n\\n14 % 2 %\\n\\n20 % $ 8 %\\n\\n28,021 12,865\\n\\n4 % 5 %\\n\\nEquipment Global Brand Divisions\\n\\n(2)\\n\\nTotal NIKE Brand Revenues\\n\\n$\\n\\n1,727 58\\n\\n48,763 $\\n\\n1,624 102 44,436\\n\\n6 % -43 % 10 %\\n\\n13 % -43 % 16 % $\\n\\n1,382 25 42,293\\n\\n18 % 308 % 5 %\\n\\nConverse Corporate\\n\\n(3)\\n\\n2,427 27\\n\\n2,346 (72)\\n\\n3 % —\\n\\n8 % —\\n\\n2,205 40\\n\\n6 % —\\n\\nTOTAL NIKE, INC. REVENUES\\n\\n$\\n\\n51,217 $\\n\\n46,710\\n\\n10 %\\n\\n16 % $\\n\\n44,538\\n\\n5 %\\n\\nSupplemental NIKE Brand Revenues Details: NIKE Brand Revenues by:\\n\\nSales to Wholesale Customers\\n\\n$\\n\\n27,397 $\\n\\n25,608\\n\\n7 %\\n\\n14 % $\\n\\n25,898\\n\\n1 %\\n\\nSales through NIKE Direct Global Brand Divisions\\n\\n(2)\\n\\n21,308 58\\n\\n18,726 102\\n\\n14 % -43 %\\n\\n20 % -43 %\\n\\n16,370 25\\n\\n14 % 308 %\\n\\nTOTAL NIKE BRAND REVENUES (1) NIKE Brand Revenues on a Wholesale Equivalent Basis :\\n\\n$\\n\\n48,763 $\\n\\n44,436\\n\\n10 %\\n\\n16 % $\\n\\n42,293\\n\\n5 %\\n\\nSales to Wholesale Customers Sales from our Wholesale Operations to NIKE Direct Operations\\n\\nTOTAL NIKE BRAND WHOLESALE EQUIVALENT REVENUES NIKE Brand Wholesale Equivalent Revenues by:\\n\\n(1),(4)\\n\\n$\\n\\n$\\n\\n27,397 $ 12,730\\n\\n40,127 $\\n\\n25,608 10,543\\n\\n36,151\\n\\n7 % 21 %\\n\\n11 %\\n\\n14 % $ 27 %\\n\\n18 % $\\n\\n25,898 9,872\\n\\n35,770\\n\\n1 % 7 % 1 %\\n\\nMen's Women's NIKE Kids'\\n\\n$\\n\\n20,733 $ 8,606 5,038\\n\\n18,797 8,273 4,874\\n\\n10 % 4 % 3 %\\n\\n17 % $ 11 % 10 %\\n\\n18,391 8,225 4,882\\n\\n2 % 1 % 0 %\\n\\nJordan Brand (5) Others\\n\\n6,589 (839)\\n\\n5,122 (915)\\n\\n29 % 8 %\\n\\n35 % -3 %\"),\n",
+       "  0.499011814594),\n",
+       " (Document(metadata={'source': 'resources/nke-10k-2023.pdf'}, page_content=\"(Dollars in millions, except per share data)\\n\\nRevenues Cost of sales\\n\\nGross profit Gross margin\\n\\nDemand creation expense Operating overhead expense\\n\\nTotal selling and administrative expense % of revenues\\n\\nInterest expense (income), net\\n\\nOther (income) expense, net Income before income taxes\\n\\nIncome tax expense Effective tax rate\\n\\nNET INCOME Diluted earnings per common share\\n\\n$\\n\\n$ $\\n\\nFISCAL 2023\\n\\n51,217 28,925\\n\\n22,292\\n\\n43.5 %\\n\\n4,060 12,317\\n\\n16,377\\n\\n32.0 % (6)\\n\\n(280) 6,201\\n\\n1,131\\n\\n18.2 %\\n\\n5,070 3.23\\n\\n$\\n\\n$ $\\n\\nFISCAL 2022\\n\\n46,710 25,231\\n\\n21,479\\n\\n46.0 %\\n\\n3,850 10,954\\n\\n14,804\\n\\n31.7 % 205\\n\\n(181) 6,651\\n\\n605 9.1 %\\n\\n6,046 3.75\\n\\n% CHANGE\\n\\n10 % $ 15 %\\n\\n4 %\\n\\n5 % 12 %\\n\\n11 %\\n\\n—\\n\\n— -7 %\\n\\n87 %\\n\\n16 % $ -14 % $\\n\\nFISCAL 2021\\n\\n% CHANGE\\n\\n44,538 24,576\\n\\n5 % 3 %\\n\\n19,962\\n\\n8 %\\n\\n44.8 %\\n\\n3,114 9,911\\n\\n24 % 11 %\\n\\n13,025\\n\\n14 %\\n\\n29.2 % 262\\n\\n—\\n\\n14 6,661\\n\\n— 0 %\\n\\n934 14.0 %\\n\\n35 %\\n\\n5,727 3.56\\n\\n6 % 5 %\\n\\n2023 FORM 10-K 31\\n\\nTable of Contents\\n\\nCONSOLIDATED OPERATING RESULTS REVENUES\\n\\n(Dollars in millions)\\n\\nFISCAL 2023\\n\\nFISCAL 2022\\n\\n% CHANGE\\n\\n% CHANGE EXCLUDING CURRENCY (1) CHANGES\\n\\nFISCAL 2021\\n\\n% CHANGE\\n\\nNIKE, Inc. Revenues:\\n\\nNIKE Brand Revenues by:\\n\\nFootwear Apparel\\n\\n$\\n\\n33,135 $ 13,843\\n\\n29,143 13,567\\n\\n14 % 2 %\\n\\n20 % $ 8 %\\n\\n28,021 12,865\\n\\n4 % 5 %\\n\\nEquipment Global Brand Divisions\\n\\n(2)\\n\\nTotal NIKE Brand Revenues\\n\\n$\\n\\n1,727 58\\n\\n48,763 $\\n\\n1,624 102 44,436\\n\\n6 % -43 % 10 %\\n\\n13 % -43 % 16 % $\\n\\n1,382 25 42,293\\n\\n18 % 308 % 5 %\\n\\nConverse Corporate\\n\\n(3)\\n\\n2,427 27\\n\\n2,346 (72)\\n\\n3 % —\\n\\n8 % —\\n\\n2,205 40\\n\\n6 % —\\n\\nTOTAL NIKE, INC. REVENUES\\n\\n$\\n\\n51,217 $\\n\\n46,710\\n\\n10 %\\n\\n16 % $\\n\\n44,538\\n\\n5 %\\n\\nSupplemental NIKE Brand Revenues Details: NIKE Brand Revenues by:\\n\\nSales to Wholesale Customers\\n\\n$\\n\\n27,397 $\\n\\n25,608\\n\\n7 %\\n\\n14 % $\\n\\n25,898\\n\\n1 %\\n\\nSales through NIKE Direct Global Brand Divisions\\n\\n(2)\\n\\n21,308 58\\n\\n18,726 102\\n\\n14 % -43 %\\n\\n20 % -43 %\\n\\n16,370 25\\n\\n14 % 308 %\\n\\nTOTAL NIKE BRAND REVENUES (1) NIKE Brand Revenues on a Wholesale Equivalent Basis :\\n\\n$\\n\\n48,763 $\\n\\n44,436\\n\\n10 %\\n\\n16 % $\\n\\n42,293\\n\\n5 %\\n\\nSales to Wholesale Customers Sales from our Wholesale Operations to NIKE Direct Operations\\n\\nTOTAL NIKE BRAND WHOLESALE EQUIVALENT REVENUES NIKE Brand Wholesale Equivalent Revenues by:\\n\\n(1),(4)\\n\\n$\\n\\n$\\n\\n27,397 $ 12,730\\n\\n40,127 $\\n\\n25,608 10,543\\n\\n36,151\\n\\n7 % 21 %\\n\\n11 %\\n\\n14 % $ 27 %\\n\\n18 % $\\n\\n25,898 9,872\\n\\n35,770\\n\\n1 % 7 % 1 %\\n\\nMen's Women's NIKE Kids'\\n\\n$\\n\\n20,733 $ 8,606 5,038\\n\\n18,797 8,273 4,874\\n\\n10 % 4 % 3 %\\n\\n17 % $ 11 % 10 %\\n\\n18,391 8,225 4,882\\n\\n2 % 1 % 0 %\\n\\nJordan Brand (5) Others\\n\\n6,589 (839)\\n\\n5,122 (915)\\n\\n29 % 8 %\\n\\n35 % -3 %\"),\n",
+       "  0.499011814594),\n",
+       " (Document(metadata={'source': 'resources/nke-10k-2023.pdf'}, page_content=\"(Dollars in millions, except per share data)\\n\\nRevenues Cost of sales\\n\\nGross profit Gross margin\\n\\nDemand creation expense Operating overhead expense\\n\\nTotal selling and administrative expense % of revenues\\n\\nInterest expense (income), net\\n\\nOther (income) expense, net Income before income taxes\\n\\nIncome tax expense Effective tax rate\\n\\nNET INCOME Diluted earnings per common share\\n\\n$\\n\\n$ $\\n\\nFISCAL 2023\\n\\n51,217 28,925\\n\\n22,292\\n\\n43.5 %\\n\\n4,060 12,317\\n\\n16,377\\n\\n32.0 % (6)\\n\\n(280) 6,201\\n\\n1,131\\n\\n18.2 %\\n\\n5,070 3.23\\n\\n$\\n\\n$ $\\n\\nFISCAL 2022\\n\\n46,710 25,231\\n\\n21,479\\n\\n46.0 %\\n\\n3,850 10,954\\n\\n14,804\\n\\n31.7 % 205\\n\\n(181) 6,651\\n\\n605 9.1 %\\n\\n6,046 3.75\\n\\n% CHANGE\\n\\n10 % $ 15 %\\n\\n4 %\\n\\n5 % 12 %\\n\\n11 %\\n\\n—\\n\\n— -7 %\\n\\n87 %\\n\\n16 % $ -14 % $\\n\\nFISCAL 2021\\n\\n% CHANGE\\n\\n44,538 24,576\\n\\n5 % 3 %\\n\\n19,962\\n\\n8 %\\n\\n44.8 %\\n\\n3,114 9,911\\n\\n24 % 11 %\\n\\n13,025\\n\\n14 %\\n\\n29.2 % 262\\n\\n—\\n\\n14 6,661\\n\\n— 0 %\\n\\n934 14.0 %\\n\\n35 %\\n\\n5,727 3.56\\n\\n6 % 5 %\\n\\n2023 FORM 10-K 31\\n\\nTable of Contents\\n\\nCONSOLIDATED OPERATING RESULTS REVENUES\\n\\n(Dollars in millions)\\n\\nFISCAL 2023\\n\\nFISCAL 2022\\n\\n% CHANGE\\n\\n% CHANGE EXCLUDING CURRENCY (1) CHANGES\\n\\nFISCAL 2021\\n\\n% CHANGE\\n\\nNIKE, Inc. Revenues:\\n\\nNIKE Brand Revenues by:\\n\\nFootwear Apparel\\n\\n$\\n\\n33,135 $ 13,843\\n\\n29,143 13,567\\n\\n14 % 2 %\\n\\n20 % $ 8 %\\n\\n28,021 12,865\\n\\n4 % 5 %\\n\\nEquipment Global Brand Divisions\\n\\n(2)\\n\\nTotal NIKE Brand Revenues\\n\\n$\\n\\n1,727 58\\n\\n48,763 $\\n\\n1,624 102 44,436\\n\\n6 % -43 % 10 %\\n\\n13 % -43 % 16 % $\\n\\n1,382 25 42,293\\n\\n18 % 308 % 5 %\\n\\nConverse Corporate\\n\\n(3)\\n\\n2,427 27\\n\\n2,346 (72)\\n\\n3 % —\\n\\n8 % —\\n\\n2,205 40\\n\\n6 % —\\n\\nTOTAL NIKE, INC. REVENUES\\n\\n$\\n\\n51,217 $\\n\\n46,710\\n\\n10 %\\n\\n16 % $\\n\\n44,538\\n\\n5 %\\n\\nSupplemental NIKE Brand Revenues Details: NIKE Brand Revenues by:\\n\\nSales to Wholesale Customers\\n\\n$\\n\\n27,397 $\\n\\n25,608\\n\\n7 %\\n\\n14 % $\\n\\n25,898\\n\\n1 %\\n\\nSales through NIKE Direct Global Brand Divisions\\n\\n(2)\\n\\n21,308 58\\n\\n18,726 102\\n\\n14 % -43 %\\n\\n20 % -43 %\\n\\n16,370 25\\n\\n14 % 308 %\\n\\nTOTAL NIKE BRAND REVENUES (1) NIKE Brand Revenues on a Wholesale Equivalent Basis :\\n\\n$\\n\\n48,763 $\\n\\n44,436\\n\\n10 %\\n\\n16 % $\\n\\n42,293\\n\\n5 %\\n\\nSales to Wholesale Customers Sales from our Wholesale Operations to NIKE Direct Operations\\n\\nTOTAL NIKE BRAND WHOLESALE EQUIVALENT REVENUES NIKE Brand Wholesale Equivalent Revenues by:\\n\\n(1),(4)\\n\\n$\\n\\n$\\n\\n27,397 $ 12,730\\n\\n40,127 $\\n\\n25,608 10,543\\n\\n36,151\\n\\n7 % 21 %\\n\\n11 %\\n\\n14 % $ 27 %\\n\\n18 % $\\n\\n25,898 9,872\\n\\n35,770\\n\\n1 % 7 % 1 %\\n\\nMen's Women's NIKE Kids'\\n\\n$\\n\\n20,733 $ 8,606 5,038\\n\\n18,797 8,273 4,874\\n\\n10 % 4 % 3 %\\n\\n17 % $ 11 % 10 %\\n\\n18,391 8,225 4,882\\n\\n2 % 1 % 0 %\\n\\nJordan Brand (5) Others\\n\\n6,589 (839)\\n\\n5,122 (915)\\n\\n29 % 8 %\\n\\n35 % -3 %\"),\n",
+       "  0.499011814594),\n",
+       " (Document(metadata={'source': 'resources/nke-10k-2023.pdf'}, page_content=\"Tax (expense) benefit Gain (loss) net of tax\\n\\n5 (14)\\n\\n(9) 22\\n\\nTotal net gain (loss) reclassified for the period\\n\\n$\\n\\n463 $\\n\\n30\\n\\n2023 FORM 10-K 82\\n\\nTable of Contents\\n\\nNOTE 14 — REVENUES\\n\\nDISAGGREGATION OF REVENUES The following tables present the Company's Revenues disaggregated by reportable operating segment, major product line and distribution channel:\\n\\n(Dollars in millions)\\n\\nNORTH AMERICA\\n\\nEUROPE, MIDDLE EAST & AFRICA\\n\\nGREATER CHINA\\n\\nYEAR ENDED MAY 31, 2023 ASIA PACIFIC & LATIN (1)\\n\\nGLOBAL BRAND DIVISIONS\\n\\nTOTAL NIKE\\n\\nAMERICA\\n\\nBRAND CONVERSE CORPORATE\\n\\nTOTAL NIKE, INC.\\n\\nRevenues by: Footwear\\n\\n$\\n\\n14,897 $\\n\\n8,260 $\\n\\n5,435 $\\n\\n4,543 $\\n\\n— $\\n\\n33,135 $\\n\\n2,155 $\\n\\n— $\\n\\n35,290\\n\\nApparel Equipment Other\\n\\n5,947 764 —\\n\\n4,566 592 —\\n\\n1,666 147 —\\n\\n1,664 224 —\\n\\n— — 58\\n\\n13,843 1,727 58\\n\\n90 28 154\\n\\n— — 27\\n\\n13,933 1,755 239\\n\\nTOTAL REVENUES\\n\\n$\\n\\n21,608 $\\n\\n13,418 $\\n\\n7,248 $\\n\\n6,431 $\\n\\n58 $\\n\\n48,763 $\\n\\n2,427 $\\n\\n27 $\\n\\n51,217\\n\\nRevenues by:\\n\\nSales to Wholesale Customers Sales through Direct to Consumer\\n\\n$\\n\\n11,273 $ 10,335\\n\\n8,522 $ 4,896\\n\\n3,866 $ 3,382\\n\\n3,736 $ 2,695\\n\\n— $ —\\n\\n27,397 $ 21,308\\n\\n1,299 $ 974\\n\\n— $ —\\n\\n28,696 22,282\\n\\nOther\\n\\nTOTAL REVENUES\\n\\n$\\n\\n—\\n\\n21,608 $\\n\\n—\\n\\n13,418 $\\n\\n— 7,248 $\\n\\n— 6,431 $\\n\\n58 58 $\\n\\n58\\n\\n48,763 $\\n\\n154 2,427 $\\n\\n27 27 $\\n\\n239 51,217\\n\\n(1) Refer to Note 18 — Acquisitions and Divestitures for additional information on the transition of the Company's NIKE Brand businesses in its CASA territory to third-party distributors.\\n\\nYEAR ENDED MAY 31, 2022\\n\\n(Dollars in millions)\\n\\nNORTH AMERICA\\n\\nEUROPE, MIDDLE EAST & AFRICA\\n\\nGREATER CHINA\\n\\nASIA PACIFIC & LATIN AMERICA\\n\\nGLOBAL BRAND DIVISIONS\\n\\nTOTAL NIKE\\n\\nBRAND CONVERSE CORPORATE\\n\\nTOTAL NIKE, INC.\\n\\nRevenues by: Footwear Apparel\\n\\n$\\n\\n12,228 $ 5,492\\n\\n7,388 $ 4,527\\n\\n5,416 $ 1,938\\n\\n4,111 $ 1,610\\n\\n— $ —\\n\\n29,143 $ 13,567\\n\\n2,094 $ 103\\n\\n— $ —\\n\\n31,237 13,670\\n\\nEquipment Other\\n\\n633 —\\n\\n564 —\\n\\n193 —\\n\\n234 —\\n\\n— 102\\n\\n1,624 102\\n\\n26 123\\n\\n— (72)\\n\\n1,650 153\\n\\nTOTAL REVENUES Revenues by:\\n\\n$\\n\\n18,353 $\\n\\n12,479 $\\n\\n7,547 $\\n\\n5,955 $\\n\\n102 $\\n\\n44,436 $\\n\\n2,346 $\\n\\n(72) $\\n\\n46,710\\n\\nSales to Wholesale Customers Sales through Direct to Consumer Other\\n\\n$\\n\\n9,621 $ 8,732 —\\n\\n8,377 $ 4,102 —\\n\\n4,081 $ 3,466 —\\n\\n3,529 $ 2,426 —\\n\\n— $ — 102\\n\\n25,608 $ 18,726 102\\n\\n1,292 $ 931 123\\n\\n— $ — (72)\\n\\n26,900 19,657 153\\n\\nTOTAL REVENUES\\n\\n$\\n\\n18,353 $\\n\\n12,479 $\\n\\n7,547 $\\n\\n5,955 $\\n\\n102 $\\n\\n44,436 $\\n\\n2,346 $\\n\\n(72) $\\n\\n46,710\\n\\n2023 FORM 10-K 83\\n\\nTable of Contents\\n\\nYEAR ENDED MAY 31, 2021\\n\\n(Dollars in millions)\\n\\nNORTH AMERICA\\n\\nEUROPE, MIDDLE EAST & AFRICA\\n\\nGREATER CHINA\"),\n",
+       "  0.529603242874)]"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# basic \"top 4\" vector search on a given query\n",
+    "rds.similarity_search_with_score(query=\"Profit margins\", k=4)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "od6Wqmya1vmy",
+    "outputId": "5dbac581-4a07-45b0-d630-995342e91dc7"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[(Document(metadata={'source': 'resources/nke-10k-2023.pdf'}, page_content=\"(Dollars in millions, except per share data)\\n\\nRevenues Cost of sales\\n\\nGross profit Gross margin\\n\\nDemand creation expense Operating overhead expense\\n\\nTotal selling and administrative expense % of revenues\\n\\nInterest expense (income), net\\n\\nOther (income) expense, net Income before income taxes\\n\\nIncome tax expense Effective tax rate\\n\\nNET INCOME Diluted earnings per common share\\n\\n$\\n\\n$ $\\n\\nFISCAL 2023\\n\\n51,217 28,925\\n\\n22,292\\n\\n43.5 %\\n\\n4,060 12,317\\n\\n16,377\\n\\n32.0 % (6)\\n\\n(280) 6,201\\n\\n1,131\\n\\n18.2 %\\n\\n5,070 3.23\\n\\n$\\n\\n$ $\\n\\nFISCAL 2022\\n\\n46,710 25,231\\n\\n21,479\\n\\n46.0 %\\n\\n3,850 10,954\\n\\n14,804\\n\\n31.7 % 205\\n\\n(181) 6,651\\n\\n605 9.1 %\\n\\n6,046 3.75\\n\\n% CHANGE\\n\\n10 % $ 15 %\\n\\n4 %\\n\\n5 % 12 %\\n\\n11 %\\n\\n—\\n\\n— -7 %\\n\\n87 %\\n\\n16 % $ -14 % $\\n\\nFISCAL 2021\\n\\n% CHANGE\\n\\n44,538 24,576\\n\\n5 % 3 %\\n\\n19,962\\n\\n8 %\\n\\n44.8 %\\n\\n3,114 9,911\\n\\n24 % 11 %\\n\\n13,025\\n\\n14 %\\n\\n29.2 % 262\\n\\n—\\n\\n14 6,661\\n\\n— 0 %\\n\\n934 14.0 %\\n\\n35 %\\n\\n5,727 3.56\\n\\n6 % 5 %\\n\\n2023 FORM 10-K 31\\n\\nTable of Contents\\n\\nCONSOLIDATED OPERATING RESULTS REVENUES\\n\\n(Dollars in millions)\\n\\nFISCAL 2023\\n\\nFISCAL 2022\\n\\n% CHANGE\\n\\n% CHANGE EXCLUDING CURRENCY (1) CHANGES\\n\\nFISCAL 2021\\n\\n% CHANGE\\n\\nNIKE, Inc. Revenues:\\n\\nNIKE Brand Revenues by:\\n\\nFootwear Apparel\\n\\n$\\n\\n33,135 $ 13,843\\n\\n29,143 13,567\\n\\n14 % 2 %\\n\\n20 % $ 8 %\\n\\n28,021 12,865\\n\\n4 % 5 %\\n\\nEquipment Global Brand Divisions\\n\\n(2)\\n\\nTotal NIKE Brand Revenues\\n\\n$\\n\\n1,727 58\\n\\n48,763 $\\n\\n1,624 102 44,436\\n\\n6 % -43 % 10 %\\n\\n13 % -43 % 16 % $\\n\\n1,382 25 42,293\\n\\n18 % 308 % 5 %\\n\\nConverse Corporate\\n\\n(3)\\n\\n2,427 27\\n\\n2,346 (72)\\n\\n3 % —\\n\\n8 % —\\n\\n2,205 40\\n\\n6 % —\\n\\nTOTAL NIKE, INC. REVENUES\\n\\n$\\n\\n51,217 $\\n\\n46,710\\n\\n10 %\\n\\n16 % $\\n\\n44,538\\n\\n5 %\\n\\nSupplemental NIKE Brand Revenues Details: NIKE Brand Revenues by:\\n\\nSales to Wholesale Customers\\n\\n$\\n\\n27,397 $\\n\\n25,608\\n\\n7 %\\n\\n14 % $\\n\\n25,898\\n\\n1 %\\n\\nSales through NIKE Direct Global Brand Divisions\\n\\n(2)\\n\\n21,308 58\\n\\n18,726 102\\n\\n14 % -43 %\\n\\n20 % -43 %\\n\\n16,370 25\\n\\n14 % 308 %\\n\\nTOTAL NIKE BRAND REVENUES (1) NIKE Brand Revenues on a Wholesale Equivalent Basis :\\n\\n$\\n\\n48,763 $\\n\\n44,436\\n\\n10 %\\n\\n16 % $\\n\\n42,293\\n\\n5 %\\n\\nSales to Wholesale Customers Sales from our Wholesale Operations to NIKE Direct Operations\\n\\nTOTAL NIKE BRAND WHOLESALE EQUIVALENT REVENUES NIKE Brand Wholesale Equivalent Revenues by:\\n\\n(1),(4)\\n\\n$\\n\\n$\\n\\n27,397 $ 12,730\\n\\n40,127 $\\n\\n25,608 10,543\\n\\n36,151\\n\\n7 % 21 %\\n\\n11 %\\n\\n14 % $ 27 %\\n\\n18 % $\\n\\n25,898 9,872\\n\\n35,770\\n\\n1 % 7 % 1 %\\n\\nMen's Women's NIKE Kids'\\n\\n$\\n\\n20,733 $ 8,606 5,038\\n\\n18,797 8,273 4,874\\n\\n10 % 4 % 3 %\\n\\n17 % $ 11 % 10 %\\n\\n18,391 8,225 4,882\\n\\n2 % 1 % 0 %\\n\\nJordan Brand (5) Others\\n\\n6,589 (839)\\n\\n5,122 (915)\\n\\n29 % 8 %\\n\\n35 % -3 %\"),\n",
+       "  0.499011814594),\n",
+       " (Document(metadata={'source': 'resources/nke-10k-2023.pdf'}, page_content=\"(Dollars in millions, except per share data)\\n\\nRevenues Cost of sales\\n\\nGross profit Gross margin\\n\\nDemand creation expense Operating overhead expense\\n\\nTotal selling and administrative expense % of revenues\\n\\nInterest expense (income), net\\n\\nOther (income) expense, net Income before income taxes\\n\\nIncome tax expense Effective tax rate\\n\\nNET INCOME Diluted earnings per common share\\n\\n$\\n\\n$ $\\n\\nFISCAL 2023\\n\\n51,217 28,925\\n\\n22,292\\n\\n43.5 %\\n\\n4,060 12,317\\n\\n16,377\\n\\n32.0 % (6)\\n\\n(280) 6,201\\n\\n1,131\\n\\n18.2 %\\n\\n5,070 3.23\\n\\n$\\n\\n$ $\\n\\nFISCAL 2022\\n\\n46,710 25,231\\n\\n21,479\\n\\n46.0 %\\n\\n3,850 10,954\\n\\n14,804\\n\\n31.7 % 205\\n\\n(181) 6,651\\n\\n605 9.1 %\\n\\n6,046 3.75\\n\\n% CHANGE\\n\\n10 % $ 15 %\\n\\n4 %\\n\\n5 % 12 %\\n\\n11 %\\n\\n—\\n\\n— -7 %\\n\\n87 %\\n\\n16 % $ -14 % $\\n\\nFISCAL 2021\\n\\n% CHANGE\\n\\n44,538 24,576\\n\\n5 % 3 %\\n\\n19,962\\n\\n8 %\\n\\n44.8 %\\n\\n3,114 9,911\\n\\n24 % 11 %\\n\\n13,025\\n\\n14 %\\n\\n29.2 % 262\\n\\n—\\n\\n14 6,661\\n\\n— 0 %\\n\\n934 14.0 %\\n\\n35 %\\n\\n5,727 3.56\\n\\n6 % 5 %\\n\\n2023 FORM 10-K 31\\n\\nTable of Contents\\n\\nCONSOLIDATED OPERATING RESULTS REVENUES\\n\\n(Dollars in millions)\\n\\nFISCAL 2023\\n\\nFISCAL 2022\\n\\n% CHANGE\\n\\n% CHANGE EXCLUDING CURRENCY (1) CHANGES\\n\\nFISCAL 2021\\n\\n% CHANGE\\n\\nNIKE, Inc. Revenues:\\n\\nNIKE Brand Revenues by:\\n\\nFootwear Apparel\\n\\n$\\n\\n33,135 $ 13,843\\n\\n29,143 13,567\\n\\n14 % 2 %\\n\\n20 % $ 8 %\\n\\n28,021 12,865\\n\\n4 % 5 %\\n\\nEquipment Global Brand Divisions\\n\\n(2)\\n\\nTotal NIKE Brand Revenues\\n\\n$\\n\\n1,727 58\\n\\n48,763 $\\n\\n1,624 102 44,436\\n\\n6 % -43 % 10 %\\n\\n13 % -43 % 16 % $\\n\\n1,382 25 42,293\\n\\n18 % 308 % 5 %\\n\\nConverse Corporate\\n\\n(3)\\n\\n2,427 27\\n\\n2,346 (72)\\n\\n3 % —\\n\\n8 % —\\n\\n2,205 40\\n\\n6 % —\\n\\nTOTAL NIKE, INC. REVENUES\\n\\n$\\n\\n51,217 $\\n\\n46,710\\n\\n10 %\\n\\n16 % $\\n\\n44,538\\n\\n5 %\\n\\nSupplemental NIKE Brand Revenues Details: NIKE Brand Revenues by:\\n\\nSales to Wholesale Customers\\n\\n$\\n\\n27,397 $\\n\\n25,608\\n\\n7 %\\n\\n14 % $\\n\\n25,898\\n\\n1 %\\n\\nSales through NIKE Direct Global Brand Divisions\\n\\n(2)\\n\\n21,308 58\\n\\n18,726 102\\n\\n14 % -43 %\\n\\n20 % -43 %\\n\\n16,370 25\\n\\n14 % 308 %\\n\\nTOTAL NIKE BRAND REVENUES (1) NIKE Brand Revenues on a Wholesale Equivalent Basis :\\n\\n$\\n\\n48,763 $\\n\\n44,436\\n\\n10 %\\n\\n16 % $\\n\\n42,293\\n\\n5 %\\n\\nSales to Wholesale Customers Sales from our Wholesale Operations to NIKE Direct Operations\\n\\nTOTAL NIKE BRAND WHOLESALE EQUIVALENT REVENUES NIKE Brand Wholesale Equivalent Revenues by:\\n\\n(1),(4)\\n\\n$\\n\\n$\\n\\n27,397 $ 12,730\\n\\n40,127 $\\n\\n25,608 10,543\\n\\n36,151\\n\\n7 % 21 %\\n\\n11 %\\n\\n14 % $ 27 %\\n\\n18 % $\\n\\n25,898 9,872\\n\\n35,770\\n\\n1 % 7 % 1 %\\n\\nMen's Women's NIKE Kids'\\n\\n$\\n\\n20,733 $ 8,606 5,038\\n\\n18,797 8,273 4,874\\n\\n10 % 4 % 3 %\\n\\n17 % $ 11 % 10 %\\n\\n18,391 8,225 4,882\\n\\n2 % 1 % 0 %\\n\\nJordan Brand (5) Others\\n\\n6,589 (839)\\n\\n5,122 (915)\\n\\n29 % 8 %\\n\\n35 % -3 %\"),\n",
+       "  0.499011814594),\n",
+       " (Document(metadata={'source': 'resources/nke-10k-2023.pdf'}, page_content=\"(Dollars in millions, except per share data)\\n\\nRevenues Cost of sales\\n\\nGross profit Gross margin\\n\\nDemand creation expense Operating overhead expense\\n\\nTotal selling and administrative expense % of revenues\\n\\nInterest expense (income), net\\n\\nOther (income) expense, net Income before income taxes\\n\\nIncome tax expense Effective tax rate\\n\\nNET INCOME Diluted earnings per common share\\n\\n$\\n\\n$ $\\n\\nFISCAL 2023\\n\\n51,217 28,925\\n\\n22,292\\n\\n43.5 %\\n\\n4,060 12,317\\n\\n16,377\\n\\n32.0 % (6)\\n\\n(280) 6,201\\n\\n1,131\\n\\n18.2 %\\n\\n5,070 3.23\\n\\n$\\n\\n$ $\\n\\nFISCAL 2022\\n\\n46,710 25,231\\n\\n21,479\\n\\n46.0 %\\n\\n3,850 10,954\\n\\n14,804\\n\\n31.7 % 205\\n\\n(181) 6,651\\n\\n605 9.1 %\\n\\n6,046 3.75\\n\\n% CHANGE\\n\\n10 % $ 15 %\\n\\n4 %\\n\\n5 % 12 %\\n\\n11 %\\n\\n—\\n\\n— -7 %\\n\\n87 %\\n\\n16 % $ -14 % $\\n\\nFISCAL 2021\\n\\n% CHANGE\\n\\n44,538 24,576\\n\\n5 % 3 %\\n\\n19,962\\n\\n8 %\\n\\n44.8 %\\n\\n3,114 9,911\\n\\n24 % 11 %\\n\\n13,025\\n\\n14 %\\n\\n29.2 % 262\\n\\n—\\n\\n14 6,661\\n\\n— 0 %\\n\\n934 14.0 %\\n\\n35 %\\n\\n5,727 3.56\\n\\n6 % 5 %\\n\\n2023 FORM 10-K 31\\n\\nTable of Contents\\n\\nCONSOLIDATED OPERATING RESULTS REVENUES\\n\\n(Dollars in millions)\\n\\nFISCAL 2023\\n\\nFISCAL 2022\\n\\n% CHANGE\\n\\n% CHANGE EXCLUDING CURRENCY (1) CHANGES\\n\\nFISCAL 2021\\n\\n% CHANGE\\n\\nNIKE, Inc. Revenues:\\n\\nNIKE Brand Revenues by:\\n\\nFootwear Apparel\\n\\n$\\n\\n33,135 $ 13,843\\n\\n29,143 13,567\\n\\n14 % 2 %\\n\\n20 % $ 8 %\\n\\n28,021 12,865\\n\\n4 % 5 %\\n\\nEquipment Global Brand Divisions\\n\\n(2)\\n\\nTotal NIKE Brand Revenues\\n\\n$\\n\\n1,727 58\\n\\n48,763 $\\n\\n1,624 102 44,436\\n\\n6 % -43 % 10 %\\n\\n13 % -43 % 16 % $\\n\\n1,382 25 42,293\\n\\n18 % 308 % 5 %\\n\\nConverse Corporate\\n\\n(3)\\n\\n2,427 27\\n\\n2,346 (72)\\n\\n3 % —\\n\\n8 % —\\n\\n2,205 40\\n\\n6 % —\\n\\nTOTAL NIKE, INC. REVENUES\\n\\n$\\n\\n51,217 $\\n\\n46,710\\n\\n10 %\\n\\n16 % $\\n\\n44,538\\n\\n5 %\\n\\nSupplemental NIKE Brand Revenues Details: NIKE Brand Revenues by:\\n\\nSales to Wholesale Customers\\n\\n$\\n\\n27,397 $\\n\\n25,608\\n\\n7 %\\n\\n14 % $\\n\\n25,898\\n\\n1 %\\n\\nSales through NIKE Direct Global Brand Divisions\\n\\n(2)\\n\\n21,308 58\\n\\n18,726 102\\n\\n14 % -43 %\\n\\n20 % -43 %\\n\\n16,370 25\\n\\n14 % 308 %\\n\\nTOTAL NIKE BRAND REVENUES (1) NIKE Brand Revenues on a Wholesale Equivalent Basis :\\n\\n$\\n\\n48,763 $\\n\\n44,436\\n\\n10 %\\n\\n16 % $\\n\\n42,293\\n\\n5 %\\n\\nSales to Wholesale Customers Sales from our Wholesale Operations to NIKE Direct Operations\\n\\nTOTAL NIKE BRAND WHOLESALE EQUIVALENT REVENUES NIKE Brand Wholesale Equivalent Revenues by:\\n\\n(1),(4)\\n\\n$\\n\\n$\\n\\n27,397 $ 12,730\\n\\n40,127 $\\n\\n25,608 10,543\\n\\n36,151\\n\\n7 % 21 %\\n\\n11 %\\n\\n14 % $ 27 %\\n\\n18 % $\\n\\n25,898 9,872\\n\\n35,770\\n\\n1 % 7 % 1 %\\n\\nMen's Women's NIKE Kids'\\n\\n$\\n\\n20,733 $ 8,606 5,038\\n\\n18,797 8,273 4,874\\n\\n10 % 4 % 3 %\\n\\n17 % $ 11 % 10 %\\n\\n18,391 8,225 4,882\\n\\n2 % 1 % 0 %\\n\\nJordan Brand (5) Others\\n\\n6,589 (839)\\n\\n5,122 (915)\\n\\n29 % 8 %\\n\\n35 % -3 %\"),\n",
+       "  0.499011814594),\n",
+       " (Document(metadata={'source': 'resources/nke-10k-2023.pdf'}, page_content='From time to time, we may invest in technology, business infrastructure, new businesses or capabilities, product offering and manufacturing innovation and expansion of existing businesses, such as our NIKE Direct operations, which require substantial cash investments and management attention. We believe cost-effective investments are essential to business growth and profitability; however, significant investments are subject to typical risks and uncertainties inherent in developing a new business or expanding an existing business. The failure of any significant investment to provide expected returns or profitability could have a material adverse effect on our financial results and divert management attention from more profitable business operations. See also \"Our NIKE Direct operations have required and will continue to require a substantial investment and commitment of resources and are subject to numerous risks and uncertainties.\"\\n\\nThe sale of a large number of shares of common stock by our principal shareholder could depress the market price of our common stock.\\n\\nAs of June 30, 2023, Swoosh, LLC beneficially owned approximately 77% of our Class A Common Stock. If, on June 30, 2023, all of these shares were converted into Class B Common Stock, Swoosh, LLC\\'s commensurate ownership percentage of our Class B Common Stock would be approximately 16%. The shares are available for resale, subject to the requirements of the U.S. securities laws and the terms of the limited liability company agreement governing Swoosh, LLC. The sale or prospect of a sale of a substantial number of these shares could have an adverse effect on the market price of our common stock. Swoosh, LLC was formed by Philip H. Knight, our Chairman Emeritus, to hold the majority of his shares of Class A Common Stock. Mr. Knight does not have voting rights with respect to Swoosh, LLC, although Travis Knight, his son and a NIKE director, has a significant role in the management of the Class A Common Stock owned by Swoosh, LLC.\\n\\nChanges in our credit ratings or macroeconomic conditions may affect our liquidity, increasing borrowing costs and limiting our financing options.'),\n",
+       "  0.604557394981)]"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# vector search with metadata filtering\n",
+    "f = Text(\"text\") % \"profit\"\n",
+    "rds.similarity_search_with_score(query=\"Profit margins\", k=4, filter=f)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "DT9sPHw51vmy",
+    "outputId": "7d2b8969-91b8-4ff7-81ba-9d0cb6280edc"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[(Document(metadata={'source': 'resources/nke-10k-2023.pdf'}, page_content='As discussed in Note 15 — Operating Segments and Related Information in the accompanying Notes to the Consolidated Financial Statements, our operating segments are evidence of the structure of the Company\\'s internal organization. The NIKE Brand segments are defined by geographic regions for operations participating in NIKE Brand sales activity.\\n\\nThe breakdown of Revenues is as follows:\\n\\n(Dollars in millions)\\n\\nFISCAL 2023 FISCAL 2022\\n\\n% CHANGE\\n\\n% CHANGE EXCLUDING CURRENCY (1) CHANGES FISCAL 2021\\n\\n% CHANGE\\n\\nNorth America Europe, Middle East & Africa Greater China\\n\\n$\\n\\n21,608 $ 13,418 7,248\\n\\n18,353 12,479 7,547\\n\\n18 % 8 % -4 %\\n\\n18 % $ 21 % 4 %\\n\\n17,179 11,456 8,290\\n\\n7 % 9 % -9 %\\n\\nAsia Pacific & Latin America Global Brand Divisions\\n\\n(3)\\n\\n(2)\\n\\n6,431 58\\n\\n5,955 102\\n\\n8 % -43 %\\n\\n17 % -43 %\\n\\n5,343 25\\n\\n11 % 308 %\\n\\nTOTAL NIKE BRAND Converse\\n\\n$\\n\\n48,763 $ 2,427\\n\\n44,436 2,346\\n\\n10 % 3 %\\n\\n16 % $ 8 %\\n\\n42,293 2,205\\n\\n5 % 6 %\\n\\n(4)\\n\\nCorporate TOTAL NIKE, INC. REVENUES\\n\\n$\\n\\n27\\n\\n51,217 $\\n\\n(72) 46,710\\n\\n— 10 %\\n\\n— 16 % $\\n\\n40 44,538\\n\\n— 5 %\\n\\n(1) The percent change excluding currency changes represents a non-GAAP financial measure. For further information, see \"Use of Non-GAAP Financial Measures\".\\n\\n(2) For additional information on the transition of our NIKE Brand businesses within our CASA territory to a third-party distributor, see Note 18 — Acquisitions and Divestitures of the Notes to Consolidated\\n\\nFinancial Statements contained in Item 8 of this Annual Report.\\n\\n(3) Global Brand Divisions revenues include NIKE Brand licensing and other miscellaneous revenues that are not part of a geographic operating segment.\\n\\n(4) Corporate revenues primarily consist of foreign currency hedge gains and losses related to revenues generated by entities within the NIKE Brand geographic operating segments and Converse, but\\n\\nmanaged through our central foreign exchange risk management program.\\n\\nThe primary financial measure used by the Company to evaluate performance is Earnings Before Interest and Taxes (\"EBIT\"). As discussed in Note 15 — Operating Segments and Related Information in the accompanying Notes to the Consolidated Financial Statements, certain corporate costs are not included in EBIT.\\n\\nThe breakdown of EBIT is as follows:\\n\\n(Dollars in millions)\\n\\nFISCAL 2023\\n\\nFISCAL 2022\\n\\n% CHANGE\\n\\nFISCAL 2021\\n\\nNorth America Europe, Middle East & Africa Greater China\\n\\n$\\n\\n5,454 3,531 2,283\\n\\n$\\n\\n5,114 3,293 2,365\\n\\n7 % $ 7 % -3 %\\n\\n5,089 2,435 3,243\\n\\nAsia Pacific & Latin America Global Brand Divisions (1)'),\n",
+       "  0.233286499977),\n",
+       " (Document(metadata={'source': 'resources/nke-10k-2023.pdf'}, page_content='As discussed in Note 15 — Operating Segments and Related Information in the accompanying Notes to the Consolidated Financial Statements, our operating segments are evidence of the structure of the Company\\'s internal organization. The NIKE Brand segments are defined by geographic regions for operations participating in NIKE Brand sales activity.\\n\\nThe breakdown of Revenues is as follows:\\n\\n(Dollars in millions)\\n\\nFISCAL 2023 FISCAL 2022\\n\\n% CHANGE\\n\\n% CHANGE EXCLUDING CURRENCY (1) CHANGES FISCAL 2021\\n\\n% CHANGE\\n\\nNorth America Europe, Middle East & Africa Greater China\\n\\n$\\n\\n21,608 $ 13,418 7,248\\n\\n18,353 12,479 7,547\\n\\n18 % 8 % -4 %\\n\\n18 % $ 21 % 4 %\\n\\n17,179 11,456 8,290\\n\\n7 % 9 % -9 %\\n\\nAsia Pacific & Latin America Global Brand Divisions\\n\\n(3)\\n\\n(2)\\n\\n6,431 58\\n\\n5,955 102\\n\\n8 % -43 %\\n\\n17 % -43 %\\n\\n5,343 25\\n\\n11 % 308 %\\n\\nTOTAL NIKE BRAND Converse\\n\\n$\\n\\n48,763 $ 2,427\\n\\n44,436 2,346\\n\\n10 % 3 %\\n\\n16 % $ 8 %\\n\\n42,293 2,205\\n\\n5 % 6 %\\n\\n(4)\\n\\nCorporate TOTAL NIKE, INC. REVENUES\\n\\n$\\n\\n27\\n\\n51,217 $\\n\\n(72) 46,710\\n\\n— 10 %\\n\\n— 16 % $\\n\\n40 44,538\\n\\n— 5 %\\n\\n(1) The percent change excluding currency changes represents a non-GAAP financial measure. For further information, see \"Use of Non-GAAP Financial Measures\".\\n\\n(2) For additional information on the transition of our NIKE Brand businesses within our CASA territory to a third-party distributor, see Note 18 — Acquisitions and Divestitures of the Notes to Consolidated\\n\\nFinancial Statements contained in Item 8 of this Annual Report.\\n\\n(3) Global Brand Divisions revenues include NIKE Brand licensing and other miscellaneous revenues that are not part of a geographic operating segment.\\n\\n(4) Corporate revenues primarily consist of foreign currency hedge gains and losses related to revenues generated by entities within the NIKE Brand geographic operating segments and Converse, but\\n\\nmanaged through our central foreign exchange risk management program.\\n\\nThe primary financial measure used by the Company to evaluate performance is Earnings Before Interest and Taxes (\"EBIT\"). As discussed in Note 15 — Operating Segments and Related Information in the accompanying Notes to the Consolidated Financial Statements, certain corporate costs are not included in EBIT.\\n\\nThe breakdown of EBIT is as follows:\\n\\n(Dollars in millions)\\n\\nFISCAL 2023\\n\\nFISCAL 2022\\n\\n% CHANGE\\n\\nFISCAL 2021\\n\\nNorth America Europe, Middle East & Africa Greater China\\n\\n$\\n\\n5,454 3,531 2,283\\n\\n$\\n\\n5,114 3,293 2,365\\n\\n7 % $ 7 % -3 %\\n\\n5,089 2,435 3,243\\n\\nAsia Pacific & Latin America Global Brand Divisions (1)'),\n",
+       "  0.233286499977),\n",
+       " (Document(metadata={'source': 'resources/nke-10k-2023.pdf'}, page_content='As discussed in Note 15 — Operating Segments and Related Information in the accompanying Notes to the Consolidated Financial Statements, our operating segments are evidence of the structure of the Company\\'s internal organization. The NIKE Brand segments are defined by geographic regions for operations participating in NIKE Brand sales activity.\\n\\nThe breakdown of Revenues is as follows:\\n\\n(Dollars in millions)\\n\\nFISCAL 2023 FISCAL 2022\\n\\n% CHANGE\\n\\n% CHANGE EXCLUDING CURRENCY (1) CHANGES FISCAL 2021\\n\\n% CHANGE\\n\\nNorth America Europe, Middle East & Africa Greater China\\n\\n$\\n\\n21,608 $ 13,418 7,248\\n\\n18,353 12,479 7,547\\n\\n18 % 8 % -4 %\\n\\n18 % $ 21 % 4 %\\n\\n17,179 11,456 8,290\\n\\n7 % 9 % -9 %\\n\\nAsia Pacific & Latin America Global Brand Divisions\\n\\n(3)\\n\\n(2)\\n\\n6,431 58\\n\\n5,955 102\\n\\n8 % -43 %\\n\\n17 % -43 %\\n\\n5,343 25\\n\\n11 % 308 %\\n\\nTOTAL NIKE BRAND Converse\\n\\n$\\n\\n48,763 $ 2,427\\n\\n44,436 2,346\\n\\n10 % 3 %\\n\\n16 % $ 8 %\\n\\n42,293 2,205\\n\\n5 % 6 %\\n\\n(4)\\n\\nCorporate TOTAL NIKE, INC. REVENUES\\n\\n$\\n\\n27\\n\\n51,217 $\\n\\n(72) 46,710\\n\\n— 10 %\\n\\n— 16 % $\\n\\n40 44,538\\n\\n— 5 %\\n\\n(1) The percent change excluding currency changes represents a non-GAAP financial measure. For further information, see \"Use of Non-GAAP Financial Measures\".\\n\\n(2) For additional information on the transition of our NIKE Brand businesses within our CASA territory to a third-party distributor, see Note 18 — Acquisitions and Divestitures of the Notes to Consolidated\\n\\nFinancial Statements contained in Item 8 of this Annual Report.\\n\\n(3) Global Brand Divisions revenues include NIKE Brand licensing and other miscellaneous revenues that are not part of a geographic operating segment.\\n\\n(4) Corporate revenues primarily consist of foreign currency hedge gains and losses related to revenues generated by entities within the NIKE Brand geographic operating segments and Converse, but\\n\\nmanaged through our central foreign exchange risk management program.\\n\\nThe primary financial measure used by the Company to evaluate performance is Earnings Before Interest and Taxes (\"EBIT\"). As discussed in Note 15 — Operating Segments and Related Information in the accompanying Notes to the Consolidated Financial Statements, certain corporate costs are not included in EBIT.\\n\\nThe breakdown of EBIT is as follows:\\n\\n(Dollars in millions)\\n\\nFISCAL 2023\\n\\nFISCAL 2022\\n\\n% CHANGE\\n\\nFISCAL 2021\\n\\nNorth America Europe, Middle East & Africa Greater China\\n\\n$\\n\\n5,454 3,531 2,283\\n\\n$\\n\\n5,114 3,293 2,365\\n\\n7 % $ 7 % -3 %\\n\\n5,089 2,435 3,243\\n\\nAsia Pacific & Latin America Global Brand Divisions (1)'),\n",
+       "  0.233286499977),\n",
+       " (Document(metadata={'source': 'resources/nke-10k-2023.pdf'}, page_content=\"Tax (expense) benefit Gain (loss) net of tax\\n\\n5 (14)\\n\\n(9) 22\\n\\nTotal net gain (loss) reclassified for the period\\n\\n$\\n\\n463 $\\n\\n30\\n\\n2023 FORM 10-K 82\\n\\nTable of Contents\\n\\nNOTE 14 — REVENUES\\n\\nDISAGGREGATION OF REVENUES The following tables present the Company's Revenues disaggregated by reportable operating segment, major product line and distribution channel:\\n\\n(Dollars in millions)\\n\\nNORTH AMERICA\\n\\nEUROPE, MIDDLE EAST & AFRICA\\n\\nGREATER CHINA\\n\\nYEAR ENDED MAY 31, 2023 ASIA PACIFIC & LATIN (1)\\n\\nGLOBAL BRAND DIVISIONS\\n\\nTOTAL NIKE\\n\\nAMERICA\\n\\nBRAND CONVERSE CORPORATE\\n\\nTOTAL NIKE, INC.\\n\\nRevenues by: Footwear\\n\\n$\\n\\n14,897 $\\n\\n8,260 $\\n\\n5,435 $\\n\\n4,543 $\\n\\n— $\\n\\n33,135 $\\n\\n2,155 $\\n\\n— $\\n\\n35,290\\n\\nApparel Equipment Other\\n\\n5,947 764 —\\n\\n4,566 592 —\\n\\n1,666 147 —\\n\\n1,664 224 —\\n\\n— — 58\\n\\n13,843 1,727 58\\n\\n90 28 154\\n\\n— — 27\\n\\n13,933 1,755 239\\n\\nTOTAL REVENUES\\n\\n$\\n\\n21,608 $\\n\\n13,418 $\\n\\n7,248 $\\n\\n6,431 $\\n\\n58 $\\n\\n48,763 $\\n\\n2,427 $\\n\\n27 $\\n\\n51,217\\n\\nRevenues by:\\n\\nSales to Wholesale Customers Sales through Direct to Consumer\\n\\n$\\n\\n11,273 $ 10,335\\n\\n8,522 $ 4,896\\n\\n3,866 $ 3,382\\n\\n3,736 $ 2,695\\n\\n— $ —\\n\\n27,397 $ 21,308\\n\\n1,299 $ 974\\n\\n— $ —\\n\\n28,696 22,282\\n\\nOther\\n\\nTOTAL REVENUES\\n\\n$\\n\\n—\\n\\n21,608 $\\n\\n—\\n\\n13,418 $\\n\\n— 7,248 $\\n\\n— 6,431 $\\n\\n58 58 $\\n\\n58\\n\\n48,763 $\\n\\n154 2,427 $\\n\\n27 27 $\\n\\n239 51,217\\n\\n(1) Refer to Note 18 — Acquisitions and Divestitures for additional information on the transition of the Company's NIKE Brand businesses in its CASA territory to third-party distributors.\\n\\nYEAR ENDED MAY 31, 2022\\n\\n(Dollars in millions)\\n\\nNORTH AMERICA\\n\\nEUROPE, MIDDLE EAST & AFRICA\\n\\nGREATER CHINA\\n\\nASIA PACIFIC & LATIN AMERICA\\n\\nGLOBAL BRAND DIVISIONS\\n\\nTOTAL NIKE\\n\\nBRAND CONVERSE CORPORATE\\n\\nTOTAL NIKE, INC.\\n\\nRevenues by: Footwear Apparel\\n\\n$\\n\\n12,228 $ 5,492\\n\\n7,388 $ 4,527\\n\\n5,416 $ 1,938\\n\\n4,111 $ 1,610\\n\\n— $ —\\n\\n29,143 $ 13,567\\n\\n2,094 $ 103\\n\\n— $ —\\n\\n31,237 13,670\\n\\nEquipment Other\\n\\n633 —\\n\\n564 —\\n\\n193 —\\n\\n234 —\\n\\n— 102\\n\\n1,624 102\\n\\n26 123\\n\\n— (72)\\n\\n1,650 153\\n\\nTOTAL REVENUES Revenues by:\\n\\n$\\n\\n18,353 $\\n\\n12,479 $\\n\\n7,547 $\\n\\n5,955 $\\n\\n102 $\\n\\n44,436 $\\n\\n2,346 $\\n\\n(72) $\\n\\n46,710\\n\\nSales to Wholesale Customers Sales through Direct to Consumer Other\\n\\n$\\n\\n9,621 $ 8,732 —\\n\\n8,377 $ 4,102 —\\n\\n4,081 $ 3,466 —\\n\\n3,529 $ 2,426 —\\n\\n— $ — 102\\n\\n25,608 $ 18,726 102\\n\\n1,292 $ 931 123\\n\\n— $ — (72)\\n\\n26,900 19,657 153\\n\\nTOTAL REVENUES\\n\\n$\\n\\n18,353 $\\n\\n12,479 $\\n\\n7,547 $\\n\\n5,955 $\\n\\n102 $\\n\\n44,436 $\\n\\n2,346 $\\n\\n(72) $\\n\\n46,710\\n\\n2023 FORM 10-K 83\\n\\nTable of Contents\\n\\nYEAR ENDED MAY 31, 2021\\n\\n(Dollars in millions)\\n\\nNORTH AMERICA\\n\\nEUROPE, MIDDLE EAST & AFRICA\\n\\nGREATER CHINA\"),\n",
+       "  0.261225402355)]"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# vector search with combinations of metadata filtering\n",
+    "\n",
+    "f = (Text(\"text\") % \"profit\") | (Text(\"text\") % \"revenue\")\n",
+    "rds.similarity_search_with_score(query=\"Nike company revenue\", k=4, filter=f)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "kIoGJOop1vmz",
+    "outputId": "9abbf5fd-77de-4094-a2e8-fba2fc5a3a05"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[(Document(metadata={'source': 'resources/nke-10k-2023.pdf'}, page_content='As discussed in Note 15 — Operating Segments and Related Information in the accompanying Notes to the Consolidated Financial Statements, our operating segments are evidence of the structure of the Company\\'s internal organization. The NIKE Brand segments are defined by geographic regions for operations participating in NIKE Brand sales activity.\\n\\nThe breakdown of Revenues is as follows:\\n\\n(Dollars in millions)\\n\\nFISCAL 2023 FISCAL 2022\\n\\n% CHANGE\\n\\n% CHANGE EXCLUDING CURRENCY (1) CHANGES FISCAL 2021\\n\\n% CHANGE\\n\\nNorth America Europe, Middle East & Africa Greater China\\n\\n$\\n\\n21,608 $ 13,418 7,248\\n\\n18,353 12,479 7,547\\n\\n18 % 8 % -4 %\\n\\n18 % $ 21 % 4 %\\n\\n17,179 11,456 8,290\\n\\n7 % 9 % -9 %\\n\\nAsia Pacific & Latin America Global Brand Divisions\\n\\n(3)\\n\\n(2)\\n\\n6,431 58\\n\\n5,955 102\\n\\n8 % -43 %\\n\\n17 % -43 %\\n\\n5,343 25\\n\\n11 % 308 %\\n\\nTOTAL NIKE BRAND Converse\\n\\n$\\n\\n48,763 $ 2,427\\n\\n44,436 2,346\\n\\n10 % 3 %\\n\\n16 % $ 8 %\\n\\n42,293 2,205\\n\\n5 % 6 %\\n\\n(4)\\n\\nCorporate TOTAL NIKE, INC. REVENUES\\n\\n$\\n\\n27\\n\\n51,217 $\\n\\n(72) 46,710\\n\\n— 10 %\\n\\n— 16 % $\\n\\n40 44,538\\n\\n— 5 %\\n\\n(1) The percent change excluding currency changes represents a non-GAAP financial measure. For further information, see \"Use of Non-GAAP Financial Measures\".\\n\\n(2) For additional information on the transition of our NIKE Brand businesses within our CASA territory to a third-party distributor, see Note 18 — Acquisitions and Divestitures of the Notes to Consolidated\\n\\nFinancial Statements contained in Item 8 of this Annual Report.\\n\\n(3) Global Brand Divisions revenues include NIKE Brand licensing and other miscellaneous revenues that are not part of a geographic operating segment.\\n\\n(4) Corporate revenues primarily consist of foreign currency hedge gains and losses related to revenues generated by entities within the NIKE Brand geographic operating segments and Converse, but\\n\\nmanaged through our central foreign exchange risk management program.\\n\\nThe primary financial measure used by the Company to evaluate performance is Earnings Before Interest and Taxes (\"EBIT\"). As discussed in Note 15 — Operating Segments and Related Information in the accompanying Notes to the Consolidated Financial Statements, certain corporate costs are not included in EBIT.\\n\\nThe breakdown of EBIT is as follows:\\n\\n(Dollars in millions)\\n\\nFISCAL 2023\\n\\nFISCAL 2022\\n\\n% CHANGE\\n\\nFISCAL 2021\\n\\nNorth America Europe, Middle East & Africa Greater China\\n\\n$\\n\\n5,454 3,531 2,283\\n\\n$\\n\\n5,114 3,293 2,365\\n\\n7 % $ 7 % -3 %\\n\\n5,089 2,435 3,243\\n\\nAsia Pacific & Latin America Global Brand Divisions (1)'),\n",
+       "  0.233286499977),\n",
+       " (Document(metadata={'source': 'resources/nke-10k-2023.pdf'}, page_content='As discussed in Note 15 — Operating Segments and Related Information in the accompanying Notes to the Consolidated Financial Statements, our operating segments are evidence of the structure of the Company\\'s internal organization. The NIKE Brand segments are defined by geographic regions for operations participating in NIKE Brand sales activity.\\n\\nThe breakdown of Revenues is as follows:\\n\\n(Dollars in millions)\\n\\nFISCAL 2023 FISCAL 2022\\n\\n% CHANGE\\n\\n% CHANGE EXCLUDING CURRENCY (1) CHANGES FISCAL 2021\\n\\n% CHANGE\\n\\nNorth America Europe, Middle East & Africa Greater China\\n\\n$\\n\\n21,608 $ 13,418 7,248\\n\\n18,353 12,479 7,547\\n\\n18 % 8 % -4 %\\n\\n18 % $ 21 % 4 %\\n\\n17,179 11,456 8,290\\n\\n7 % 9 % -9 %\\n\\nAsia Pacific & Latin America Global Brand Divisions\\n\\n(3)\\n\\n(2)\\n\\n6,431 58\\n\\n5,955 102\\n\\n8 % -43 %\\n\\n17 % -43 %\\n\\n5,343 25\\n\\n11 % 308 %\\n\\nTOTAL NIKE BRAND Converse\\n\\n$\\n\\n48,763 $ 2,427\\n\\n44,436 2,346\\n\\n10 % 3 %\\n\\n16 % $ 8 %\\n\\n42,293 2,205\\n\\n5 % 6 %\\n\\n(4)\\n\\nCorporate TOTAL NIKE, INC. REVENUES\\n\\n$\\n\\n27\\n\\n51,217 $\\n\\n(72) 46,710\\n\\n— 10 %\\n\\n— 16 % $\\n\\n40 44,538\\n\\n— 5 %\\n\\n(1) The percent change excluding currency changes represents a non-GAAP financial measure. For further information, see \"Use of Non-GAAP Financial Measures\".\\n\\n(2) For additional information on the transition of our NIKE Brand businesses within our CASA territory to a third-party distributor, see Note 18 — Acquisitions and Divestitures of the Notes to Consolidated\\n\\nFinancial Statements contained in Item 8 of this Annual Report.\\n\\n(3) Global Brand Divisions revenues include NIKE Brand licensing and other miscellaneous revenues that are not part of a geographic operating segment.\\n\\n(4) Corporate revenues primarily consist of foreign currency hedge gains and losses related to revenues generated by entities within the NIKE Brand geographic operating segments and Converse, but\\n\\nmanaged through our central foreign exchange risk management program.\\n\\nThe primary financial measure used by the Company to evaluate performance is Earnings Before Interest and Taxes (\"EBIT\"). As discussed in Note 15 — Operating Segments and Related Information in the accompanying Notes to the Consolidated Financial Statements, certain corporate costs are not included in EBIT.\\n\\nThe breakdown of EBIT is as follows:\\n\\n(Dollars in millions)\\n\\nFISCAL 2023\\n\\nFISCAL 2022\\n\\n% CHANGE\\n\\nFISCAL 2021\\n\\nNorth America Europe, Middle East & Africa Greater China\\n\\n$\\n\\n5,454 3,531 2,283\\n\\n$\\n\\n5,114 3,293 2,365\\n\\n7 % $ 7 % -3 %\\n\\n5,089 2,435 3,243\\n\\nAsia Pacific & Latin America Global Brand Divisions (1)'),\n",
+       "  0.233286499977),\n",
+       " (Document(metadata={'source': 'resources/nke-10k-2023.pdf'}, page_content='As discussed in Note 15 — Operating Segments and Related Information in the accompanying Notes to the Consolidated Financial Statements, our operating segments are evidence of the structure of the Company\\'s internal organization. The NIKE Brand segments are defined by geographic regions for operations participating in NIKE Brand sales activity.\\n\\nThe breakdown of Revenues is as follows:\\n\\n(Dollars in millions)\\n\\nFISCAL 2023 FISCAL 2022\\n\\n% CHANGE\\n\\n% CHANGE EXCLUDING CURRENCY (1) CHANGES FISCAL 2021\\n\\n% CHANGE\\n\\nNorth America Europe, Middle East & Africa Greater China\\n\\n$\\n\\n21,608 $ 13,418 7,248\\n\\n18,353 12,479 7,547\\n\\n18 % 8 % -4 %\\n\\n18 % $ 21 % 4 %\\n\\n17,179 11,456 8,290\\n\\n7 % 9 % -9 %\\n\\nAsia Pacific & Latin America Global Brand Divisions\\n\\n(3)\\n\\n(2)\\n\\n6,431 58\\n\\n5,955 102\\n\\n8 % -43 %\\n\\n17 % -43 %\\n\\n5,343 25\\n\\n11 % 308 %\\n\\nTOTAL NIKE BRAND Converse\\n\\n$\\n\\n48,763 $ 2,427\\n\\n44,436 2,346\\n\\n10 % 3 %\\n\\n16 % $ 8 %\\n\\n42,293 2,205\\n\\n5 % 6 %\\n\\n(4)\\n\\nCorporate TOTAL NIKE, INC. REVENUES\\n\\n$\\n\\n27\\n\\n51,217 $\\n\\n(72) 46,710\\n\\n— 10 %\\n\\n— 16 % $\\n\\n40 44,538\\n\\n— 5 %\\n\\n(1) The percent change excluding currency changes represents a non-GAAP financial measure. For further information, see \"Use of Non-GAAP Financial Measures\".\\n\\n(2) For additional information on the transition of our NIKE Brand businesses within our CASA territory to a third-party distributor, see Note 18 — Acquisitions and Divestitures of the Notes to Consolidated\\n\\nFinancial Statements contained in Item 8 of this Annual Report.\\n\\n(3) Global Brand Divisions revenues include NIKE Brand licensing and other miscellaneous revenues that are not part of a geographic operating segment.\\n\\n(4) Corporate revenues primarily consist of foreign currency hedge gains and losses related to revenues generated by entities within the NIKE Brand geographic operating segments and Converse, but\\n\\nmanaged through our central foreign exchange risk management program.\\n\\nThe primary financial measure used by the Company to evaluate performance is Earnings Before Interest and Taxes (\"EBIT\"). As discussed in Note 15 — Operating Segments and Related Information in the accompanying Notes to the Consolidated Financial Statements, certain corporate costs are not included in EBIT.\\n\\nThe breakdown of EBIT is as follows:\\n\\n(Dollars in millions)\\n\\nFISCAL 2023\\n\\nFISCAL 2022\\n\\n% CHANGE\\n\\nFISCAL 2021\\n\\nNorth America Europe, Middle East & Africa Greater China\\n\\n$\\n\\n5,454 3,531 2,283\\n\\n$\\n\\n5,114 3,293 2,365\\n\\n7 % $ 7 % -3 %\\n\\n5,089 2,435 3,243\\n\\nAsia Pacific & Latin America Global Brand Divisions (1)'),\n",
+       "  0.233286499977),\n",
+       " (Document(metadata={'source': 'resources/nke-10k-2023.pdf'}, page_content=\"Tax (expense) benefit Gain (loss) net of tax\\n\\n5 (14)\\n\\n(9) 22\\n\\nTotal net gain (loss) reclassified for the period\\n\\n$\\n\\n463 $\\n\\n30\\n\\n2023 FORM 10-K 82\\n\\nTable of Contents\\n\\nNOTE 14 — REVENUES\\n\\nDISAGGREGATION OF REVENUES The following tables present the Company's Revenues disaggregated by reportable operating segment, major product line and distribution channel:\\n\\n(Dollars in millions)\\n\\nNORTH AMERICA\\n\\nEUROPE, MIDDLE EAST & AFRICA\\n\\nGREATER CHINA\\n\\nYEAR ENDED MAY 31, 2023 ASIA PACIFIC & LATIN (1)\\n\\nGLOBAL BRAND DIVISIONS\\n\\nTOTAL NIKE\\n\\nAMERICA\\n\\nBRAND CONVERSE CORPORATE\\n\\nTOTAL NIKE, INC.\\n\\nRevenues by: Footwear\\n\\n$\\n\\n14,897 $\\n\\n8,260 $\\n\\n5,435 $\\n\\n4,543 $\\n\\n— $\\n\\n33,135 $\\n\\n2,155 $\\n\\n— $\\n\\n35,290\\n\\nApparel Equipment Other\\n\\n5,947 764 —\\n\\n4,566 592 —\\n\\n1,666 147 —\\n\\n1,664 224 —\\n\\n— — 58\\n\\n13,843 1,727 58\\n\\n90 28 154\\n\\n— — 27\\n\\n13,933 1,755 239\\n\\nTOTAL REVENUES\\n\\n$\\n\\n21,608 $\\n\\n13,418 $\\n\\n7,248 $\\n\\n6,431 $\\n\\n58 $\\n\\n48,763 $\\n\\n2,427 $\\n\\n27 $\\n\\n51,217\\n\\nRevenues by:\\n\\nSales to Wholesale Customers Sales through Direct to Consumer\\n\\n$\\n\\n11,273 $ 10,335\\n\\n8,522 $ 4,896\\n\\n3,866 $ 3,382\\n\\n3,736 $ 2,695\\n\\n— $ —\\n\\n27,397 $ 21,308\\n\\n1,299 $ 974\\n\\n— $ —\\n\\n28,696 22,282\\n\\nOther\\n\\nTOTAL REVENUES\\n\\n$\\n\\n—\\n\\n21,608 $\\n\\n—\\n\\n13,418 $\\n\\n— 7,248 $\\n\\n— 6,431 $\\n\\n58 58 $\\n\\n58\\n\\n48,763 $\\n\\n154 2,427 $\\n\\n27 27 $\\n\\n239 51,217\\n\\n(1) Refer to Note 18 — Acquisitions and Divestitures for additional information on the transition of the Company's NIKE Brand businesses in its CASA territory to third-party distributors.\\n\\nYEAR ENDED MAY 31, 2022\\n\\n(Dollars in millions)\\n\\nNORTH AMERICA\\n\\nEUROPE, MIDDLE EAST & AFRICA\\n\\nGREATER CHINA\\n\\nASIA PACIFIC & LATIN AMERICA\\n\\nGLOBAL BRAND DIVISIONS\\n\\nTOTAL NIKE\\n\\nBRAND CONVERSE CORPORATE\\n\\nTOTAL NIKE, INC.\\n\\nRevenues by: Footwear Apparel\\n\\n$\\n\\n12,228 $ 5,492\\n\\n7,388 $ 4,527\\n\\n5,416 $ 1,938\\n\\n4,111 $ 1,610\\n\\n— $ —\\n\\n29,143 $ 13,567\\n\\n2,094 $ 103\\n\\n— $ —\\n\\n31,237 13,670\\n\\nEquipment Other\\n\\n633 —\\n\\n564 —\\n\\n193 —\\n\\n234 —\\n\\n— 102\\n\\n1,624 102\\n\\n26 123\\n\\n— (72)\\n\\n1,650 153\\n\\nTOTAL REVENUES Revenues by:\\n\\n$\\n\\n18,353 $\\n\\n12,479 $\\n\\n7,547 $\\n\\n5,955 $\\n\\n102 $\\n\\n44,436 $\\n\\n2,346 $\\n\\n(72) $\\n\\n46,710\\n\\nSales to Wholesale Customers Sales through Direct to Consumer Other\\n\\n$\\n\\n9,621 $ 8,732 —\\n\\n8,377 $ 4,102 —\\n\\n4,081 $ 3,466 —\\n\\n3,529 $ 2,426 —\\n\\n— $ — 102\\n\\n25,608 $ 18,726 102\\n\\n1,292 $ 931 123\\n\\n— $ — (72)\\n\\n26,900 19,657 153\\n\\nTOTAL REVENUES\\n\\n$\\n\\n18,353 $\\n\\n12,479 $\\n\\n7,547 $\\n\\n5,955 $\\n\\n102 $\\n\\n44,436 $\\n\\n2,346 $\\n\\n(72) $\\n\\n46,710\\n\\n2023 FORM 10-K 83\\n\\nTable of Contents\\n\\nYEAR ENDED MAY 31, 2021\\n\\n(Dollars in millions)\\n\\nNORTH AMERICA\\n\\nEUROPE, MIDDLE EAST & AFRICA\\n\\nGREATER CHINA\"),\n",
+       "  0.261225402355)]"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# filter results to a certain distance threshold\n",
+    "rds.similarity_search_with_score(query=\"Nike company revenue\", k=4, distance_threshold=0.3)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "XdzQa112Bf2b"
+   },
+   "source": [
+    "## RAG with LangChain\n",
+    "LangChain makes it easy to now take this vector store and build retireval augmented generation (RAG) applications over your data."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": false,
+    "id": "CU2aFQPW1vmz"
+   },
+   "source": [
+    "### Initialize OpenAI\n",
+    "\n",
+    "You need to supply an OpenAI API key (starts with `sk-...`) when prompted. If the key is in your env -- great, otherwise enter it when prompted below. You can find your API key at https://platform.openai.com/account/api-keys"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "GSpH-cur1vmz",
+    "outputId": "b00de5c7-1684-4e8e-c146-6d402910cdc5"
+   },
+   "outputs": [],
+   "source": [
+    "import getpass\n",
+    "from langchain_openai import ChatOpenAI\n",
+    "\n",
+    "llm = ChatOpenAI(openai_api_key=os.getenv(\"OPENAI_API_KEY\") or getpass.getpass(prompt=\"OpenAI API Key:\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "-SQXQB-c1vmz"
+   },
+   "source": [
+    "### Setup prompt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langchain_core.output_parsers import StrOutputParser\n",
+    "from langchain_core.prompts import ChatPromptTemplate\n",
+    "from langchain_core.runnables import RunnablePassthrough\n",
+    "\n",
+    "prompt_template = \"\"\"\n",
+    "    Use the following pieces of context from financial 10k filings data to answer the user question at the end. \n",
+    "    If you don't know the answer, say that you don't know, don't try to make up an answer.\n",
+    "\n",
+    "    Context:\n",
+    "    ---------\n",
+    "    {context}\n",
+    "    ---------\n",
+    "    Question:\n",
+    "    {question}\n",
+    "    Answer:\n",
+    "\"\"\"\n",
+    "\n",
+    "def format_docs(docs):\n",
+    "    return \"\\n\\n\".join(doc.page_content for doc in docs)\n",
+    "\n",
+    "prompt = ChatPromptTemplate.from_template(prompt_template)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "xgEXBujxG1dO"
+   },
+   "source": [
+    "### Putting it all together\n",
+    "\n",
+    "This is where the Langchain brings all the components together in a form of a simple RAG application with the financial PDF document."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rag_chain = (\n",
+    "    {\n",
+    "        \"context\": rds.as_retriever() | format_docs,\n",
+    "        \"question\": RunnablePassthrough()\n",
+    "    }\n",
+    "    | prompt\n",
+    "    | llm\n",
+    "    | StrOutputParser()\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "SURTtVbYBFGc"
+   },
+   "source": [
+    "### Finally - let's ask questions!\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 52
+    },
+    "id": "0JkswfOHZu9h",
+    "outputId": "813fffe6-3d8b-4df7-a035-c54e421c0856"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "\"Nike's revenue last year was $44,538 million, and this year it was $51,217 million.\""
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "query = \"What was Nike's revenue last year compared to this year??\"\n",
+    "rag_chain.invoke(query)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 52
+    },
+    "id": "ZvioUduS1vm0",
+    "outputId": "a8ba0e5d-c06b-4848-d066-c26884b3caee"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'The exact number of products Nike offers is not explicitly stated in the provided context. However, Nike is part of the athletic footwear, apparel, and equipment industry, which is highly competitive both in the United States and worldwide.'"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "query = \"How many products does Nike offer? What is the industry that Nike is part of?\"\n",
+    "rag_chain.invoke(query)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 35
+    },
+    "id": "Q9mE5z-61vm1",
+    "outputId": "e3860d3e-e68b-489b-9897-c7118377c7bb"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'Based on the provided information, there is no specific mention or data that directly addresses the ethical practices of Nike as a company. Therefore, it is not possible to determine if Nike is an ethical company based on the provided context.'"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "query = \"Is Nike an ethical company?\"\n",
+    "rag_chain.invoke(query)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "5itk4UPF1vm1"
+   },
+   "source": [
+    "## Cleanup\n",
+    "\n",
+    "Cleanup the index and data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {
+    "id": "DtZi-mQ61vm-"
+   },
+   "outputs": [
+    {
+     "ename": "ValueError",
+     "evalue": "REDIS_URL env var not set",
+     "output_type": "error",
+     "traceback": [
+      "\u001B[0;31m---------------------------------------------------------------------------\u001B[0m",
+      "\u001B[0;31mValueError\u001B[0m                                Traceback (most recent call last)",
+      "Cell \u001B[0;32mIn[18], line 3\u001B[0m\n\u001B[1;32m      1\u001B[0m \u001B[38;5;28;01mfrom\u001B[39;00m \u001B[38;5;21;01mredisvl\u001B[39;00m\u001B[38;5;21;01m.\u001B[39;00m\u001B[38;5;21;01mindex\u001B[39;00m \u001B[38;5;28;01mimport\u001B[39;00m SearchIndex\n\u001B[0;32m----> 3\u001B[0m idx \u001B[38;5;241m=\u001B[39m \u001B[43mSearchIndex\u001B[49m\u001B[38;5;241;43m.\u001B[39;49m\u001B[43mfrom_existing\u001B[49m\u001B[43m(\u001B[49m\n\u001B[1;32m      4\u001B[0m \u001B[43m    \u001B[49m\u001B[43mindex_name\u001B[49m\u001B[43m,\u001B[49m\n\u001B[1;32m      5\u001B[0m \u001B[43m    \u001B[49m\u001B[43mredis_url\u001B[49m\u001B[38;5;241;43m=\u001B[39;49m\u001B[43mREDIS_URL\u001B[49m\n\u001B[1;32m      6\u001B[0m \u001B[43m)\u001B[49m\n\u001B[1;32m      8\u001B[0m idx\u001B[38;5;241m.\u001B[39mdelete()\n",
+      "File \u001B[0;32m~/.pyenv/versions/3.11.9/lib/python3.11/site-packages/redisvl/index/index.py:322\u001B[0m, in \u001B[0;36mSearchIndex.from_existing\u001B[0;34m(cls, name, redis_client, redis_url, **kwargs)\u001B[0m\n\u001B[1;32m    320\u001B[0m \u001B[38;5;28;01mtry\u001B[39;00m:\n\u001B[1;32m    321\u001B[0m     \u001B[38;5;28;01mif\u001B[39;00m redis_url:\n\u001B[0;32m--> 322\u001B[0m         redis_client \u001B[38;5;241m=\u001B[39m \u001B[43mRedisConnectionFactory\u001B[49m\u001B[38;5;241;43m.\u001B[39;49m\u001B[43mget_redis_connection\u001B[49m\u001B[43m(\u001B[49m\n\u001B[1;32m    323\u001B[0m \u001B[43m            \u001B[49m\u001B[43mredis_url\u001B[49m\u001B[38;5;241;43m=\u001B[39;49m\u001B[43mredis_url\u001B[49m\u001B[43m,\u001B[49m\n\u001B[1;32m    324\u001B[0m \u001B[43m            \u001B[49m\u001B[43mrequired_modules\u001B[49m\u001B[38;5;241;43m=\u001B[39;49m\u001B[43mREQUIRED_MODULES_FOR_INTROSPECTION\u001B[49m\u001B[43m,\u001B[49m\n\u001B[1;32m    325\u001B[0m \u001B[43m            \u001B[49m\u001B[38;5;241;43m*\u001B[39;49m\u001B[38;5;241;43m*\u001B[39;49m\u001B[43mkwargs\u001B[49m\u001B[43m,\u001B[49m\n\u001B[1;32m    326\u001B[0m \u001B[43m        \u001B[49m\u001B[43m)\u001B[49m\n\u001B[1;32m    327\u001B[0m     \u001B[38;5;28;01melif\u001B[39;00m redis_client:\n\u001B[1;32m    328\u001B[0m         RedisConnectionFactory\u001B[38;5;241m.\u001B[39mvalidate_sync_redis(\n\u001B[1;32m    329\u001B[0m             redis_client, required_modules\u001B[38;5;241m=\u001B[39mREQUIRED_MODULES_FOR_INTROSPECTION\n\u001B[1;32m    330\u001B[0m         )\n",
+      "File \u001B[0;32m~/.pyenv/versions/3.11.9/lib/python3.11/site-packages/redisvl/redis/connection.py:248\u001B[0m, in \u001B[0;36mRedisConnectionFactory.get_redis_connection\u001B[0;34m(url, required_modules, **kwargs)\u001B[0m\n\u001B[1;32m    224\u001B[0m \u001B[38;5;129m@staticmethod\u001B[39m\n\u001B[1;32m    225\u001B[0m \u001B[38;5;28;01mdef\u001B[39;00m \u001B[38;5;21mget_redis_connection\u001B[39m(\n\u001B[1;32m    226\u001B[0m     url: Optional[\u001B[38;5;28mstr\u001B[39m] \u001B[38;5;241m=\u001B[39m \u001B[38;5;28;01mNone\u001B[39;00m,\n\u001B[1;32m    227\u001B[0m     required_modules: Optional[List[Dict[\u001B[38;5;28mstr\u001B[39m, Any]]] \u001B[38;5;241m=\u001B[39m \u001B[38;5;28;01mNone\u001B[39;00m,\n\u001B[1;32m    228\u001B[0m     \u001B[38;5;241m*\u001B[39m\u001B[38;5;241m*\u001B[39mkwargs,\n\u001B[1;32m    229\u001B[0m ) \u001B[38;5;241m-\u001B[39m\u001B[38;5;241m>\u001B[39m Redis:\n\u001B[1;32m    230\u001B[0m \u001B[38;5;250m    \u001B[39m\u001B[38;5;124;03m\"\"\"Creates and returns a synchronous Redis client.\u001B[39;00m\n\u001B[1;32m    231\u001B[0m \n\u001B[1;32m    232\u001B[0m \u001B[38;5;124;03m    Args:\u001B[39;00m\n\u001B[0;32m   (...)\u001B[0m\n\u001B[1;32m    246\u001B[0m \u001B[38;5;124;03m        RedisModuleVersionError: If required Redis modules are not installed.\u001B[39;00m\n\u001B[1;32m    247\u001B[0m \u001B[38;5;124;03m    \"\"\"\u001B[39;00m\n\u001B[0;32m--> 248\u001B[0m     url \u001B[38;5;241m=\u001B[39m url \u001B[38;5;129;01mor\u001B[39;00m \u001B[43mget_address_from_env\u001B[49m\u001B[43m(\u001B[49m\u001B[43m)\u001B[49m\n\u001B[1;32m    249\u001B[0m     client \u001B[38;5;241m=\u001B[39m Redis\u001B[38;5;241m.\u001B[39mfrom_url(url, \u001B[38;5;241m*\u001B[39m\u001B[38;5;241m*\u001B[39mkwargs)\n\u001B[1;32m    251\u001B[0m     RedisConnectionFactory\u001B[38;5;241m.\u001B[39mvalidate_sync_redis(\n\u001B[1;32m    252\u001B[0m         client, required_modules\u001B[38;5;241m=\u001B[39mrequired_modules\n\u001B[1;32m    253\u001B[0m     )\n",
+      "File \u001B[0;32m~/.pyenv/versions/3.11.9/lib/python3.11/site-packages/redisvl/redis/connection.py:61\u001B[0m, in \u001B[0;36mget_address_from_env\u001B[0;34m()\u001B[0m\n\u001B[1;32m     55\u001B[0m \u001B[38;5;250m\u001B[39m\u001B[38;5;124;03m\"\"\"Get a redis connection from environment variables.\u001B[39;00m\n\u001B[1;32m     56\u001B[0m \n\u001B[1;32m     57\u001B[0m \u001B[38;5;124;03mReturns:\u001B[39;00m\n\u001B[1;32m     58\u001B[0m \u001B[38;5;124;03m    str: Redis URL\u001B[39;00m\n\u001B[1;32m     59\u001B[0m \u001B[38;5;124;03m\"\"\"\u001B[39;00m\n\u001B[1;32m     60\u001B[0m \u001B[38;5;28;01mif\u001B[39;00m \u001B[38;5;124m\"\u001B[39m\u001B[38;5;124mREDIS_URL\u001B[39m\u001B[38;5;124m\"\u001B[39m \u001B[38;5;129;01mnot\u001B[39;00m \u001B[38;5;129;01min\u001B[39;00m os\u001B[38;5;241m.\u001B[39menviron:\n\u001B[0;32m---> 61\u001B[0m     \u001B[38;5;28;01mraise\u001B[39;00m \u001B[38;5;167;01mValueError\u001B[39;00m(\u001B[38;5;124m\"\u001B[39m\u001B[38;5;124mREDIS_URL env var not set\u001B[39m\u001B[38;5;124m\"\u001B[39m)\n\u001B[1;32m     62\u001B[0m \u001B[38;5;28;01mreturn\u001B[39;00m os\u001B[38;5;241m.\u001B[39menviron[\u001B[38;5;124m\"\u001B[39m\u001B[38;5;124mREDIS_URL\u001B[39m\u001B[38;5;124m\"\u001B[39m]\n",
+      "\u001B[0;31mValueError\u001B[0m: REDIS_URL env var not set"
+     ]
+    }
+   ],
+   "source": [
+    "from redisvl.index import SearchIndex\n",
+    "\n",
+    "idx = SearchIndex.from_existing(\n",
+    "    index_name,\n",
+    "    redis_url=REDIS_URL\n",
+    ")\n",
+    "\n",
+    "idx.delete()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'0.4.0'"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import redisvl\n",
+    "\n",
+    "redisvl.__version__"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'5.2.1'"
+      ]
+     },
+     "execution_count": 20,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import redis\n",
+    "\n",
+    "redis.__version__"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'redis://:@localhost:6379'"
+      ]
+     },
+     "execution_count": 21,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "REDIS_URL"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "accelerator": "GPU",
+  "colab": {
+   "gpuType": "T4",
+   "provenance": []
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
 }

--- a/python-recipes/RAG/02_langchain.ipynb
+++ b/python-recipes/RAG/02_langchain.ipynb
@@ -231,8 +231,8 @@
     }
    ],
    "source": [
-    "from langchain_text_splitters import RecursiveCharacterTextSplitter\n",
-    "from langchain_community.document_loaders import UnstructuredFileLoader\n",
+    "from langchain.text_splitter import RecursiveCharacterTextSplitter\n",
+    "from langchain.document_loaders import UnstructuredFileLoader\n",
     "\n",
     "# Load list of pdfs from a folder\n",
     "data_path = \"resources/\"\n",

--- a/python-recipes/RAG/02_langchain.ipynb
+++ b/python-recipes/RAG/02_langchain.ipynb
@@ -1,1048 +1,1048 @@
 {
- "cells": [
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "R2-i8jBl9GRH"
-   },
-   "source": [
-    "![Redis](https://redis.io/wp-content/uploads/2024/04/Logotype.svg?auto=webp&quality=85,75&width=120)\n",
-    "# RAG with LangChain\n",
-    "\n",
-    "This notebook uses [LangChain](https://python.langchain.com/docs/get_started/introduction) and [Redis](https://redis.com) to perform document + embdding indexing and semantic search tasks. It also shows how to integrate with an LLM like OpenAI's GPT models. See the full partner package source code [here](https://github.com/langchain-ai/langchain-redis/tree/main).\n",
-    "\n",
-    "## Let's Begin!\n",
-    "<a href=\"https://colab.research.google.com/github/redis-developer/redis-ai-resources/blob/main/python-recipes/RAG/02_langchain.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "ctOVb_LZ1vmk"
-   },
-   "source": [
-    "## Environment Setup\n",
-    "\n",
-    "### Pull Github Materials\n",
-    "Because you are likely running this notebook in **Google Colab**, we need to first\n",
-    "pull the necessary dataset and materials directly from GitHub. The following commands grab the material, move to root for colab, and clean up unneeded files.\n",
-    "\n",
-    "**If you are running this notebook locally**, FYI you may not need to perform this\n",
-    "step at all."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "id": "UQezgPCG1vml",
-    "outputId": "97b9bc03-da1b-439a-c37b-be6fdb58ab21"
-   },
-   "outputs": [],
-   "source": [
-    "# NBVAL_SKIP\n",
-    "!git clone https://github.com/redis-developer/redis-ai-resources.git temp_repo\n",
-    "!mv temp_repo/python-recipes/RAG/resources .\n",
-    "!rm -rf temp_repo"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "9eieJowO1vmo"
-   },
-   "source": [
-    "### Install Python Dependencies"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 23,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "id": "B3v1wUzX1vmq",
-    "outputId": "84a3feff-e7c1-41ba-9ab1-8c975074552e"
-   },
-   "outputs": [
+  "cells": [
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "huggingface/tokenizers: The current process just got forked, after parallelism has already been used. Disabling parallelism to avoid deadlocks...\n",
-      "To disable this warning, you can either:\n",
-      "\t- Avoid using `tokenizers` before the fork if possible\n",
-      "\t- Explicitly set the environment variable TOKENIZERS_PARALLELISM=(true | false)\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "\u001B[1m[\u001B[0m\u001B[34;49mnotice\u001B[0m\u001B[1;39;49m]\u001B[0m\u001B[39;49m A new release of pip is available: \u001B[0m\u001B[31;49m24.0\u001B[0m\u001B[39;49m -> \u001B[0m\u001B[32;49m25.0.1\u001B[0m\n",
-      "\u001B[1m[\u001B[0m\u001B[34;49mnotice\u001B[0m\u001B[1;39;49m]\u001B[0m\u001B[39;49m To update, run: \u001B[0m\u001B[32;49mpip install --upgrade pip\u001B[0m\n",
-      "Note: you may need to restart the kernel to use updated packages.\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "huggingface/tokenizers: The current process just got forked, after parallelism has already been used. Disabling parallelism to avoid deadlocks...\n",
-      "To disable this warning, you can either:\n",
-      "\t- Avoid using `tokenizers` before the fork if possible\n",
-      "\t- Explicitly set the environment variable TOKENIZERS_PARALLELISM=(true | false)\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "\u001B[1m[\u001B[0m\u001B[34;49mnotice\u001B[0m\u001B[1;39;49m]\u001B[0m\u001B[39;49m A new release of pip is available: \u001B[0m\u001B[31;49m24.0\u001B[0m\u001B[39;49m -> \u001B[0m\u001B[32;49m25.0.1\u001B[0m\n",
-      "\u001B[1m[\u001B[0m\u001B[34;49mnotice\u001B[0m\u001B[1;39;49m]\u001B[0m\u001B[39;49m To update, run: \u001B[0m\u001B[32;49mpip install --upgrade pip\u001B[0m\n",
-      "Note: you may need to restart the kernel to use updated packages.\n"
-     ]
-    }
-   ],
-   "source": [
-    "%pip install -q redis \"unstructured[pdf]\" sentence-transformers langchain\n",
-    "%pip install -q langchain-community \"langchain-redis>=0.2.0\" langchain-huggingface langchain-openai"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Install Redis Stack\n",
-    "\n",
-    "Later in this tutorial, Redis will be used to store, index, and query vector\n",
-    "embeddings created from PDF document chunks. **We need to make sure we have a Redis\n",
-    "instance available.**"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "#### For Colab\n",
-    "Use the shell script below to download, extract, and install [Redis Stack](https://redis.io/docs/getting-started/install-stack/) directly from the Redis package archive."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# NBVAL_SKIP\n",
-    "%%sh\n",
-    "curl -fsSL https://packages.redis.io/gpg | sudo gpg --dearmor -o /usr/share/keyrings/redis-archive-keyring.gpg\n",
-    "echo \"deb [signed-by=/usr/share/keyrings/redis-archive-keyring.gpg] https://packages.redis.io/deb $(lsb_release -cs) main\" | sudo tee /etc/apt/sources.list.d/redis.list\n",
-    "sudo apt-get update  > /dev/null 2>&1\n",
-    "sudo apt-get install redis-stack-server  > /dev/null 2>&1\n",
-    "redis-stack-server --daemonize yes"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "#### For Alternative Environments\n",
-    "There are many ways to get the necessary redis-stack instance running\n",
-    "1. On cloud, deploy a [FREE instance of Redis in the cloud](https://redis.com/try-free/). Or, if you have your\n",
-    "own version of Redis Enterprise running, that works too!\n",
-    "2. Per OS, [see the docs](https://redis.io/docs/latest/operate/oss_and_stack/install/install-stack/)\n",
-    "3. With docker: `docker run -d --name redis-stack-server -p 6379:6379 redis/redis-stack-server:latest`"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Define the Redis Connection URL\n",
-    "\n",
-    "By default this notebook connects to the local instance of Redis Stack. **If you have your own Redis Enterprise instance** - replace REDIS_PASSWORD, REDIS_HOST and REDIS_PORT values with your own."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 1,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import os\n",
-    "import warnings\n",
-    "warnings.filterwarnings('ignore')\n",
-    "\n",
-    "# Replace values below with your own if using Redis Cloud instance\n",
-    "REDIS_HOST = os.getenv(\"REDIS_HOST\", \"localhost\") # ex: \"redis-18374.c253.us-central1-1.gce.cloud.redislabs.com\"\n",
-    "REDIS_PORT = os.getenv(\"REDIS_PORT\", \"6379\")      # ex: 18374\n",
-    "REDIS_PASSWORD = os.getenv(\"REDIS_PASSWORD\", \"\")  # ex: \"1TNxTEdYRDgIDKM2gDfasupCADXXXX\"\n",
-    "\n",
-    "# If SSL is enabled on the endpoint, use rediss:// as the URL prefix\n",
-    "REDIS_URL = f\"redis://:{REDIS_PASSWORD}@{REDIS_HOST}:{REDIS_PORT}\""
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## RAG with LangChain"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "7MaVqU8Y1vms"
-   },
-   "source": [
-    "### Dataset Preparation (PDF Documents)\n",
-    "\n",
-    "To best demonstrate Redis as a vector database layer, we will load a single\n",
-    "financial (10k filings) doc and preprocess it using some helpers from LangChain:\n",
-    "\n",
-    "- `UnstructuredFileLoader` is not the only document loader type that LangChain provides. Docs: https://python.langchain.com/docs/integrations/document_loaders/unstructured_file\n",
-    "- `RecursiveCharacterTextSplitter` is what we use to create smaller chunks of text from the doc. Docs: https://python.langchain.com/docs/modules/data_connection/document_transformers/text_splitters/recursive_text_splitter"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "id": "I7VS1bPr1vmt",
-    "outputId": "72299230-26c4-4d80-d61f-138616e2173b"
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Listing available documents ... ['resources/nke-10k-2023.pdf', 'resources/amzn-10k-2023.pdf', 'resources/metrics_2500_0.csv', 'resources/jnj-10k-2023.pdf', 'resources/aapl-10k-2023.pdf', 'resources/testset_15.csv', 'resources/retrieval_basic_rag_test.csv', 'resources/2022-chevy-colorado-ebrochure.pdf', 'resources/nvd-10k-2023.pdf', 'resources/testset.csv', 'resources/msft-10k-2023.pdf', 'resources/propositions.json', 'resources/generation_basic_rag_test.csv']\n"
-     ]
-    }
-   ],
-   "source": [
-    "from langchain.text_splitter import RecursiveCharacterTextSplitter\n",
-    "from langchain.document_loaders import UnstructuredFileLoader\n",
-    "\n",
-    "# Load list of pdfs from a folder\n",
-    "data_path = \"resources/\"\n",
-    "docs = [os.path.join(data_path, file) for file in os.listdir(data_path)]\n",
-    "\n",
-    "print(\"Listing available documents ...\", docs)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/var/folders/_g/rr4lnxxx1_z7m78lz89dhvsm0000gp/T/ipykernel_45325/1931079106.py:8: LangChainDeprecationWarning: The class `UnstructuredFileLoader` was deprecated in LangChain 0.2.8 and will be removed in 1.0. An updated version of the class exists in the :class:`~langchain-unstructured package and should be used instead. To use it run `pip install -U :class:`~langchain-unstructured` and import as `from :class:`~langchain_unstructured import UnstructuredLoader``.\n",
-      "  loader = UnstructuredFileLoader(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Done preprocessing. Created 179 chunks of the original pdf resources/nke-10k-2023.pdf\n"
-     ]
-    }
-   ],
-   "source": [
-    "# pick out the Nike doc for this exercise\n",
-    "doc = [doc for doc in docs if \"nke\" in doc][0]\n",
-    "\n",
-    "# set up the file loader/extractor and text splitter to create chunks\n",
-    "text_splitter = RecursiveCharacterTextSplitter(\n",
-    "    chunk_size=2500, chunk_overlap=0\n",
-    ")\n",
-    "loader = UnstructuredFileLoader(\n",
-    "    doc, mode=\"single\", strategy=\"fast\"\n",
-    ")\n",
-    "\n",
-    "# extract, load, and make chunks\n",
-    "chunks = loader.load_and_split(text_splitter)\n",
-    "\n",
-    "print(\"Done preprocessing. Created\", len(chunks), \"chunks of the original pdf\", doc)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "96BzcyW31vmw"
-   },
-   "source": [
-    "### Initialize Embeddings Model\n",
-    "Here we will use LangChain's built in embedding engine so that it will work seemlessly with the LangChain VectorStore classes."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 4,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 465,
-     "referenced_widgets": [
-      "e822a189950844309e630f3e428d5a9a",
-      "d3e5c2097a8e44f481e91646e0410e62",
-      "b1e8dcf4ead64c5b8155594fd1d20632",
-      "bd042dad15084b098dfbf7c9277d3581",
-      "54c512a0bb9f485a9612f088c717eec8",
-      "e769ce42211749599822ffc3a18e7292",
-      "0d6362898099436abb80e52eac043c4f",
-      "e3afaca826464f94b6b904e68c827cab",
-      "27ba4306f92c4d659cadcd5c1e0ab787",
-      "15378b3263a449fabf00643fdd23565e",
-      "aee906bc037849e2be3ac68955281892",
-      "2e3997001c494151829379467dde2182",
-      "0281867e8ce8433fb665e287505d0404",
-      "d6ff7f1d2a6b44ff829212b67613e03b",
-      "3402b3afe4304aec81a1e4389e2eafec",
-      "fc32fd51efd2488e9bff38274079d7e5",
-      "07a6bd4b6a484dbebda92c366f3a6740",
-      "13fb05f6cbe24acba47be67e8b0a69a6",
-      "3d30fc25d10e4ce18d50320a88b0a2ec",
-      "ebe649c53e4d48fda0d4ea9a46ec5613",
-      "843c2b0500ee4219841c959f3af20542",
-      "d84881099d4f4f1fa8a481ea9f9dafdd",
-      "04c8bb6bb7c8425b92e0f3fab63d8362",
-      "4d54077e8c38411080b1ef9bfb42e3f8",
-      "b8c9c7fb7b6e4dcfb717f96da1639553",
-      "52961d70221846f78523df1414eb3436",
-      "008e25d7de5e4e548d80be81e26bdb8f",
-      "b0d11b0e853740b7b8e49e5158c940e5",
-      "ac450c103bb44f549a7103f67634f9bf",
-      "99204cde99b348ccb4f45589802f5a38",
-      "2860317abc5b41fab94f8fefe9cb6b3b",
-      "30ebda1e38294648b014354009c17269",
-      "755e63baf4ad4a289fd756d662d9a0bf",
-      "723ef31f042343bd94217075e1857989",
-      "820afc900ef34cdc82f4e5d7c38fb67f",
-      "f06938274c0d4b4591b6cfa2e7a8d183",
-      "1ab52b039fdb4cab909eb439a4ea3524",
-      "d1e27bbac128455e9a0e959ba251eedd",
-      "ff4297f185ce4f2eaf340a422b721774",
-      "168314c6ae1044d6810def7ff06f80c2",
-      "dad25775795b46ec9e7bb788b1d25f82",
-      "4e74d1276be141c9b0f2601ce4c7246a",
-      "2dff47a7d6364e2ba73f057e9b17a705",
-      "f4b4bc8eeef84da2abcf1691e174a080",
-      "6dbbd3a5f81b46d99c9c897dba53d6a5",
-      "b63b4da89d0f45819ad0aead03833f4c",
-      "27725152494c4f0b85e48bf081113764",
-      "8d8356cdf3b54b2daa02fe6d06c2b372",
-      "e61f0ecfe4794a4d929b76b8a5434800",
-      "b1e6fa50486c4973b44b20e29c4837a9",
-      "5d3f0bfd81b34819a6edce0496958f5a",
-      "266abb8c7e064dbea106c6c2903404c3",
-      "59317d931ba14c409d7f9baae6b4b2fc",
-      "da5242e187fd4d6c950e7a75cebb33fa",
-      "a28d8e8eedf34026afe93d2105d7d779",
-      "b4683c36fb744ac18ed8f98f1d352d16",
-      "a68f0e29f8f745fab98bd16b4835956a",
-      "d7791474a31b4ef7bffecdd264cbd0a5",
-      "e49064443c9549ebb7a6d0710d2ad02e",
-      "ee0db8230ae64f1b94e246e2947682a3",
-      "cff28f0f731c48e88de8ccad15146e2f",
-      "af1f8d072046449d9437cb10ccdb2218",
-      "a1f692c86e6d4c668f31bcb4f4189f48",
-      "a8b7b5ad3c954b94bda03987653ce1c8",
-      "32a5f8335e3a4312aea8bb83505b4ed3",
-      "0d4624d3273d46268299e37d96c0d85d",
-      "7c1867628e4742868ba1e1fa322b948e",
-      "35e9d31c8cfb41199df0e4636537a9c0",
-      "f1fff6bb909d4fcbbe0a7582fe5a09d4",
-      "0b3b28fae35d497886c72e4222470629",
-      "bfd29912ee224c4e93ec37f545339586",
-      "d335cf6ac50b46f5a50870069a14a066",
-      "5b7765acd2024e04ba423edc346fe021",
-      "96c778b21e154c77952c3b6456831f6a",
-      "67730a22939d42db8894a633483fd412",
-      "c3e15e863ece4df88d1ad4fa4601fb43",
-      "ce7fbbb4b844429aa16d60c6524bb6ca",
-      "0d1bc800782745a9b89e93bb992e0ce0",
-      "369c5197fd23479c8aa79ac72cbea260",
-      "5317c63c5168499eb992b4d764761dfc",
-      "364519d35ab848199a6fb3e15906318a",
-      "8b7e8c8ff5f3478aa064f5b79ffaaadf",
-      "ccb27092ee314285add51fd91e5ca49d",
-      "61f3b41fdcf04cff88dd08b36a4a5f41",
-      "816a516fa90f43a18dfda92374c2f4ed",
-      "7d8e2e3c678642afba660b450d5f3201",
-      "872caf759d1f45439397ee35c8cf5dc0",
-      "74b0c9b3b9944eab80f16b2789d6c041",
-      "27b3516e55614d1e91ce4c87c022ee0a",
-      "3991f774ac7f492993002be26cd67f18",
-      "d6804472f88d4254925b7b006a97b2c8",
-      "e0cae801b89e43598bab0ce7f38d7042",
-      "09049b516bc545ea844a770021f6812a",
-      "6a3ae2fa53c942edbb1b29a86717ad89",
-      "3da15201c5da4e40b0b3ac999552723a",
-      "bda924a0e1364f89a7f6c9c5ceb03b62",
-      "7a83acfd4fb240c181f127fc7ee07d48",
-      "d6ebd756685b4a589332a3598a25cd89",
-      "f3d585528e6a4962bfb93afbe92b6312",
-      "879c273bd3924ec0acaec655a92350e0",
-      "744ba6e1b34e4883b49c138ab1bdbebc",
-      "d449ea30c72044f986ffc3e1f9a128d8",
-      "976d3f30f0654d48b096a5c39a8dece5",
-      "41685bf8cb4344368edf161b66ae15b2",
-      "7034b97b70c84a01a3d48e316814b555",
-      "39a239df60004a039de689a69c571afc",
-      "1b2f3f0c7afd419e88f061d0c3280989",
-      "701d2879a67c4b86b9f9de76ff675e7c",
-      "955d7c1b76b348549daceb8482a8e825",
-      "2d0a785ceb884a1f9ee020d22c987fa1",
-      "543e7442413d4035bb6949ccbab5cb6b",
-      "5d47f3871bf44a469dcfd0e456d3dae0",
-      "bbb1a53611e14dcb9b028fe82d71e317",
-      "0d31b15287954c3094750dd36a10d47a",
-      "9818040fcf844fd9b00cd0e438209d40",
-      "7c269846386c4f14bfafde1d5c0e871e",
-      "b11227ec73784e09871e0c25131b9f86",
-      "4083110114e3443c920cbeb8c396d4da",
-      "366cf22df75b42509e5610ff9c9b1d3d",
-      "ff231927834c41088becbe8f94f96f7b",
-      "6e3f1af22a534a7ebdb9752acb7f1b96",
-      "7a6e695c3dcf417f9f53ceb019e37111",
-      "5bf9cc6f60614542bf0628586b8560dd",
-      "d08483b9393840cfb36dd504514043c4",
-      "d36c28d414af4712b16a7f0543f61fc9",
-      "00b534687273409fbc18960bb7db0907",
-      "a27b96cc3ce944549ba2d26f5d7338c2",
-      "75f27178134f477db58ef7cfc487897b",
-      "e2816b9d2a21443c82b547466c3347d1",
-      "0a9b8aa436604adc85c1f9a86a9889a6",
-      "37e5517b0c7b45e0ad3366d4daf5b668",
-      "58f9c1e1f51f49c48c6dc6b441078218",
-      "a8114c2300b74599b0652601806b080e",
-      "e211cf2a0e6d4d1096bfb9dfaae00cbb",
-      "f63c59800b0845b8bc8d9c2cce8bafc0",
-      "1f7ba17ad64c4ab68fe963eaf7a1efa7",
-      "05d146ed0f084dac8845c32c4bb28cff",
-      "d05d9073ecd2434da541da9d71c3a907",
-      "52a56e10c8084ce999802b6db17ab78e",
-      "84e4dc1690b642b7b00f5e1cedff91e8",
-      "0ab7b921de994f6980493fb89d3b8572",
-      "6ff193e5c339435cba696e69b4a1ea20",
-      "7ebc91105d344011898341ce4f7edce0",
-      "ae72de3e05a4461d9c2b0c1f953894b2",
-      "69d7c03c926e441a9bccfbe86fd5731d",
-      "9e0ba3c3e2a84f43ae708c89203c814a",
-      "b2b8a580aa1944e6a00106f47070935c",
-      "cf7adc55be354c75b64d9a94285ea8f9",
-      "770d6b0784674359a669f3f1836a5876",
-      "c60fc7a6181a40d489ff43af79ff29b4",
-      "4ffcc071ec56449ba865c876bc5cff5c",
-      "a9c792cb80884e0899da0f40d9472e97",
-      "7ba192f9998e41b782db482b60655f86",
-      "737a0eaff10c4237a67cbd680160ee91"
-     ]
-    },
-    "id": "_h1e-L9yZfaY",
-    "outputId": "fd540dd7-a0aa-4827-e001-f6d4ef603c6a"
-   },
-   "outputs": [],
-   "source": [
-    "from langchain_huggingface import HuggingFaceEmbeddings\n",
-    "\n",
-    "embeddings = HuggingFaceEmbeddings(model_name=\"sentence-transformers/all-MiniLM-L6-v2\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "Qrj-jeGmBRTL"
-   },
-   "source": [
-    "## Vector Search with LangChain\n",
-    "### Create Redis vector store instance\n",
-    "\n",
-    "We also need to create a schema for the vector index so we can take advantage of the metadata along with the vectors.\n",
-    "\n",
-    "**Important Note**: LangChain does not support JSON data types yet. Only supports HASH for now. This update should be coming soon."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "id": "yY69FViAjNv1",
-    "outputId": "ab7b212b-3c55-44b1-cf72-6eb926cf302f"
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "16:18:04 redisvl.index.index INFO   Index already exists, not overwriting.\n"
-     ]
-    }
-   ],
-   "source": [
-    "from langchain_redis import RedisVectorStore\n",
-    "\n",
-    "index_name = \"langchain_ex\"\n",
-    "\n",
-    "# construct the vector store class from texts and metadata\n",
-    "rds = RedisVectorStore.from_documents(\n",
-    "    chunks,\n",
-    "    embeddings,\n",
-    "    index_name=index_name,\n",
-    "    redis_url=REDIS_URL,\n",
-    "    metadata_schema=[\n",
-    "        {\n",
-    "            \"name\": \"source\",\n",
-    "            \"type\": \"text\"\n",
-    "        },\n",
-    "    ]\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "id": "gntcxF1P1vmx",
-    "outputId": "3bef4861-8778-4ab7-fb61-710aba655f2c"
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "1123"
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "R2-i8jBl9GRH"
+      },
+      "source": [
+        "![Redis](https://redis.io/wp-content/uploads/2024/04/Logotype.svg?auto=webp&quality=85,75&width=120)\n",
+        "# RAG with LangChain\n",
+        "\n",
+        "This notebook uses [LangChain](https://python.langchain.com/docs/get_started/introduction) and [Redis](https://redis.com) to perform document + embdding indexing and semantic search tasks. It also shows how to integrate with an LLM like OpenAI's GPT models. See the full partner package source code [here](https://github.com/langchain-ai/langchain-redis/tree/main).\n",
+        "\n",
+        "## Let's Begin!\n",
+        "<a href=\"https://colab.research.google.com/github/redis-developer/redis-ai-resources/blob/main/python-recipes/RAG/02_langchain.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
       ]
-     },
-     "execution_count": 6,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "# access underlying redis client to see how many docs have been stores\n",
-    "rds._index.client.dbsize()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "61xV5qyp1vmy"
-   },
-   "source": [
-    "### Query the database\n",
-    "Now we can use the LangChain vector store class to perform similarity search operations on Redis"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {
-    "id": "Gv6SxKOB1vmy"
-   },
-   "outputs": [],
-   "source": [
-    "from redisvl.query.filter import Text"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 8,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
     },
-    "id": "Q3pH3MPD1vmy",
-    "outputId": "2754347f-be31-4a38-d356-31ecc235ffe8"
-   },
-   "outputs": [
     {
-     "data": {
-      "text/plain": [
-       "[(Document(metadata={'source': 'resources/nke-10k-2023.pdf'}, page_content=\"(Dollars in millions, except per share data)\\n\\nRevenues Cost of sales\\n\\nGross profit Gross margin\\n\\nDemand creation expense Operating overhead expense\\n\\nTotal selling and administrative expense % of revenues\\n\\nInterest expense (income), net\\n\\nOther (income) expense, net Income before income taxes\\n\\nIncome tax expense Effective tax rate\\n\\nNET INCOME Diluted earnings per common share\\n\\n$\\n\\n$ $\\n\\nFISCAL 2023\\n\\n51,217 28,925\\n\\n22,292\\n\\n43.5 %\\n\\n4,060 12,317\\n\\n16,377\\n\\n32.0 % (6)\\n\\n(280) 6,201\\n\\n1,131\\n\\n18.2 %\\n\\n5,070 3.23\\n\\n$\\n\\n$ $\\n\\nFISCAL 2022\\n\\n46,710 25,231\\n\\n21,479\\n\\n46.0 %\\n\\n3,850 10,954\\n\\n14,804\\n\\n31.7 % 205\\n\\n(181) 6,651\\n\\n605 9.1 %\\n\\n6,046 3.75\\n\\n% CHANGE\\n\\n10 % $ 15 %\\n\\n4 %\\n\\n5 % 12 %\\n\\n11 %\\n\\n—\\n\\n— -7 %\\n\\n87 %\\n\\n16 % $ -14 % $\\n\\nFISCAL 2021\\n\\n% CHANGE\\n\\n44,538 24,576\\n\\n5 % 3 %\\n\\n19,962\\n\\n8 %\\n\\n44.8 %\\n\\n3,114 9,911\\n\\n24 % 11 %\\n\\n13,025\\n\\n14 %\\n\\n29.2 % 262\\n\\n—\\n\\n14 6,661\\n\\n— 0 %\\n\\n934 14.0 %\\n\\n35 %\\n\\n5,727 3.56\\n\\n6 % 5 %\\n\\n2023 FORM 10-K 31\\n\\nTable of Contents\\n\\nCONSOLIDATED OPERATING RESULTS REVENUES\\n\\n(Dollars in millions)\\n\\nFISCAL 2023\\n\\nFISCAL 2022\\n\\n% CHANGE\\n\\n% CHANGE EXCLUDING CURRENCY (1) CHANGES\\n\\nFISCAL 2021\\n\\n% CHANGE\\n\\nNIKE, Inc. Revenues:\\n\\nNIKE Brand Revenues by:\\n\\nFootwear Apparel\\n\\n$\\n\\n33,135 $ 13,843\\n\\n29,143 13,567\\n\\n14 % 2 %\\n\\n20 % $ 8 %\\n\\n28,021 12,865\\n\\n4 % 5 %\\n\\nEquipment Global Brand Divisions\\n\\n(2)\\n\\nTotal NIKE Brand Revenues\\n\\n$\\n\\n1,727 58\\n\\n48,763 $\\n\\n1,624 102 44,436\\n\\n6 % -43 % 10 %\\n\\n13 % -43 % 16 % $\\n\\n1,382 25 42,293\\n\\n18 % 308 % 5 %\\n\\nConverse Corporate\\n\\n(3)\\n\\n2,427 27\\n\\n2,346 (72)\\n\\n3 % —\\n\\n8 % —\\n\\n2,205 40\\n\\n6 % —\\n\\nTOTAL NIKE, INC. REVENUES\\n\\n$\\n\\n51,217 $\\n\\n46,710\\n\\n10 %\\n\\n16 % $\\n\\n44,538\\n\\n5 %\\n\\nSupplemental NIKE Brand Revenues Details: NIKE Brand Revenues by:\\n\\nSales to Wholesale Customers\\n\\n$\\n\\n27,397 $\\n\\n25,608\\n\\n7 %\\n\\n14 % $\\n\\n25,898\\n\\n1 %\\n\\nSales through NIKE Direct Global Brand Divisions\\n\\n(2)\\n\\n21,308 58\\n\\n18,726 102\\n\\n14 % -43 %\\n\\n20 % -43 %\\n\\n16,370 25\\n\\n14 % 308 %\\n\\nTOTAL NIKE BRAND REVENUES (1) NIKE Brand Revenues on a Wholesale Equivalent Basis :\\n\\n$\\n\\n48,763 $\\n\\n44,436\\n\\n10 %\\n\\n16 % $\\n\\n42,293\\n\\n5 %\\n\\nSales to Wholesale Customers Sales from our Wholesale Operations to NIKE Direct Operations\\n\\nTOTAL NIKE BRAND WHOLESALE EQUIVALENT REVENUES NIKE Brand Wholesale Equivalent Revenues by:\\n\\n(1),(4)\\n\\n$\\n\\n$\\n\\n27,397 $ 12,730\\n\\n40,127 $\\n\\n25,608 10,543\\n\\n36,151\\n\\n7 % 21 %\\n\\n11 %\\n\\n14 % $ 27 %\\n\\n18 % $\\n\\n25,898 9,872\\n\\n35,770\\n\\n1 % 7 % 1 %\\n\\nMen's Women's NIKE Kids'\\n\\n$\\n\\n20,733 $ 8,606 5,038\\n\\n18,797 8,273 4,874\\n\\n10 % 4 % 3 %\\n\\n17 % $ 11 % 10 %\\n\\n18,391 8,225 4,882\\n\\n2 % 1 % 0 %\\n\\nJordan Brand (5) Others\\n\\n6,589 (839)\\n\\n5,122 (915)\\n\\n29 % 8 %\\n\\n35 % -3 %\"),\n",
-       "  0.499011814594),\n",
-       " (Document(metadata={'source': 'resources/nke-10k-2023.pdf'}, page_content=\"(Dollars in millions, except per share data)\\n\\nRevenues Cost of sales\\n\\nGross profit Gross margin\\n\\nDemand creation expense Operating overhead expense\\n\\nTotal selling and administrative expense % of revenues\\n\\nInterest expense (income), net\\n\\nOther (income) expense, net Income before income taxes\\n\\nIncome tax expense Effective tax rate\\n\\nNET INCOME Diluted earnings per common share\\n\\n$\\n\\n$ $\\n\\nFISCAL 2023\\n\\n51,217 28,925\\n\\n22,292\\n\\n43.5 %\\n\\n4,060 12,317\\n\\n16,377\\n\\n32.0 % (6)\\n\\n(280) 6,201\\n\\n1,131\\n\\n18.2 %\\n\\n5,070 3.23\\n\\n$\\n\\n$ $\\n\\nFISCAL 2022\\n\\n46,710 25,231\\n\\n21,479\\n\\n46.0 %\\n\\n3,850 10,954\\n\\n14,804\\n\\n31.7 % 205\\n\\n(181) 6,651\\n\\n605 9.1 %\\n\\n6,046 3.75\\n\\n% CHANGE\\n\\n10 % $ 15 %\\n\\n4 %\\n\\n5 % 12 %\\n\\n11 %\\n\\n—\\n\\n— -7 %\\n\\n87 %\\n\\n16 % $ -14 % $\\n\\nFISCAL 2021\\n\\n% CHANGE\\n\\n44,538 24,576\\n\\n5 % 3 %\\n\\n19,962\\n\\n8 %\\n\\n44.8 %\\n\\n3,114 9,911\\n\\n24 % 11 %\\n\\n13,025\\n\\n14 %\\n\\n29.2 % 262\\n\\n—\\n\\n14 6,661\\n\\n— 0 %\\n\\n934 14.0 %\\n\\n35 %\\n\\n5,727 3.56\\n\\n6 % 5 %\\n\\n2023 FORM 10-K 31\\n\\nTable of Contents\\n\\nCONSOLIDATED OPERATING RESULTS REVENUES\\n\\n(Dollars in millions)\\n\\nFISCAL 2023\\n\\nFISCAL 2022\\n\\n% CHANGE\\n\\n% CHANGE EXCLUDING CURRENCY (1) CHANGES\\n\\nFISCAL 2021\\n\\n% CHANGE\\n\\nNIKE, Inc. Revenues:\\n\\nNIKE Brand Revenues by:\\n\\nFootwear Apparel\\n\\n$\\n\\n33,135 $ 13,843\\n\\n29,143 13,567\\n\\n14 % 2 %\\n\\n20 % $ 8 %\\n\\n28,021 12,865\\n\\n4 % 5 %\\n\\nEquipment Global Brand Divisions\\n\\n(2)\\n\\nTotal NIKE Brand Revenues\\n\\n$\\n\\n1,727 58\\n\\n48,763 $\\n\\n1,624 102 44,436\\n\\n6 % -43 % 10 %\\n\\n13 % -43 % 16 % $\\n\\n1,382 25 42,293\\n\\n18 % 308 % 5 %\\n\\nConverse Corporate\\n\\n(3)\\n\\n2,427 27\\n\\n2,346 (72)\\n\\n3 % —\\n\\n8 % —\\n\\n2,205 40\\n\\n6 % —\\n\\nTOTAL NIKE, INC. REVENUES\\n\\n$\\n\\n51,217 $\\n\\n46,710\\n\\n10 %\\n\\n16 % $\\n\\n44,538\\n\\n5 %\\n\\nSupplemental NIKE Brand Revenues Details: NIKE Brand Revenues by:\\n\\nSales to Wholesale Customers\\n\\n$\\n\\n27,397 $\\n\\n25,608\\n\\n7 %\\n\\n14 % $\\n\\n25,898\\n\\n1 %\\n\\nSales through NIKE Direct Global Brand Divisions\\n\\n(2)\\n\\n21,308 58\\n\\n18,726 102\\n\\n14 % -43 %\\n\\n20 % -43 %\\n\\n16,370 25\\n\\n14 % 308 %\\n\\nTOTAL NIKE BRAND REVENUES (1) NIKE Brand Revenues on a Wholesale Equivalent Basis :\\n\\n$\\n\\n48,763 $\\n\\n44,436\\n\\n10 %\\n\\n16 % $\\n\\n42,293\\n\\n5 %\\n\\nSales to Wholesale Customers Sales from our Wholesale Operations to NIKE Direct Operations\\n\\nTOTAL NIKE BRAND WHOLESALE EQUIVALENT REVENUES NIKE Brand Wholesale Equivalent Revenues by:\\n\\n(1),(4)\\n\\n$\\n\\n$\\n\\n27,397 $ 12,730\\n\\n40,127 $\\n\\n25,608 10,543\\n\\n36,151\\n\\n7 % 21 %\\n\\n11 %\\n\\n14 % $ 27 %\\n\\n18 % $\\n\\n25,898 9,872\\n\\n35,770\\n\\n1 % 7 % 1 %\\n\\nMen's Women's NIKE Kids'\\n\\n$\\n\\n20,733 $ 8,606 5,038\\n\\n18,797 8,273 4,874\\n\\n10 % 4 % 3 %\\n\\n17 % $ 11 % 10 %\\n\\n18,391 8,225 4,882\\n\\n2 % 1 % 0 %\\n\\nJordan Brand (5) Others\\n\\n6,589 (839)\\n\\n5,122 (915)\\n\\n29 % 8 %\\n\\n35 % -3 %\"),\n",
-       "  0.499011814594),\n",
-       " (Document(metadata={'source': 'resources/nke-10k-2023.pdf'}, page_content=\"(Dollars in millions, except per share data)\\n\\nRevenues Cost of sales\\n\\nGross profit Gross margin\\n\\nDemand creation expense Operating overhead expense\\n\\nTotal selling and administrative expense % of revenues\\n\\nInterest expense (income), net\\n\\nOther (income) expense, net Income before income taxes\\n\\nIncome tax expense Effective tax rate\\n\\nNET INCOME Diluted earnings per common share\\n\\n$\\n\\n$ $\\n\\nFISCAL 2023\\n\\n51,217 28,925\\n\\n22,292\\n\\n43.5 %\\n\\n4,060 12,317\\n\\n16,377\\n\\n32.0 % (6)\\n\\n(280) 6,201\\n\\n1,131\\n\\n18.2 %\\n\\n5,070 3.23\\n\\n$\\n\\n$ $\\n\\nFISCAL 2022\\n\\n46,710 25,231\\n\\n21,479\\n\\n46.0 %\\n\\n3,850 10,954\\n\\n14,804\\n\\n31.7 % 205\\n\\n(181) 6,651\\n\\n605 9.1 %\\n\\n6,046 3.75\\n\\n% CHANGE\\n\\n10 % $ 15 %\\n\\n4 %\\n\\n5 % 12 %\\n\\n11 %\\n\\n—\\n\\n— -7 %\\n\\n87 %\\n\\n16 % $ -14 % $\\n\\nFISCAL 2021\\n\\n% CHANGE\\n\\n44,538 24,576\\n\\n5 % 3 %\\n\\n19,962\\n\\n8 %\\n\\n44.8 %\\n\\n3,114 9,911\\n\\n24 % 11 %\\n\\n13,025\\n\\n14 %\\n\\n29.2 % 262\\n\\n—\\n\\n14 6,661\\n\\n— 0 %\\n\\n934 14.0 %\\n\\n35 %\\n\\n5,727 3.56\\n\\n6 % 5 %\\n\\n2023 FORM 10-K 31\\n\\nTable of Contents\\n\\nCONSOLIDATED OPERATING RESULTS REVENUES\\n\\n(Dollars in millions)\\n\\nFISCAL 2023\\n\\nFISCAL 2022\\n\\n% CHANGE\\n\\n% CHANGE EXCLUDING CURRENCY (1) CHANGES\\n\\nFISCAL 2021\\n\\n% CHANGE\\n\\nNIKE, Inc. Revenues:\\n\\nNIKE Brand Revenues by:\\n\\nFootwear Apparel\\n\\n$\\n\\n33,135 $ 13,843\\n\\n29,143 13,567\\n\\n14 % 2 %\\n\\n20 % $ 8 %\\n\\n28,021 12,865\\n\\n4 % 5 %\\n\\nEquipment Global Brand Divisions\\n\\n(2)\\n\\nTotal NIKE Brand Revenues\\n\\n$\\n\\n1,727 58\\n\\n48,763 $\\n\\n1,624 102 44,436\\n\\n6 % -43 % 10 %\\n\\n13 % -43 % 16 % $\\n\\n1,382 25 42,293\\n\\n18 % 308 % 5 %\\n\\nConverse Corporate\\n\\n(3)\\n\\n2,427 27\\n\\n2,346 (72)\\n\\n3 % —\\n\\n8 % —\\n\\n2,205 40\\n\\n6 % —\\n\\nTOTAL NIKE, INC. REVENUES\\n\\n$\\n\\n51,217 $\\n\\n46,710\\n\\n10 %\\n\\n16 % $\\n\\n44,538\\n\\n5 %\\n\\nSupplemental NIKE Brand Revenues Details: NIKE Brand Revenues by:\\n\\nSales to Wholesale Customers\\n\\n$\\n\\n27,397 $\\n\\n25,608\\n\\n7 %\\n\\n14 % $\\n\\n25,898\\n\\n1 %\\n\\nSales through NIKE Direct Global Brand Divisions\\n\\n(2)\\n\\n21,308 58\\n\\n18,726 102\\n\\n14 % -43 %\\n\\n20 % -43 %\\n\\n16,370 25\\n\\n14 % 308 %\\n\\nTOTAL NIKE BRAND REVENUES (1) NIKE Brand Revenues on a Wholesale Equivalent Basis :\\n\\n$\\n\\n48,763 $\\n\\n44,436\\n\\n10 %\\n\\n16 % $\\n\\n42,293\\n\\n5 %\\n\\nSales to Wholesale Customers Sales from our Wholesale Operations to NIKE Direct Operations\\n\\nTOTAL NIKE BRAND WHOLESALE EQUIVALENT REVENUES NIKE Brand Wholesale Equivalent Revenues by:\\n\\n(1),(4)\\n\\n$\\n\\n$\\n\\n27,397 $ 12,730\\n\\n40,127 $\\n\\n25,608 10,543\\n\\n36,151\\n\\n7 % 21 %\\n\\n11 %\\n\\n14 % $ 27 %\\n\\n18 % $\\n\\n25,898 9,872\\n\\n35,770\\n\\n1 % 7 % 1 %\\n\\nMen's Women's NIKE Kids'\\n\\n$\\n\\n20,733 $ 8,606 5,038\\n\\n18,797 8,273 4,874\\n\\n10 % 4 % 3 %\\n\\n17 % $ 11 % 10 %\\n\\n18,391 8,225 4,882\\n\\n2 % 1 % 0 %\\n\\nJordan Brand (5) Others\\n\\n6,589 (839)\\n\\n5,122 (915)\\n\\n29 % 8 %\\n\\n35 % -3 %\"),\n",
-       "  0.499011814594),\n",
-       " (Document(metadata={'source': 'resources/nke-10k-2023.pdf'}, page_content=\"Tax (expense) benefit Gain (loss) net of tax\\n\\n5 (14)\\n\\n(9) 22\\n\\nTotal net gain (loss) reclassified for the period\\n\\n$\\n\\n463 $\\n\\n30\\n\\n2023 FORM 10-K 82\\n\\nTable of Contents\\n\\nNOTE 14 — REVENUES\\n\\nDISAGGREGATION OF REVENUES The following tables present the Company's Revenues disaggregated by reportable operating segment, major product line and distribution channel:\\n\\n(Dollars in millions)\\n\\nNORTH AMERICA\\n\\nEUROPE, MIDDLE EAST & AFRICA\\n\\nGREATER CHINA\\n\\nYEAR ENDED MAY 31, 2023 ASIA PACIFIC & LATIN (1)\\n\\nGLOBAL BRAND DIVISIONS\\n\\nTOTAL NIKE\\n\\nAMERICA\\n\\nBRAND CONVERSE CORPORATE\\n\\nTOTAL NIKE, INC.\\n\\nRevenues by: Footwear\\n\\n$\\n\\n14,897 $\\n\\n8,260 $\\n\\n5,435 $\\n\\n4,543 $\\n\\n— $\\n\\n33,135 $\\n\\n2,155 $\\n\\n— $\\n\\n35,290\\n\\nApparel Equipment Other\\n\\n5,947 764 —\\n\\n4,566 592 —\\n\\n1,666 147 —\\n\\n1,664 224 —\\n\\n— — 58\\n\\n13,843 1,727 58\\n\\n90 28 154\\n\\n— — 27\\n\\n13,933 1,755 239\\n\\nTOTAL REVENUES\\n\\n$\\n\\n21,608 $\\n\\n13,418 $\\n\\n7,248 $\\n\\n6,431 $\\n\\n58 $\\n\\n48,763 $\\n\\n2,427 $\\n\\n27 $\\n\\n51,217\\n\\nRevenues by:\\n\\nSales to Wholesale Customers Sales through Direct to Consumer\\n\\n$\\n\\n11,273 $ 10,335\\n\\n8,522 $ 4,896\\n\\n3,866 $ 3,382\\n\\n3,736 $ 2,695\\n\\n— $ —\\n\\n27,397 $ 21,308\\n\\n1,299 $ 974\\n\\n— $ —\\n\\n28,696 22,282\\n\\nOther\\n\\nTOTAL REVENUES\\n\\n$\\n\\n—\\n\\n21,608 $\\n\\n—\\n\\n13,418 $\\n\\n— 7,248 $\\n\\n— 6,431 $\\n\\n58 58 $\\n\\n58\\n\\n48,763 $\\n\\n154 2,427 $\\n\\n27 27 $\\n\\n239 51,217\\n\\n(1) Refer to Note 18 — Acquisitions and Divestitures for additional information on the transition of the Company's NIKE Brand businesses in its CASA territory to third-party distributors.\\n\\nYEAR ENDED MAY 31, 2022\\n\\n(Dollars in millions)\\n\\nNORTH AMERICA\\n\\nEUROPE, MIDDLE EAST & AFRICA\\n\\nGREATER CHINA\\n\\nASIA PACIFIC & LATIN AMERICA\\n\\nGLOBAL BRAND DIVISIONS\\n\\nTOTAL NIKE\\n\\nBRAND CONVERSE CORPORATE\\n\\nTOTAL NIKE, INC.\\n\\nRevenues by: Footwear Apparel\\n\\n$\\n\\n12,228 $ 5,492\\n\\n7,388 $ 4,527\\n\\n5,416 $ 1,938\\n\\n4,111 $ 1,610\\n\\n— $ —\\n\\n29,143 $ 13,567\\n\\n2,094 $ 103\\n\\n— $ —\\n\\n31,237 13,670\\n\\nEquipment Other\\n\\n633 —\\n\\n564 —\\n\\n193 —\\n\\n234 —\\n\\n— 102\\n\\n1,624 102\\n\\n26 123\\n\\n— (72)\\n\\n1,650 153\\n\\nTOTAL REVENUES Revenues by:\\n\\n$\\n\\n18,353 $\\n\\n12,479 $\\n\\n7,547 $\\n\\n5,955 $\\n\\n102 $\\n\\n44,436 $\\n\\n2,346 $\\n\\n(72) $\\n\\n46,710\\n\\nSales to Wholesale Customers Sales through Direct to Consumer Other\\n\\n$\\n\\n9,621 $ 8,732 —\\n\\n8,377 $ 4,102 —\\n\\n4,081 $ 3,466 —\\n\\n3,529 $ 2,426 —\\n\\n— $ — 102\\n\\n25,608 $ 18,726 102\\n\\n1,292 $ 931 123\\n\\n— $ — (72)\\n\\n26,900 19,657 153\\n\\nTOTAL REVENUES\\n\\n$\\n\\n18,353 $\\n\\n12,479 $\\n\\n7,547 $\\n\\n5,955 $\\n\\n102 $\\n\\n44,436 $\\n\\n2,346 $\\n\\n(72) $\\n\\n46,710\\n\\n2023 FORM 10-K 83\\n\\nTable of Contents\\n\\nYEAR ENDED MAY 31, 2021\\n\\n(Dollars in millions)\\n\\nNORTH AMERICA\\n\\nEUROPE, MIDDLE EAST & AFRICA\\n\\nGREATER CHINA\"),\n",
-       "  0.529603242874)]"
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "ctOVb_LZ1vmk"
+      },
+      "source": [
+        "## Environment Setup\n",
+        "\n",
+        "### Pull Github Materials\n",
+        "Because you are likely running this notebook in **Google Colab**, we need to first\n",
+        "pull the necessary dataset and materials directly from GitHub. The following commands grab the material, move to root for colab, and clean up unneeded files.\n",
+        "\n",
+        "**If you are running this notebook locally**, FYI you may not need to perform this\n",
+        "step at all."
       ]
-     },
-     "execution_count": 8,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "# basic \"top 4\" vector search on a given query\n",
-    "rds.similarity_search_with_score(query=\"Profit margins\", k=4)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 9,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
     },
-    "id": "od6Wqmya1vmy",
-    "outputId": "5dbac581-4a07-45b0-d630-995342e91dc7"
-   },
-   "outputs": [
     {
-     "data": {
-      "text/plain": [
-       "[(Document(metadata={'source': 'resources/nke-10k-2023.pdf'}, page_content=\"(Dollars in millions, except per share data)\\n\\nRevenues Cost of sales\\n\\nGross profit Gross margin\\n\\nDemand creation expense Operating overhead expense\\n\\nTotal selling and administrative expense % of revenues\\n\\nInterest expense (income), net\\n\\nOther (income) expense, net Income before income taxes\\n\\nIncome tax expense Effective tax rate\\n\\nNET INCOME Diluted earnings per common share\\n\\n$\\n\\n$ $\\n\\nFISCAL 2023\\n\\n51,217 28,925\\n\\n22,292\\n\\n43.5 %\\n\\n4,060 12,317\\n\\n16,377\\n\\n32.0 % (6)\\n\\n(280) 6,201\\n\\n1,131\\n\\n18.2 %\\n\\n5,070 3.23\\n\\n$\\n\\n$ $\\n\\nFISCAL 2022\\n\\n46,710 25,231\\n\\n21,479\\n\\n46.0 %\\n\\n3,850 10,954\\n\\n14,804\\n\\n31.7 % 205\\n\\n(181) 6,651\\n\\n605 9.1 %\\n\\n6,046 3.75\\n\\n% CHANGE\\n\\n10 % $ 15 %\\n\\n4 %\\n\\n5 % 12 %\\n\\n11 %\\n\\n—\\n\\n— -7 %\\n\\n87 %\\n\\n16 % $ -14 % $\\n\\nFISCAL 2021\\n\\n% CHANGE\\n\\n44,538 24,576\\n\\n5 % 3 %\\n\\n19,962\\n\\n8 %\\n\\n44.8 %\\n\\n3,114 9,911\\n\\n24 % 11 %\\n\\n13,025\\n\\n14 %\\n\\n29.2 % 262\\n\\n—\\n\\n14 6,661\\n\\n— 0 %\\n\\n934 14.0 %\\n\\n35 %\\n\\n5,727 3.56\\n\\n6 % 5 %\\n\\n2023 FORM 10-K 31\\n\\nTable of Contents\\n\\nCONSOLIDATED OPERATING RESULTS REVENUES\\n\\n(Dollars in millions)\\n\\nFISCAL 2023\\n\\nFISCAL 2022\\n\\n% CHANGE\\n\\n% CHANGE EXCLUDING CURRENCY (1) CHANGES\\n\\nFISCAL 2021\\n\\n% CHANGE\\n\\nNIKE, Inc. Revenues:\\n\\nNIKE Brand Revenues by:\\n\\nFootwear Apparel\\n\\n$\\n\\n33,135 $ 13,843\\n\\n29,143 13,567\\n\\n14 % 2 %\\n\\n20 % $ 8 %\\n\\n28,021 12,865\\n\\n4 % 5 %\\n\\nEquipment Global Brand Divisions\\n\\n(2)\\n\\nTotal NIKE Brand Revenues\\n\\n$\\n\\n1,727 58\\n\\n48,763 $\\n\\n1,624 102 44,436\\n\\n6 % -43 % 10 %\\n\\n13 % -43 % 16 % $\\n\\n1,382 25 42,293\\n\\n18 % 308 % 5 %\\n\\nConverse Corporate\\n\\n(3)\\n\\n2,427 27\\n\\n2,346 (72)\\n\\n3 % —\\n\\n8 % —\\n\\n2,205 40\\n\\n6 % —\\n\\nTOTAL NIKE, INC. REVENUES\\n\\n$\\n\\n51,217 $\\n\\n46,710\\n\\n10 %\\n\\n16 % $\\n\\n44,538\\n\\n5 %\\n\\nSupplemental NIKE Brand Revenues Details: NIKE Brand Revenues by:\\n\\nSales to Wholesale Customers\\n\\n$\\n\\n27,397 $\\n\\n25,608\\n\\n7 %\\n\\n14 % $\\n\\n25,898\\n\\n1 %\\n\\nSales through NIKE Direct Global Brand Divisions\\n\\n(2)\\n\\n21,308 58\\n\\n18,726 102\\n\\n14 % -43 %\\n\\n20 % -43 %\\n\\n16,370 25\\n\\n14 % 308 %\\n\\nTOTAL NIKE BRAND REVENUES (1) NIKE Brand Revenues on a Wholesale Equivalent Basis :\\n\\n$\\n\\n48,763 $\\n\\n44,436\\n\\n10 %\\n\\n16 % $\\n\\n42,293\\n\\n5 %\\n\\nSales to Wholesale Customers Sales from our Wholesale Operations to NIKE Direct Operations\\n\\nTOTAL NIKE BRAND WHOLESALE EQUIVALENT REVENUES NIKE Brand Wholesale Equivalent Revenues by:\\n\\n(1),(4)\\n\\n$\\n\\n$\\n\\n27,397 $ 12,730\\n\\n40,127 $\\n\\n25,608 10,543\\n\\n36,151\\n\\n7 % 21 %\\n\\n11 %\\n\\n14 % $ 27 %\\n\\n18 % $\\n\\n25,898 9,872\\n\\n35,770\\n\\n1 % 7 % 1 %\\n\\nMen's Women's NIKE Kids'\\n\\n$\\n\\n20,733 $ 8,606 5,038\\n\\n18,797 8,273 4,874\\n\\n10 % 4 % 3 %\\n\\n17 % $ 11 % 10 %\\n\\n18,391 8,225 4,882\\n\\n2 % 1 % 0 %\\n\\nJordan Brand (5) Others\\n\\n6,589 (839)\\n\\n5,122 (915)\\n\\n29 % 8 %\\n\\n35 % -3 %\"),\n",
-       "  0.499011814594),\n",
-       " (Document(metadata={'source': 'resources/nke-10k-2023.pdf'}, page_content=\"(Dollars in millions, except per share data)\\n\\nRevenues Cost of sales\\n\\nGross profit Gross margin\\n\\nDemand creation expense Operating overhead expense\\n\\nTotal selling and administrative expense % of revenues\\n\\nInterest expense (income), net\\n\\nOther (income) expense, net Income before income taxes\\n\\nIncome tax expense Effective tax rate\\n\\nNET INCOME Diluted earnings per common share\\n\\n$\\n\\n$ $\\n\\nFISCAL 2023\\n\\n51,217 28,925\\n\\n22,292\\n\\n43.5 %\\n\\n4,060 12,317\\n\\n16,377\\n\\n32.0 % (6)\\n\\n(280) 6,201\\n\\n1,131\\n\\n18.2 %\\n\\n5,070 3.23\\n\\n$\\n\\n$ $\\n\\nFISCAL 2022\\n\\n46,710 25,231\\n\\n21,479\\n\\n46.0 %\\n\\n3,850 10,954\\n\\n14,804\\n\\n31.7 % 205\\n\\n(181) 6,651\\n\\n605 9.1 %\\n\\n6,046 3.75\\n\\n% CHANGE\\n\\n10 % $ 15 %\\n\\n4 %\\n\\n5 % 12 %\\n\\n11 %\\n\\n—\\n\\n— -7 %\\n\\n87 %\\n\\n16 % $ -14 % $\\n\\nFISCAL 2021\\n\\n% CHANGE\\n\\n44,538 24,576\\n\\n5 % 3 %\\n\\n19,962\\n\\n8 %\\n\\n44.8 %\\n\\n3,114 9,911\\n\\n24 % 11 %\\n\\n13,025\\n\\n14 %\\n\\n29.2 % 262\\n\\n—\\n\\n14 6,661\\n\\n— 0 %\\n\\n934 14.0 %\\n\\n35 %\\n\\n5,727 3.56\\n\\n6 % 5 %\\n\\n2023 FORM 10-K 31\\n\\nTable of Contents\\n\\nCONSOLIDATED OPERATING RESULTS REVENUES\\n\\n(Dollars in millions)\\n\\nFISCAL 2023\\n\\nFISCAL 2022\\n\\n% CHANGE\\n\\n% CHANGE EXCLUDING CURRENCY (1) CHANGES\\n\\nFISCAL 2021\\n\\n% CHANGE\\n\\nNIKE, Inc. Revenues:\\n\\nNIKE Brand Revenues by:\\n\\nFootwear Apparel\\n\\n$\\n\\n33,135 $ 13,843\\n\\n29,143 13,567\\n\\n14 % 2 %\\n\\n20 % $ 8 %\\n\\n28,021 12,865\\n\\n4 % 5 %\\n\\nEquipment Global Brand Divisions\\n\\n(2)\\n\\nTotal NIKE Brand Revenues\\n\\n$\\n\\n1,727 58\\n\\n48,763 $\\n\\n1,624 102 44,436\\n\\n6 % -43 % 10 %\\n\\n13 % -43 % 16 % $\\n\\n1,382 25 42,293\\n\\n18 % 308 % 5 %\\n\\nConverse Corporate\\n\\n(3)\\n\\n2,427 27\\n\\n2,346 (72)\\n\\n3 % —\\n\\n8 % —\\n\\n2,205 40\\n\\n6 % —\\n\\nTOTAL NIKE, INC. REVENUES\\n\\n$\\n\\n51,217 $\\n\\n46,710\\n\\n10 %\\n\\n16 % $\\n\\n44,538\\n\\n5 %\\n\\nSupplemental NIKE Brand Revenues Details: NIKE Brand Revenues by:\\n\\nSales to Wholesale Customers\\n\\n$\\n\\n27,397 $\\n\\n25,608\\n\\n7 %\\n\\n14 % $\\n\\n25,898\\n\\n1 %\\n\\nSales through NIKE Direct Global Brand Divisions\\n\\n(2)\\n\\n21,308 58\\n\\n18,726 102\\n\\n14 % -43 %\\n\\n20 % -43 %\\n\\n16,370 25\\n\\n14 % 308 %\\n\\nTOTAL NIKE BRAND REVENUES (1) NIKE Brand Revenues on a Wholesale Equivalent Basis :\\n\\n$\\n\\n48,763 $\\n\\n44,436\\n\\n10 %\\n\\n16 % $\\n\\n42,293\\n\\n5 %\\n\\nSales to Wholesale Customers Sales from our Wholesale Operations to NIKE Direct Operations\\n\\nTOTAL NIKE BRAND WHOLESALE EQUIVALENT REVENUES NIKE Brand Wholesale Equivalent Revenues by:\\n\\n(1),(4)\\n\\n$\\n\\n$\\n\\n27,397 $ 12,730\\n\\n40,127 $\\n\\n25,608 10,543\\n\\n36,151\\n\\n7 % 21 %\\n\\n11 %\\n\\n14 % $ 27 %\\n\\n18 % $\\n\\n25,898 9,872\\n\\n35,770\\n\\n1 % 7 % 1 %\\n\\nMen's Women's NIKE Kids'\\n\\n$\\n\\n20,733 $ 8,606 5,038\\n\\n18,797 8,273 4,874\\n\\n10 % 4 % 3 %\\n\\n17 % $ 11 % 10 %\\n\\n18,391 8,225 4,882\\n\\n2 % 1 % 0 %\\n\\nJordan Brand (5) Others\\n\\n6,589 (839)\\n\\n5,122 (915)\\n\\n29 % 8 %\\n\\n35 % -3 %\"),\n",
-       "  0.499011814594),\n",
-       " (Document(metadata={'source': 'resources/nke-10k-2023.pdf'}, page_content=\"(Dollars in millions, except per share data)\\n\\nRevenues Cost of sales\\n\\nGross profit Gross margin\\n\\nDemand creation expense Operating overhead expense\\n\\nTotal selling and administrative expense % of revenues\\n\\nInterest expense (income), net\\n\\nOther (income) expense, net Income before income taxes\\n\\nIncome tax expense Effective tax rate\\n\\nNET INCOME Diluted earnings per common share\\n\\n$\\n\\n$ $\\n\\nFISCAL 2023\\n\\n51,217 28,925\\n\\n22,292\\n\\n43.5 %\\n\\n4,060 12,317\\n\\n16,377\\n\\n32.0 % (6)\\n\\n(280) 6,201\\n\\n1,131\\n\\n18.2 %\\n\\n5,070 3.23\\n\\n$\\n\\n$ $\\n\\nFISCAL 2022\\n\\n46,710 25,231\\n\\n21,479\\n\\n46.0 %\\n\\n3,850 10,954\\n\\n14,804\\n\\n31.7 % 205\\n\\n(181) 6,651\\n\\n605 9.1 %\\n\\n6,046 3.75\\n\\n% CHANGE\\n\\n10 % $ 15 %\\n\\n4 %\\n\\n5 % 12 %\\n\\n11 %\\n\\n—\\n\\n— -7 %\\n\\n87 %\\n\\n16 % $ -14 % $\\n\\nFISCAL 2021\\n\\n% CHANGE\\n\\n44,538 24,576\\n\\n5 % 3 %\\n\\n19,962\\n\\n8 %\\n\\n44.8 %\\n\\n3,114 9,911\\n\\n24 % 11 %\\n\\n13,025\\n\\n14 %\\n\\n29.2 % 262\\n\\n—\\n\\n14 6,661\\n\\n— 0 %\\n\\n934 14.0 %\\n\\n35 %\\n\\n5,727 3.56\\n\\n6 % 5 %\\n\\n2023 FORM 10-K 31\\n\\nTable of Contents\\n\\nCONSOLIDATED OPERATING RESULTS REVENUES\\n\\n(Dollars in millions)\\n\\nFISCAL 2023\\n\\nFISCAL 2022\\n\\n% CHANGE\\n\\n% CHANGE EXCLUDING CURRENCY (1) CHANGES\\n\\nFISCAL 2021\\n\\n% CHANGE\\n\\nNIKE, Inc. Revenues:\\n\\nNIKE Brand Revenues by:\\n\\nFootwear Apparel\\n\\n$\\n\\n33,135 $ 13,843\\n\\n29,143 13,567\\n\\n14 % 2 %\\n\\n20 % $ 8 %\\n\\n28,021 12,865\\n\\n4 % 5 %\\n\\nEquipment Global Brand Divisions\\n\\n(2)\\n\\nTotal NIKE Brand Revenues\\n\\n$\\n\\n1,727 58\\n\\n48,763 $\\n\\n1,624 102 44,436\\n\\n6 % -43 % 10 %\\n\\n13 % -43 % 16 % $\\n\\n1,382 25 42,293\\n\\n18 % 308 % 5 %\\n\\nConverse Corporate\\n\\n(3)\\n\\n2,427 27\\n\\n2,346 (72)\\n\\n3 % —\\n\\n8 % —\\n\\n2,205 40\\n\\n6 % —\\n\\nTOTAL NIKE, INC. REVENUES\\n\\n$\\n\\n51,217 $\\n\\n46,710\\n\\n10 %\\n\\n16 % $\\n\\n44,538\\n\\n5 %\\n\\nSupplemental NIKE Brand Revenues Details: NIKE Brand Revenues by:\\n\\nSales to Wholesale Customers\\n\\n$\\n\\n27,397 $\\n\\n25,608\\n\\n7 %\\n\\n14 % $\\n\\n25,898\\n\\n1 %\\n\\nSales through NIKE Direct Global Brand Divisions\\n\\n(2)\\n\\n21,308 58\\n\\n18,726 102\\n\\n14 % -43 %\\n\\n20 % -43 %\\n\\n16,370 25\\n\\n14 % 308 %\\n\\nTOTAL NIKE BRAND REVENUES (1) NIKE Brand Revenues on a Wholesale Equivalent Basis :\\n\\n$\\n\\n48,763 $\\n\\n44,436\\n\\n10 %\\n\\n16 % $\\n\\n42,293\\n\\n5 %\\n\\nSales to Wholesale Customers Sales from our Wholesale Operations to NIKE Direct Operations\\n\\nTOTAL NIKE BRAND WHOLESALE EQUIVALENT REVENUES NIKE Brand Wholesale Equivalent Revenues by:\\n\\n(1),(4)\\n\\n$\\n\\n$\\n\\n27,397 $ 12,730\\n\\n40,127 $\\n\\n25,608 10,543\\n\\n36,151\\n\\n7 % 21 %\\n\\n11 %\\n\\n14 % $ 27 %\\n\\n18 % $\\n\\n25,898 9,872\\n\\n35,770\\n\\n1 % 7 % 1 %\\n\\nMen's Women's NIKE Kids'\\n\\n$\\n\\n20,733 $ 8,606 5,038\\n\\n18,797 8,273 4,874\\n\\n10 % 4 % 3 %\\n\\n17 % $ 11 % 10 %\\n\\n18,391 8,225 4,882\\n\\n2 % 1 % 0 %\\n\\nJordan Brand (5) Others\\n\\n6,589 (839)\\n\\n5,122 (915)\\n\\n29 % 8 %\\n\\n35 % -3 %\"),\n",
-       "  0.499011814594),\n",
-       " (Document(metadata={'source': 'resources/nke-10k-2023.pdf'}, page_content='From time to time, we may invest in technology, business infrastructure, new businesses or capabilities, product offering and manufacturing innovation and expansion of existing businesses, such as our NIKE Direct operations, which require substantial cash investments and management attention. We believe cost-effective investments are essential to business growth and profitability; however, significant investments are subject to typical risks and uncertainties inherent in developing a new business or expanding an existing business. The failure of any significant investment to provide expected returns or profitability could have a material adverse effect on our financial results and divert management attention from more profitable business operations. See also \"Our NIKE Direct operations have required and will continue to require a substantial investment and commitment of resources and are subject to numerous risks and uncertainties.\"\\n\\nThe sale of a large number of shares of common stock by our principal shareholder could depress the market price of our common stock.\\n\\nAs of June 30, 2023, Swoosh, LLC beneficially owned approximately 77% of our Class A Common Stock. If, on June 30, 2023, all of these shares were converted into Class B Common Stock, Swoosh, LLC\\'s commensurate ownership percentage of our Class B Common Stock would be approximately 16%. The shares are available for resale, subject to the requirements of the U.S. securities laws and the terms of the limited liability company agreement governing Swoosh, LLC. The sale or prospect of a sale of a substantial number of these shares could have an adverse effect on the market price of our common stock. Swoosh, LLC was formed by Philip H. Knight, our Chairman Emeritus, to hold the majority of his shares of Class A Common Stock. Mr. Knight does not have voting rights with respect to Swoosh, LLC, although Travis Knight, his son and a NIKE director, has a significant role in the management of the Class A Common Stock owned by Swoosh, LLC.\\n\\nChanges in our credit ratings or macroeconomic conditions may affect our liquidity, increasing borrowing costs and limiting our financing options.'),\n",
-       "  0.604557394981)]"
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "UQezgPCG1vml",
+        "outputId": "97b9bc03-da1b-439a-c37b-be6fdb58ab21"
+      },
+      "outputs": [],
+      "source": [
+        "# NBVAL_SKIP\n",
+        "!git clone https://github.com/redis-developer/redis-ai-resources.git temp_repo\n",
+        "!mv temp_repo/python-recipes/RAG/resources .\n",
+        "!rm -rf temp_repo"
       ]
-     },
-     "execution_count": 9,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "# vector search with metadata filtering\n",
-    "f = Text(\"text\") % \"profit\"\n",
-    "rds.similarity_search_with_score(query=\"Profit margins\", k=4, filter=f)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 10,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
     },
-    "id": "DT9sPHw51vmy",
-    "outputId": "7d2b8969-91b8-4ff7-81ba-9d0cb6280edc"
-   },
-   "outputs": [
     {
-     "data": {
-      "text/plain": [
-       "[(Document(metadata={'source': 'resources/nke-10k-2023.pdf'}, page_content='As discussed in Note 15 — Operating Segments and Related Information in the accompanying Notes to the Consolidated Financial Statements, our operating segments are evidence of the structure of the Company\\'s internal organization. The NIKE Brand segments are defined by geographic regions for operations participating in NIKE Brand sales activity.\\n\\nThe breakdown of Revenues is as follows:\\n\\n(Dollars in millions)\\n\\nFISCAL 2023 FISCAL 2022\\n\\n% CHANGE\\n\\n% CHANGE EXCLUDING CURRENCY (1) CHANGES FISCAL 2021\\n\\n% CHANGE\\n\\nNorth America Europe, Middle East & Africa Greater China\\n\\n$\\n\\n21,608 $ 13,418 7,248\\n\\n18,353 12,479 7,547\\n\\n18 % 8 % -4 %\\n\\n18 % $ 21 % 4 %\\n\\n17,179 11,456 8,290\\n\\n7 % 9 % -9 %\\n\\nAsia Pacific & Latin America Global Brand Divisions\\n\\n(3)\\n\\n(2)\\n\\n6,431 58\\n\\n5,955 102\\n\\n8 % -43 %\\n\\n17 % -43 %\\n\\n5,343 25\\n\\n11 % 308 %\\n\\nTOTAL NIKE BRAND Converse\\n\\n$\\n\\n48,763 $ 2,427\\n\\n44,436 2,346\\n\\n10 % 3 %\\n\\n16 % $ 8 %\\n\\n42,293 2,205\\n\\n5 % 6 %\\n\\n(4)\\n\\nCorporate TOTAL NIKE, INC. REVENUES\\n\\n$\\n\\n27\\n\\n51,217 $\\n\\n(72) 46,710\\n\\n— 10 %\\n\\n— 16 % $\\n\\n40 44,538\\n\\n— 5 %\\n\\n(1) The percent change excluding currency changes represents a non-GAAP financial measure. For further information, see \"Use of Non-GAAP Financial Measures\".\\n\\n(2) For additional information on the transition of our NIKE Brand businesses within our CASA territory to a third-party distributor, see Note 18 — Acquisitions and Divestitures of the Notes to Consolidated\\n\\nFinancial Statements contained in Item 8 of this Annual Report.\\n\\n(3) Global Brand Divisions revenues include NIKE Brand licensing and other miscellaneous revenues that are not part of a geographic operating segment.\\n\\n(4) Corporate revenues primarily consist of foreign currency hedge gains and losses related to revenues generated by entities within the NIKE Brand geographic operating segments and Converse, but\\n\\nmanaged through our central foreign exchange risk management program.\\n\\nThe primary financial measure used by the Company to evaluate performance is Earnings Before Interest and Taxes (\"EBIT\"). As discussed in Note 15 — Operating Segments and Related Information in the accompanying Notes to the Consolidated Financial Statements, certain corporate costs are not included in EBIT.\\n\\nThe breakdown of EBIT is as follows:\\n\\n(Dollars in millions)\\n\\nFISCAL 2023\\n\\nFISCAL 2022\\n\\n% CHANGE\\n\\nFISCAL 2021\\n\\nNorth America Europe, Middle East & Africa Greater China\\n\\n$\\n\\n5,454 3,531 2,283\\n\\n$\\n\\n5,114 3,293 2,365\\n\\n7 % $ 7 % -3 %\\n\\n5,089 2,435 3,243\\n\\nAsia Pacific & Latin America Global Brand Divisions (1)'),\n",
-       "  0.233286499977),\n",
-       " (Document(metadata={'source': 'resources/nke-10k-2023.pdf'}, page_content='As discussed in Note 15 — Operating Segments and Related Information in the accompanying Notes to the Consolidated Financial Statements, our operating segments are evidence of the structure of the Company\\'s internal organization. The NIKE Brand segments are defined by geographic regions for operations participating in NIKE Brand sales activity.\\n\\nThe breakdown of Revenues is as follows:\\n\\n(Dollars in millions)\\n\\nFISCAL 2023 FISCAL 2022\\n\\n% CHANGE\\n\\n% CHANGE EXCLUDING CURRENCY (1) CHANGES FISCAL 2021\\n\\n% CHANGE\\n\\nNorth America Europe, Middle East & Africa Greater China\\n\\n$\\n\\n21,608 $ 13,418 7,248\\n\\n18,353 12,479 7,547\\n\\n18 % 8 % -4 %\\n\\n18 % $ 21 % 4 %\\n\\n17,179 11,456 8,290\\n\\n7 % 9 % -9 %\\n\\nAsia Pacific & Latin America Global Brand Divisions\\n\\n(3)\\n\\n(2)\\n\\n6,431 58\\n\\n5,955 102\\n\\n8 % -43 %\\n\\n17 % -43 %\\n\\n5,343 25\\n\\n11 % 308 %\\n\\nTOTAL NIKE BRAND Converse\\n\\n$\\n\\n48,763 $ 2,427\\n\\n44,436 2,346\\n\\n10 % 3 %\\n\\n16 % $ 8 %\\n\\n42,293 2,205\\n\\n5 % 6 %\\n\\n(4)\\n\\nCorporate TOTAL NIKE, INC. REVENUES\\n\\n$\\n\\n27\\n\\n51,217 $\\n\\n(72) 46,710\\n\\n— 10 %\\n\\n— 16 % $\\n\\n40 44,538\\n\\n— 5 %\\n\\n(1) The percent change excluding currency changes represents a non-GAAP financial measure. For further information, see \"Use of Non-GAAP Financial Measures\".\\n\\n(2) For additional information on the transition of our NIKE Brand businesses within our CASA territory to a third-party distributor, see Note 18 — Acquisitions and Divestitures of the Notes to Consolidated\\n\\nFinancial Statements contained in Item 8 of this Annual Report.\\n\\n(3) Global Brand Divisions revenues include NIKE Brand licensing and other miscellaneous revenues that are not part of a geographic operating segment.\\n\\n(4) Corporate revenues primarily consist of foreign currency hedge gains and losses related to revenues generated by entities within the NIKE Brand geographic operating segments and Converse, but\\n\\nmanaged through our central foreign exchange risk management program.\\n\\nThe primary financial measure used by the Company to evaluate performance is Earnings Before Interest and Taxes (\"EBIT\"). As discussed in Note 15 — Operating Segments and Related Information in the accompanying Notes to the Consolidated Financial Statements, certain corporate costs are not included in EBIT.\\n\\nThe breakdown of EBIT is as follows:\\n\\n(Dollars in millions)\\n\\nFISCAL 2023\\n\\nFISCAL 2022\\n\\n% CHANGE\\n\\nFISCAL 2021\\n\\nNorth America Europe, Middle East & Africa Greater China\\n\\n$\\n\\n5,454 3,531 2,283\\n\\n$\\n\\n5,114 3,293 2,365\\n\\n7 % $ 7 % -3 %\\n\\n5,089 2,435 3,243\\n\\nAsia Pacific & Latin America Global Brand Divisions (1)'),\n",
-       "  0.233286499977),\n",
-       " (Document(metadata={'source': 'resources/nke-10k-2023.pdf'}, page_content='As discussed in Note 15 — Operating Segments and Related Information in the accompanying Notes to the Consolidated Financial Statements, our operating segments are evidence of the structure of the Company\\'s internal organization. The NIKE Brand segments are defined by geographic regions for operations participating in NIKE Brand sales activity.\\n\\nThe breakdown of Revenues is as follows:\\n\\n(Dollars in millions)\\n\\nFISCAL 2023 FISCAL 2022\\n\\n% CHANGE\\n\\n% CHANGE EXCLUDING CURRENCY (1) CHANGES FISCAL 2021\\n\\n% CHANGE\\n\\nNorth America Europe, Middle East & Africa Greater China\\n\\n$\\n\\n21,608 $ 13,418 7,248\\n\\n18,353 12,479 7,547\\n\\n18 % 8 % -4 %\\n\\n18 % $ 21 % 4 %\\n\\n17,179 11,456 8,290\\n\\n7 % 9 % -9 %\\n\\nAsia Pacific & Latin America Global Brand Divisions\\n\\n(3)\\n\\n(2)\\n\\n6,431 58\\n\\n5,955 102\\n\\n8 % -43 %\\n\\n17 % -43 %\\n\\n5,343 25\\n\\n11 % 308 %\\n\\nTOTAL NIKE BRAND Converse\\n\\n$\\n\\n48,763 $ 2,427\\n\\n44,436 2,346\\n\\n10 % 3 %\\n\\n16 % $ 8 %\\n\\n42,293 2,205\\n\\n5 % 6 %\\n\\n(4)\\n\\nCorporate TOTAL NIKE, INC. REVENUES\\n\\n$\\n\\n27\\n\\n51,217 $\\n\\n(72) 46,710\\n\\n— 10 %\\n\\n— 16 % $\\n\\n40 44,538\\n\\n— 5 %\\n\\n(1) The percent change excluding currency changes represents a non-GAAP financial measure. For further information, see \"Use of Non-GAAP Financial Measures\".\\n\\n(2) For additional information on the transition of our NIKE Brand businesses within our CASA territory to a third-party distributor, see Note 18 — Acquisitions and Divestitures of the Notes to Consolidated\\n\\nFinancial Statements contained in Item 8 of this Annual Report.\\n\\n(3) Global Brand Divisions revenues include NIKE Brand licensing and other miscellaneous revenues that are not part of a geographic operating segment.\\n\\n(4) Corporate revenues primarily consist of foreign currency hedge gains and losses related to revenues generated by entities within the NIKE Brand geographic operating segments and Converse, but\\n\\nmanaged through our central foreign exchange risk management program.\\n\\nThe primary financial measure used by the Company to evaluate performance is Earnings Before Interest and Taxes (\"EBIT\"). As discussed in Note 15 — Operating Segments and Related Information in the accompanying Notes to the Consolidated Financial Statements, certain corporate costs are not included in EBIT.\\n\\nThe breakdown of EBIT is as follows:\\n\\n(Dollars in millions)\\n\\nFISCAL 2023\\n\\nFISCAL 2022\\n\\n% CHANGE\\n\\nFISCAL 2021\\n\\nNorth America Europe, Middle East & Africa Greater China\\n\\n$\\n\\n5,454 3,531 2,283\\n\\n$\\n\\n5,114 3,293 2,365\\n\\n7 % $ 7 % -3 %\\n\\n5,089 2,435 3,243\\n\\nAsia Pacific & Latin America Global Brand Divisions (1)'),\n",
-       "  0.233286499977),\n",
-       " (Document(metadata={'source': 'resources/nke-10k-2023.pdf'}, page_content=\"Tax (expense) benefit Gain (loss) net of tax\\n\\n5 (14)\\n\\n(9) 22\\n\\nTotal net gain (loss) reclassified for the period\\n\\n$\\n\\n463 $\\n\\n30\\n\\n2023 FORM 10-K 82\\n\\nTable of Contents\\n\\nNOTE 14 — REVENUES\\n\\nDISAGGREGATION OF REVENUES The following tables present the Company's Revenues disaggregated by reportable operating segment, major product line and distribution channel:\\n\\n(Dollars in millions)\\n\\nNORTH AMERICA\\n\\nEUROPE, MIDDLE EAST & AFRICA\\n\\nGREATER CHINA\\n\\nYEAR ENDED MAY 31, 2023 ASIA PACIFIC & LATIN (1)\\n\\nGLOBAL BRAND DIVISIONS\\n\\nTOTAL NIKE\\n\\nAMERICA\\n\\nBRAND CONVERSE CORPORATE\\n\\nTOTAL NIKE, INC.\\n\\nRevenues by: Footwear\\n\\n$\\n\\n14,897 $\\n\\n8,260 $\\n\\n5,435 $\\n\\n4,543 $\\n\\n— $\\n\\n33,135 $\\n\\n2,155 $\\n\\n— $\\n\\n35,290\\n\\nApparel Equipment Other\\n\\n5,947 764 —\\n\\n4,566 592 —\\n\\n1,666 147 —\\n\\n1,664 224 —\\n\\n— — 58\\n\\n13,843 1,727 58\\n\\n90 28 154\\n\\n— — 27\\n\\n13,933 1,755 239\\n\\nTOTAL REVENUES\\n\\n$\\n\\n21,608 $\\n\\n13,418 $\\n\\n7,248 $\\n\\n6,431 $\\n\\n58 $\\n\\n48,763 $\\n\\n2,427 $\\n\\n27 $\\n\\n51,217\\n\\nRevenues by:\\n\\nSales to Wholesale Customers Sales through Direct to Consumer\\n\\n$\\n\\n11,273 $ 10,335\\n\\n8,522 $ 4,896\\n\\n3,866 $ 3,382\\n\\n3,736 $ 2,695\\n\\n— $ —\\n\\n27,397 $ 21,308\\n\\n1,299 $ 974\\n\\n— $ —\\n\\n28,696 22,282\\n\\nOther\\n\\nTOTAL REVENUES\\n\\n$\\n\\n—\\n\\n21,608 $\\n\\n—\\n\\n13,418 $\\n\\n— 7,248 $\\n\\n— 6,431 $\\n\\n58 58 $\\n\\n58\\n\\n48,763 $\\n\\n154 2,427 $\\n\\n27 27 $\\n\\n239 51,217\\n\\n(1) Refer to Note 18 — Acquisitions and Divestitures for additional information on the transition of the Company's NIKE Brand businesses in its CASA territory to third-party distributors.\\n\\nYEAR ENDED MAY 31, 2022\\n\\n(Dollars in millions)\\n\\nNORTH AMERICA\\n\\nEUROPE, MIDDLE EAST & AFRICA\\n\\nGREATER CHINA\\n\\nASIA PACIFIC & LATIN AMERICA\\n\\nGLOBAL BRAND DIVISIONS\\n\\nTOTAL NIKE\\n\\nBRAND CONVERSE CORPORATE\\n\\nTOTAL NIKE, INC.\\n\\nRevenues by: Footwear Apparel\\n\\n$\\n\\n12,228 $ 5,492\\n\\n7,388 $ 4,527\\n\\n5,416 $ 1,938\\n\\n4,111 $ 1,610\\n\\n— $ —\\n\\n29,143 $ 13,567\\n\\n2,094 $ 103\\n\\n— $ —\\n\\n31,237 13,670\\n\\nEquipment Other\\n\\n633 —\\n\\n564 —\\n\\n193 —\\n\\n234 —\\n\\n— 102\\n\\n1,624 102\\n\\n26 123\\n\\n— (72)\\n\\n1,650 153\\n\\nTOTAL REVENUES Revenues by:\\n\\n$\\n\\n18,353 $\\n\\n12,479 $\\n\\n7,547 $\\n\\n5,955 $\\n\\n102 $\\n\\n44,436 $\\n\\n2,346 $\\n\\n(72) $\\n\\n46,710\\n\\nSales to Wholesale Customers Sales through Direct to Consumer Other\\n\\n$\\n\\n9,621 $ 8,732 —\\n\\n8,377 $ 4,102 —\\n\\n4,081 $ 3,466 —\\n\\n3,529 $ 2,426 —\\n\\n— $ — 102\\n\\n25,608 $ 18,726 102\\n\\n1,292 $ 931 123\\n\\n— $ — (72)\\n\\n26,900 19,657 153\\n\\nTOTAL REVENUES\\n\\n$\\n\\n18,353 $\\n\\n12,479 $\\n\\n7,547 $\\n\\n5,955 $\\n\\n102 $\\n\\n44,436 $\\n\\n2,346 $\\n\\n(72) $\\n\\n46,710\\n\\n2023 FORM 10-K 83\\n\\nTable of Contents\\n\\nYEAR ENDED MAY 31, 2021\\n\\n(Dollars in millions)\\n\\nNORTH AMERICA\\n\\nEUROPE, MIDDLE EAST & AFRICA\\n\\nGREATER CHINA\"),\n",
-       "  0.261225402355)]"
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "9eieJowO1vmo"
+      },
+      "source": [
+        "### Install Python Dependencies"
       ]
-     },
-     "execution_count": 10,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "# vector search with combinations of metadata filtering\n",
-    "\n",
-    "f = (Text(\"text\") % \"profit\") | (Text(\"text\") % \"revenue\")\n",
-    "rds.similarity_search_with_score(query=\"Nike company revenue\", k=4, filter=f)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 11,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
     },
-    "id": "kIoGJOop1vmz",
-    "outputId": "9abbf5fd-77de-4094-a2e8-fba2fc5a3a05"
-   },
-   "outputs": [
     {
-     "data": {
-      "text/plain": [
-       "[(Document(metadata={'source': 'resources/nke-10k-2023.pdf'}, page_content='As discussed in Note 15 — Operating Segments and Related Information in the accompanying Notes to the Consolidated Financial Statements, our operating segments are evidence of the structure of the Company\\'s internal organization. The NIKE Brand segments are defined by geographic regions for operations participating in NIKE Brand sales activity.\\n\\nThe breakdown of Revenues is as follows:\\n\\n(Dollars in millions)\\n\\nFISCAL 2023 FISCAL 2022\\n\\n% CHANGE\\n\\n% CHANGE EXCLUDING CURRENCY (1) CHANGES FISCAL 2021\\n\\n% CHANGE\\n\\nNorth America Europe, Middle East & Africa Greater China\\n\\n$\\n\\n21,608 $ 13,418 7,248\\n\\n18,353 12,479 7,547\\n\\n18 % 8 % -4 %\\n\\n18 % $ 21 % 4 %\\n\\n17,179 11,456 8,290\\n\\n7 % 9 % -9 %\\n\\nAsia Pacific & Latin America Global Brand Divisions\\n\\n(3)\\n\\n(2)\\n\\n6,431 58\\n\\n5,955 102\\n\\n8 % -43 %\\n\\n17 % -43 %\\n\\n5,343 25\\n\\n11 % 308 %\\n\\nTOTAL NIKE BRAND Converse\\n\\n$\\n\\n48,763 $ 2,427\\n\\n44,436 2,346\\n\\n10 % 3 %\\n\\n16 % $ 8 %\\n\\n42,293 2,205\\n\\n5 % 6 %\\n\\n(4)\\n\\nCorporate TOTAL NIKE, INC. REVENUES\\n\\n$\\n\\n27\\n\\n51,217 $\\n\\n(72) 46,710\\n\\n— 10 %\\n\\n— 16 % $\\n\\n40 44,538\\n\\n— 5 %\\n\\n(1) The percent change excluding currency changes represents a non-GAAP financial measure. For further information, see \"Use of Non-GAAP Financial Measures\".\\n\\n(2) For additional information on the transition of our NIKE Brand businesses within our CASA territory to a third-party distributor, see Note 18 — Acquisitions and Divestitures of the Notes to Consolidated\\n\\nFinancial Statements contained in Item 8 of this Annual Report.\\n\\n(3) Global Brand Divisions revenues include NIKE Brand licensing and other miscellaneous revenues that are not part of a geographic operating segment.\\n\\n(4) Corporate revenues primarily consist of foreign currency hedge gains and losses related to revenues generated by entities within the NIKE Brand geographic operating segments and Converse, but\\n\\nmanaged through our central foreign exchange risk management program.\\n\\nThe primary financial measure used by the Company to evaluate performance is Earnings Before Interest and Taxes (\"EBIT\"). As discussed in Note 15 — Operating Segments and Related Information in the accompanying Notes to the Consolidated Financial Statements, certain corporate costs are not included in EBIT.\\n\\nThe breakdown of EBIT is as follows:\\n\\n(Dollars in millions)\\n\\nFISCAL 2023\\n\\nFISCAL 2022\\n\\n% CHANGE\\n\\nFISCAL 2021\\n\\nNorth America Europe, Middle East & Africa Greater China\\n\\n$\\n\\n5,454 3,531 2,283\\n\\n$\\n\\n5,114 3,293 2,365\\n\\n7 % $ 7 % -3 %\\n\\n5,089 2,435 3,243\\n\\nAsia Pacific & Latin America Global Brand Divisions (1)'),\n",
-       "  0.233286499977),\n",
-       " (Document(metadata={'source': 'resources/nke-10k-2023.pdf'}, page_content='As discussed in Note 15 — Operating Segments and Related Information in the accompanying Notes to the Consolidated Financial Statements, our operating segments are evidence of the structure of the Company\\'s internal organization. The NIKE Brand segments are defined by geographic regions for operations participating in NIKE Brand sales activity.\\n\\nThe breakdown of Revenues is as follows:\\n\\n(Dollars in millions)\\n\\nFISCAL 2023 FISCAL 2022\\n\\n% CHANGE\\n\\n% CHANGE EXCLUDING CURRENCY (1) CHANGES FISCAL 2021\\n\\n% CHANGE\\n\\nNorth America Europe, Middle East & Africa Greater China\\n\\n$\\n\\n21,608 $ 13,418 7,248\\n\\n18,353 12,479 7,547\\n\\n18 % 8 % -4 %\\n\\n18 % $ 21 % 4 %\\n\\n17,179 11,456 8,290\\n\\n7 % 9 % -9 %\\n\\nAsia Pacific & Latin America Global Brand Divisions\\n\\n(3)\\n\\n(2)\\n\\n6,431 58\\n\\n5,955 102\\n\\n8 % -43 %\\n\\n17 % -43 %\\n\\n5,343 25\\n\\n11 % 308 %\\n\\nTOTAL NIKE BRAND Converse\\n\\n$\\n\\n48,763 $ 2,427\\n\\n44,436 2,346\\n\\n10 % 3 %\\n\\n16 % $ 8 %\\n\\n42,293 2,205\\n\\n5 % 6 %\\n\\n(4)\\n\\nCorporate TOTAL NIKE, INC. REVENUES\\n\\n$\\n\\n27\\n\\n51,217 $\\n\\n(72) 46,710\\n\\n— 10 %\\n\\n— 16 % $\\n\\n40 44,538\\n\\n— 5 %\\n\\n(1) The percent change excluding currency changes represents a non-GAAP financial measure. For further information, see \"Use of Non-GAAP Financial Measures\".\\n\\n(2) For additional information on the transition of our NIKE Brand businesses within our CASA territory to a third-party distributor, see Note 18 — Acquisitions and Divestitures of the Notes to Consolidated\\n\\nFinancial Statements contained in Item 8 of this Annual Report.\\n\\n(3) Global Brand Divisions revenues include NIKE Brand licensing and other miscellaneous revenues that are not part of a geographic operating segment.\\n\\n(4) Corporate revenues primarily consist of foreign currency hedge gains and losses related to revenues generated by entities within the NIKE Brand geographic operating segments and Converse, but\\n\\nmanaged through our central foreign exchange risk management program.\\n\\nThe primary financial measure used by the Company to evaluate performance is Earnings Before Interest and Taxes (\"EBIT\"). As discussed in Note 15 — Operating Segments and Related Information in the accompanying Notes to the Consolidated Financial Statements, certain corporate costs are not included in EBIT.\\n\\nThe breakdown of EBIT is as follows:\\n\\n(Dollars in millions)\\n\\nFISCAL 2023\\n\\nFISCAL 2022\\n\\n% CHANGE\\n\\nFISCAL 2021\\n\\nNorth America Europe, Middle East & Africa Greater China\\n\\n$\\n\\n5,454 3,531 2,283\\n\\n$\\n\\n5,114 3,293 2,365\\n\\n7 % $ 7 % -3 %\\n\\n5,089 2,435 3,243\\n\\nAsia Pacific & Latin America Global Brand Divisions (1)'),\n",
-       "  0.233286499977),\n",
-       " (Document(metadata={'source': 'resources/nke-10k-2023.pdf'}, page_content='As discussed in Note 15 — Operating Segments and Related Information in the accompanying Notes to the Consolidated Financial Statements, our operating segments are evidence of the structure of the Company\\'s internal organization. The NIKE Brand segments are defined by geographic regions for operations participating in NIKE Brand sales activity.\\n\\nThe breakdown of Revenues is as follows:\\n\\n(Dollars in millions)\\n\\nFISCAL 2023 FISCAL 2022\\n\\n% CHANGE\\n\\n% CHANGE EXCLUDING CURRENCY (1) CHANGES FISCAL 2021\\n\\n% CHANGE\\n\\nNorth America Europe, Middle East & Africa Greater China\\n\\n$\\n\\n21,608 $ 13,418 7,248\\n\\n18,353 12,479 7,547\\n\\n18 % 8 % -4 %\\n\\n18 % $ 21 % 4 %\\n\\n17,179 11,456 8,290\\n\\n7 % 9 % -9 %\\n\\nAsia Pacific & Latin America Global Brand Divisions\\n\\n(3)\\n\\n(2)\\n\\n6,431 58\\n\\n5,955 102\\n\\n8 % -43 %\\n\\n17 % -43 %\\n\\n5,343 25\\n\\n11 % 308 %\\n\\nTOTAL NIKE BRAND Converse\\n\\n$\\n\\n48,763 $ 2,427\\n\\n44,436 2,346\\n\\n10 % 3 %\\n\\n16 % $ 8 %\\n\\n42,293 2,205\\n\\n5 % 6 %\\n\\n(4)\\n\\nCorporate TOTAL NIKE, INC. REVENUES\\n\\n$\\n\\n27\\n\\n51,217 $\\n\\n(72) 46,710\\n\\n— 10 %\\n\\n— 16 % $\\n\\n40 44,538\\n\\n— 5 %\\n\\n(1) The percent change excluding currency changes represents a non-GAAP financial measure. For further information, see \"Use of Non-GAAP Financial Measures\".\\n\\n(2) For additional information on the transition of our NIKE Brand businesses within our CASA territory to a third-party distributor, see Note 18 — Acquisitions and Divestitures of the Notes to Consolidated\\n\\nFinancial Statements contained in Item 8 of this Annual Report.\\n\\n(3) Global Brand Divisions revenues include NIKE Brand licensing and other miscellaneous revenues that are not part of a geographic operating segment.\\n\\n(4) Corporate revenues primarily consist of foreign currency hedge gains and losses related to revenues generated by entities within the NIKE Brand geographic operating segments and Converse, but\\n\\nmanaged through our central foreign exchange risk management program.\\n\\nThe primary financial measure used by the Company to evaluate performance is Earnings Before Interest and Taxes (\"EBIT\"). As discussed in Note 15 — Operating Segments and Related Information in the accompanying Notes to the Consolidated Financial Statements, certain corporate costs are not included in EBIT.\\n\\nThe breakdown of EBIT is as follows:\\n\\n(Dollars in millions)\\n\\nFISCAL 2023\\n\\nFISCAL 2022\\n\\n% CHANGE\\n\\nFISCAL 2021\\n\\nNorth America Europe, Middle East & Africa Greater China\\n\\n$\\n\\n5,454 3,531 2,283\\n\\n$\\n\\n5,114 3,293 2,365\\n\\n7 % $ 7 % -3 %\\n\\n5,089 2,435 3,243\\n\\nAsia Pacific & Latin America Global Brand Divisions (1)'),\n",
-       "  0.233286499977),\n",
-       " (Document(metadata={'source': 'resources/nke-10k-2023.pdf'}, page_content=\"Tax (expense) benefit Gain (loss) net of tax\\n\\n5 (14)\\n\\n(9) 22\\n\\nTotal net gain (loss) reclassified for the period\\n\\n$\\n\\n463 $\\n\\n30\\n\\n2023 FORM 10-K 82\\n\\nTable of Contents\\n\\nNOTE 14 — REVENUES\\n\\nDISAGGREGATION OF REVENUES The following tables present the Company's Revenues disaggregated by reportable operating segment, major product line and distribution channel:\\n\\n(Dollars in millions)\\n\\nNORTH AMERICA\\n\\nEUROPE, MIDDLE EAST & AFRICA\\n\\nGREATER CHINA\\n\\nYEAR ENDED MAY 31, 2023 ASIA PACIFIC & LATIN (1)\\n\\nGLOBAL BRAND DIVISIONS\\n\\nTOTAL NIKE\\n\\nAMERICA\\n\\nBRAND CONVERSE CORPORATE\\n\\nTOTAL NIKE, INC.\\n\\nRevenues by: Footwear\\n\\n$\\n\\n14,897 $\\n\\n8,260 $\\n\\n5,435 $\\n\\n4,543 $\\n\\n— $\\n\\n33,135 $\\n\\n2,155 $\\n\\n— $\\n\\n35,290\\n\\nApparel Equipment Other\\n\\n5,947 764 —\\n\\n4,566 592 —\\n\\n1,666 147 —\\n\\n1,664 224 —\\n\\n— — 58\\n\\n13,843 1,727 58\\n\\n90 28 154\\n\\n— — 27\\n\\n13,933 1,755 239\\n\\nTOTAL REVENUES\\n\\n$\\n\\n21,608 $\\n\\n13,418 $\\n\\n7,248 $\\n\\n6,431 $\\n\\n58 $\\n\\n48,763 $\\n\\n2,427 $\\n\\n27 $\\n\\n51,217\\n\\nRevenues by:\\n\\nSales to Wholesale Customers Sales through Direct to Consumer\\n\\n$\\n\\n11,273 $ 10,335\\n\\n8,522 $ 4,896\\n\\n3,866 $ 3,382\\n\\n3,736 $ 2,695\\n\\n— $ —\\n\\n27,397 $ 21,308\\n\\n1,299 $ 974\\n\\n— $ —\\n\\n28,696 22,282\\n\\nOther\\n\\nTOTAL REVENUES\\n\\n$\\n\\n—\\n\\n21,608 $\\n\\n—\\n\\n13,418 $\\n\\n— 7,248 $\\n\\n— 6,431 $\\n\\n58 58 $\\n\\n58\\n\\n48,763 $\\n\\n154 2,427 $\\n\\n27 27 $\\n\\n239 51,217\\n\\n(1) Refer to Note 18 — Acquisitions and Divestitures for additional information on the transition of the Company's NIKE Brand businesses in its CASA territory to third-party distributors.\\n\\nYEAR ENDED MAY 31, 2022\\n\\n(Dollars in millions)\\n\\nNORTH AMERICA\\n\\nEUROPE, MIDDLE EAST & AFRICA\\n\\nGREATER CHINA\\n\\nASIA PACIFIC & LATIN AMERICA\\n\\nGLOBAL BRAND DIVISIONS\\n\\nTOTAL NIKE\\n\\nBRAND CONVERSE CORPORATE\\n\\nTOTAL NIKE, INC.\\n\\nRevenues by: Footwear Apparel\\n\\n$\\n\\n12,228 $ 5,492\\n\\n7,388 $ 4,527\\n\\n5,416 $ 1,938\\n\\n4,111 $ 1,610\\n\\n— $ —\\n\\n29,143 $ 13,567\\n\\n2,094 $ 103\\n\\n— $ —\\n\\n31,237 13,670\\n\\nEquipment Other\\n\\n633 —\\n\\n564 —\\n\\n193 —\\n\\n234 —\\n\\n— 102\\n\\n1,624 102\\n\\n26 123\\n\\n— (72)\\n\\n1,650 153\\n\\nTOTAL REVENUES Revenues by:\\n\\n$\\n\\n18,353 $\\n\\n12,479 $\\n\\n7,547 $\\n\\n5,955 $\\n\\n102 $\\n\\n44,436 $\\n\\n2,346 $\\n\\n(72) $\\n\\n46,710\\n\\nSales to Wholesale Customers Sales through Direct to Consumer Other\\n\\n$\\n\\n9,621 $ 8,732 —\\n\\n8,377 $ 4,102 —\\n\\n4,081 $ 3,466 —\\n\\n3,529 $ 2,426 —\\n\\n— $ — 102\\n\\n25,608 $ 18,726 102\\n\\n1,292 $ 931 123\\n\\n— $ — (72)\\n\\n26,900 19,657 153\\n\\nTOTAL REVENUES\\n\\n$\\n\\n18,353 $\\n\\n12,479 $\\n\\n7,547 $\\n\\n5,955 $\\n\\n102 $\\n\\n44,436 $\\n\\n2,346 $\\n\\n(72) $\\n\\n46,710\\n\\n2023 FORM 10-K 83\\n\\nTable of Contents\\n\\nYEAR ENDED MAY 31, 2021\\n\\n(Dollars in millions)\\n\\nNORTH AMERICA\\n\\nEUROPE, MIDDLE EAST & AFRICA\\n\\nGREATER CHINA\"),\n",
-       "  0.261225402355)]"
+      "cell_type": "code",
+      "execution_count": 23,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "B3v1wUzX1vmq",
+        "outputId": "84a3feff-e7c1-41ba-9ab1-8c975074552e"
+      },
+      "outputs": [
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "huggingface/tokenizers: The current process just got forked, after parallelism has already been used. Disabling parallelism to avoid deadlocks...\n",
+            "To disable this warning, you can either:\n",
+            "\t- Avoid using `tokenizers` before the fork if possible\n",
+            "\t- Explicitly set the environment variable TOKENIZERS_PARALLELISM=(true | false)\n"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "\n",
+            "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m A new release of pip is available: \u001b[0m\u001b[31;49m24.0\u001b[0m\u001b[39;49m -> \u001b[0m\u001b[32;49m25.0.1\u001b[0m\n",
+            "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m To update, run: \u001b[0m\u001b[32;49mpip install --upgrade pip\u001b[0m\n",
+            "Note: you may need to restart the kernel to use updated packages.\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "huggingface/tokenizers: The current process just got forked, after parallelism has already been used. Disabling parallelism to avoid deadlocks...\n",
+            "To disable this warning, you can either:\n",
+            "\t- Avoid using `tokenizers` before the fork if possible\n",
+            "\t- Explicitly set the environment variable TOKENIZERS_PARALLELISM=(true | false)\n"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "\n",
+            "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m A new release of pip is available: \u001b[0m\u001b[31;49m24.0\u001b[0m\u001b[39;49m -> \u001b[0m\u001b[32;49m25.0.1\u001b[0m\n",
+            "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m To update, run: \u001b[0m\u001b[32;49mpip install --upgrade pip\u001b[0m\n",
+            "Note: you may need to restart the kernel to use updated packages.\n"
+          ]
+        }
+      ],
+      "source": [
+        "%pip install -q redis \"unstructured[pdf]\" sentence-transformers langchain \n",
+        "%pip install -q langchain-community \"langchain-redis>=0.2.0\" langchain-huggingface langchain-openai"
       ]
-     },
-     "execution_count": 11,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "# filter results to a certain distance threshold\n",
-    "rds.similarity_search_with_score(query=\"Nike company revenue\", k=4, distance_threshold=0.3)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "XdzQa112Bf2b"
-   },
-   "source": [
-    "## RAG with LangChain\n",
-    "LangChain makes it easy to now take this vector store and build retireval augmented generation (RAG) applications over your data."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "collapsed": false,
-    "id": "CU2aFQPW1vmz"
-   },
-   "source": [
-    "### Initialize OpenAI\n",
-    "\n",
-    "You need to supply an OpenAI API key (starts with `sk-...`) when prompted. If the key is in your env -- great, otherwise enter it when prompted below. You can find your API key at https://platform.openai.com/account/api-keys"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 12,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
     },
-    "id": "GSpH-cur1vmz",
-    "outputId": "b00de5c7-1684-4e8e-c146-6d402910cdc5"
-   },
-   "outputs": [],
-   "source": [
-    "import getpass\n",
-    "from langchain_openai import ChatOpenAI\n",
-    "\n",
-    "llm = ChatOpenAI(openai_api_key=os.getenv(\"OPENAI_API_KEY\") or getpass.getpass(prompt=\"OpenAI API Key:\"))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "-SQXQB-c1vmz"
-   },
-   "source": [
-    "### Setup prompt"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 13,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from langchain_core.output_parsers import StrOutputParser\n",
-    "from langchain_core.prompts import ChatPromptTemplate\n",
-    "from langchain_core.runnables import RunnablePassthrough\n",
-    "\n",
-    "prompt_template = \"\"\"\n",
-    "    Use the following pieces of context from financial 10k filings data to answer the user question at the end. \n",
-    "    If you don't know the answer, say that you don't know, don't try to make up an answer.\n",
-    "\n",
-    "    Context:\n",
-    "    ---------\n",
-    "    {context}\n",
-    "    ---------\n",
-    "    Question:\n",
-    "    {question}\n",
-    "    Answer:\n",
-    "\"\"\"\n",
-    "\n",
-    "def format_docs(docs):\n",
-    "    return \"\\n\\n\".join(doc.page_content for doc in docs)\n",
-    "\n",
-    "prompt = ChatPromptTemplate.from_template(prompt_template)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "xgEXBujxG1dO"
-   },
-   "source": [
-    "### Putting it all together\n",
-    "\n",
-    "This is where the Langchain brings all the components together in a form of a simple RAG application with the financial PDF document."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 14,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "rag_chain = (\n",
-    "    {\n",
-    "        \"context\": rds.as_retriever() | format_docs,\n",
-    "        \"question\": RunnablePassthrough()\n",
-    "    }\n",
-    "    | prompt\n",
-    "    | llm\n",
-    "    | StrOutputParser()\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "SURTtVbYBFGc"
-   },
-   "source": [
-    "### Finally - let's ask questions!\n",
-    "\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 15,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 52
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Install Redis Stack\n",
+        "\n",
+        "Later in this tutorial, Redis will be used to store, index, and query vector\n",
+        "embeddings created from PDF document chunks. **We need to make sure we have a Redis\n",
+        "instance available.**"
+      ]
     },
-    "id": "0JkswfOHZu9h",
-    "outputId": "813fffe6-3d8b-4df7-a035-c54e421c0856"
-   },
-   "outputs": [
     {
-     "data": {
-      "text/plain": [
-       "\"Nike's revenue last year was $44,538 million, and this year it was $51,217 million.\""
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "#### For Colab\n",
+        "Use the shell script below to download, extract, and install [Redis Stack](https://redis.io/docs/getting-started/install-stack/) directly from the Redis package archive."
       ]
-     },
-     "execution_count": 15,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "query = \"What was Nike's revenue last year compared to this year??\"\n",
-    "rag_chain.invoke(query)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 16,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 52
     },
-    "id": "ZvioUduS1vm0",
-    "outputId": "a8ba0e5d-c06b-4848-d066-c26884b3caee"
-   },
-   "outputs": [
     {
-     "data": {
-      "text/plain": [
-       "'The exact number of products Nike offers is not explicitly stated in the provided context. However, Nike is part of the athletic footwear, apparel, and equipment industry, which is highly competitive both in the United States and worldwide.'"
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# NBVAL_SKIP\n",
+        "%%sh\n",
+        "curl -fsSL https://packages.redis.io/gpg | sudo gpg --dearmor -o /usr/share/keyrings/redis-archive-keyring.gpg\n",
+        "echo \"deb [signed-by=/usr/share/keyrings/redis-archive-keyring.gpg] https://packages.redis.io/deb $(lsb_release -cs) main\" | sudo tee /etc/apt/sources.list.d/redis.list\n",
+        "sudo apt-get update  > /dev/null 2>&1\n",
+        "sudo apt-get install redis-stack-server  > /dev/null 2>&1\n",
+        "redis-stack-server --daemonize yes"
       ]
-     },
-     "execution_count": 16,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "query = \"How many products does Nike offer? What is the industry that Nike is part of?\"\n",
-    "rag_chain.invoke(query)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 17,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 35
     },
-    "id": "Q9mE5z-61vm1",
-    "outputId": "e3860d3e-e68b-489b-9897-c7118377c7bb"
-   },
-   "outputs": [
     {
-     "data": {
-      "text/plain": [
-       "'Based on the provided information, there is no specific mention or data that directly addresses the ethical practices of Nike as a company. Therefore, it is not possible to determine if Nike is an ethical company based on the provided context.'"
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "#### For Alternative Environments\n",
+        "There are many ways to get the necessary redis-stack instance running\n",
+        "1. On cloud, deploy a [FREE instance of Redis in the cloud](https://redis.com/try-free/). Or, if you have your\n",
+        "own version of Redis Enterprise running, that works too!\n",
+        "2. Per OS, [see the docs](https://redis.io/docs/latest/operate/oss_and_stack/install/install-stack/)\n",
+        "3. With docker: `docker run -d --name redis-stack-server -p 6379:6379 redis/redis-stack-server:latest`"
       ]
-     },
-     "execution_count": 17,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "query = \"Is Nike an ethical company?\"\n",
-    "rag_chain.invoke(query)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "5itk4UPF1vm1"
-   },
-   "source": [
-    "## Cleanup\n",
-    "\n",
-    "Cleanup the index and data."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 18,
-   "metadata": {
-    "id": "DtZi-mQ61vm-"
-   },
-   "outputs": [
+    },
     {
-     "ename": "ValueError",
-     "evalue": "REDIS_URL env var not set",
-     "output_type": "error",
-     "traceback": [
-      "\u001B[0;31m---------------------------------------------------------------------------\u001B[0m",
-      "\u001B[0;31mValueError\u001B[0m                                Traceback (most recent call last)",
-      "Cell \u001B[0;32mIn[18], line 3\u001B[0m\n\u001B[1;32m      1\u001B[0m \u001B[38;5;28;01mfrom\u001B[39;00m \u001B[38;5;21;01mredisvl\u001B[39;00m\u001B[38;5;21;01m.\u001B[39;00m\u001B[38;5;21;01mindex\u001B[39;00m \u001B[38;5;28;01mimport\u001B[39;00m SearchIndex\n\u001B[0;32m----> 3\u001B[0m idx \u001B[38;5;241m=\u001B[39m \u001B[43mSearchIndex\u001B[49m\u001B[38;5;241;43m.\u001B[39;49m\u001B[43mfrom_existing\u001B[49m\u001B[43m(\u001B[49m\n\u001B[1;32m      4\u001B[0m \u001B[43m    \u001B[49m\u001B[43mindex_name\u001B[49m\u001B[43m,\u001B[49m\n\u001B[1;32m      5\u001B[0m \u001B[43m    \u001B[49m\u001B[43mredis_url\u001B[49m\u001B[38;5;241;43m=\u001B[39;49m\u001B[43mREDIS_URL\u001B[49m\n\u001B[1;32m      6\u001B[0m \u001B[43m)\u001B[49m\n\u001B[1;32m      8\u001B[0m idx\u001B[38;5;241m.\u001B[39mdelete()\n",
-      "File \u001B[0;32m~/.pyenv/versions/3.11.9/lib/python3.11/site-packages/redisvl/index/index.py:322\u001B[0m, in \u001B[0;36mSearchIndex.from_existing\u001B[0;34m(cls, name, redis_client, redis_url, **kwargs)\u001B[0m\n\u001B[1;32m    320\u001B[0m \u001B[38;5;28;01mtry\u001B[39;00m:\n\u001B[1;32m    321\u001B[0m     \u001B[38;5;28;01mif\u001B[39;00m redis_url:\n\u001B[0;32m--> 322\u001B[0m         redis_client \u001B[38;5;241m=\u001B[39m \u001B[43mRedisConnectionFactory\u001B[49m\u001B[38;5;241;43m.\u001B[39;49m\u001B[43mget_redis_connection\u001B[49m\u001B[43m(\u001B[49m\n\u001B[1;32m    323\u001B[0m \u001B[43m            \u001B[49m\u001B[43mredis_url\u001B[49m\u001B[38;5;241;43m=\u001B[39;49m\u001B[43mredis_url\u001B[49m\u001B[43m,\u001B[49m\n\u001B[1;32m    324\u001B[0m \u001B[43m            \u001B[49m\u001B[43mrequired_modules\u001B[49m\u001B[38;5;241;43m=\u001B[39;49m\u001B[43mREQUIRED_MODULES_FOR_INTROSPECTION\u001B[49m\u001B[43m,\u001B[49m\n\u001B[1;32m    325\u001B[0m \u001B[43m            \u001B[49m\u001B[38;5;241;43m*\u001B[39;49m\u001B[38;5;241;43m*\u001B[39;49m\u001B[43mkwargs\u001B[49m\u001B[43m,\u001B[49m\n\u001B[1;32m    326\u001B[0m \u001B[43m        \u001B[49m\u001B[43m)\u001B[49m\n\u001B[1;32m    327\u001B[0m     \u001B[38;5;28;01melif\u001B[39;00m redis_client:\n\u001B[1;32m    328\u001B[0m         RedisConnectionFactory\u001B[38;5;241m.\u001B[39mvalidate_sync_redis(\n\u001B[1;32m    329\u001B[0m             redis_client, required_modules\u001B[38;5;241m=\u001B[39mREQUIRED_MODULES_FOR_INTROSPECTION\n\u001B[1;32m    330\u001B[0m         )\n",
-      "File \u001B[0;32m~/.pyenv/versions/3.11.9/lib/python3.11/site-packages/redisvl/redis/connection.py:248\u001B[0m, in \u001B[0;36mRedisConnectionFactory.get_redis_connection\u001B[0;34m(url, required_modules, **kwargs)\u001B[0m\n\u001B[1;32m    224\u001B[0m \u001B[38;5;129m@staticmethod\u001B[39m\n\u001B[1;32m    225\u001B[0m \u001B[38;5;28;01mdef\u001B[39;00m \u001B[38;5;21mget_redis_connection\u001B[39m(\n\u001B[1;32m    226\u001B[0m     url: Optional[\u001B[38;5;28mstr\u001B[39m] \u001B[38;5;241m=\u001B[39m \u001B[38;5;28;01mNone\u001B[39;00m,\n\u001B[1;32m    227\u001B[0m     required_modules: Optional[List[Dict[\u001B[38;5;28mstr\u001B[39m, Any]]] \u001B[38;5;241m=\u001B[39m \u001B[38;5;28;01mNone\u001B[39;00m,\n\u001B[1;32m    228\u001B[0m     \u001B[38;5;241m*\u001B[39m\u001B[38;5;241m*\u001B[39mkwargs,\n\u001B[1;32m    229\u001B[0m ) \u001B[38;5;241m-\u001B[39m\u001B[38;5;241m>\u001B[39m Redis:\n\u001B[1;32m    230\u001B[0m \u001B[38;5;250m    \u001B[39m\u001B[38;5;124;03m\"\"\"Creates and returns a synchronous Redis client.\u001B[39;00m\n\u001B[1;32m    231\u001B[0m \n\u001B[1;32m    232\u001B[0m \u001B[38;5;124;03m    Args:\u001B[39;00m\n\u001B[0;32m   (...)\u001B[0m\n\u001B[1;32m    246\u001B[0m \u001B[38;5;124;03m        RedisModuleVersionError: If required Redis modules are not installed.\u001B[39;00m\n\u001B[1;32m    247\u001B[0m \u001B[38;5;124;03m    \"\"\"\u001B[39;00m\n\u001B[0;32m--> 248\u001B[0m     url \u001B[38;5;241m=\u001B[39m url \u001B[38;5;129;01mor\u001B[39;00m \u001B[43mget_address_from_env\u001B[49m\u001B[43m(\u001B[49m\u001B[43m)\u001B[49m\n\u001B[1;32m    249\u001B[0m     client \u001B[38;5;241m=\u001B[39m Redis\u001B[38;5;241m.\u001B[39mfrom_url(url, \u001B[38;5;241m*\u001B[39m\u001B[38;5;241m*\u001B[39mkwargs)\n\u001B[1;32m    251\u001B[0m     RedisConnectionFactory\u001B[38;5;241m.\u001B[39mvalidate_sync_redis(\n\u001B[1;32m    252\u001B[0m         client, required_modules\u001B[38;5;241m=\u001B[39mrequired_modules\n\u001B[1;32m    253\u001B[0m     )\n",
-      "File \u001B[0;32m~/.pyenv/versions/3.11.9/lib/python3.11/site-packages/redisvl/redis/connection.py:61\u001B[0m, in \u001B[0;36mget_address_from_env\u001B[0;34m()\u001B[0m\n\u001B[1;32m     55\u001B[0m \u001B[38;5;250m\u001B[39m\u001B[38;5;124;03m\"\"\"Get a redis connection from environment variables.\u001B[39;00m\n\u001B[1;32m     56\u001B[0m \n\u001B[1;32m     57\u001B[0m \u001B[38;5;124;03mReturns:\u001B[39;00m\n\u001B[1;32m     58\u001B[0m \u001B[38;5;124;03m    str: Redis URL\u001B[39;00m\n\u001B[1;32m     59\u001B[0m \u001B[38;5;124;03m\"\"\"\u001B[39;00m\n\u001B[1;32m     60\u001B[0m \u001B[38;5;28;01mif\u001B[39;00m \u001B[38;5;124m\"\u001B[39m\u001B[38;5;124mREDIS_URL\u001B[39m\u001B[38;5;124m\"\u001B[39m \u001B[38;5;129;01mnot\u001B[39;00m \u001B[38;5;129;01min\u001B[39;00m os\u001B[38;5;241m.\u001B[39menviron:\n\u001B[0;32m---> 61\u001B[0m     \u001B[38;5;28;01mraise\u001B[39;00m \u001B[38;5;167;01mValueError\u001B[39;00m(\u001B[38;5;124m\"\u001B[39m\u001B[38;5;124mREDIS_URL env var not set\u001B[39m\u001B[38;5;124m\"\u001B[39m)\n\u001B[1;32m     62\u001B[0m \u001B[38;5;28;01mreturn\u001B[39;00m os\u001B[38;5;241m.\u001B[39menviron[\u001B[38;5;124m\"\u001B[39m\u001B[38;5;124mREDIS_URL\u001B[39m\u001B[38;5;124m\"\u001B[39m]\n",
-      "\u001B[0;31mValueError\u001B[0m: REDIS_URL env var not set"
-     ]
-    }
-   ],
-   "source": [
-    "from redisvl.index import SearchIndex\n",
-    "\n",
-    "idx = SearchIndex.from_existing(\n",
-    "    index_name,\n",
-    "    redis_url=REDIS_URL\n",
-    ")\n",
-    "\n",
-    "idx.delete()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 19,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'0.4.0'"
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Define the Redis Connection URL\n",
+        "\n",
+        "By default this notebook connects to the local instance of Redis Stack. **If you have your own Redis Enterprise instance** - replace REDIS_PASSWORD, REDIS_HOST and REDIS_PORT values with your own."
       ]
-     },
-     "execution_count": 19,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "import redisvl\n",
-    "\n",
-    "redisvl.__version__"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 20,
-   "metadata": {},
-   "outputs": [
+    },
     {
-     "data": {
-      "text/plain": [
-       "'5.2.1'"
+      "cell_type": "code",
+      "execution_count": 1,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "import os\n",
+        "import warnings\n",
+        "warnings.filterwarnings('ignore')\n",
+        "\n",
+        "# Replace values below with your own if using Redis Cloud instance\n",
+        "REDIS_HOST = os.getenv(\"REDIS_HOST\", \"localhost\") # ex: \"redis-18374.c253.us-central1-1.gce.cloud.redislabs.com\"\n",
+        "REDIS_PORT = os.getenv(\"REDIS_PORT\", \"6379\")      # ex: 18374\n",
+        "REDIS_PASSWORD = os.getenv(\"REDIS_PASSWORD\", \"\")  # ex: \"1TNxTEdYRDgIDKM2gDfasupCADXXXX\"\n",
+        "\n",
+        "# If SSL is enabled on the endpoint, use rediss:// as the URL prefix\n",
+        "REDIS_URL = f\"redis://:{REDIS_PASSWORD}@{REDIS_HOST}:{REDIS_PORT}\""
       ]
-     },
-     "execution_count": 20,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "import redis\n",
-    "\n",
-    "redis.__version__"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 21,
-   "metadata": {},
-   "outputs": [
+    },
     {
-     "data": {
-      "text/plain": [
-       "'redis://:@localhost:6379'"
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## RAG with LangChain"
       ]
-     },
-     "execution_count": 21,
-     "metadata": {},
-     "output_type": "execute_result"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "7MaVqU8Y1vms"
+      },
+      "source": [
+        "### Dataset Preparation (PDF Documents)\n",
+        "\n",
+        "To best demonstrate Redis as a vector database layer, we will load a single\n",
+        "financial (10k filings) doc and preprocess it using some helpers from LangChain:\n",
+        "\n",
+        "- `UnstructuredFileLoader` is not the only document loader type that LangChain provides. Docs: https://python.langchain.com/docs/integrations/document_loaders/unstructured_file\n",
+        "- `RecursiveCharacterTextSplitter` is what we use to create smaller chunks of text from the doc. Docs: https://python.langchain.com/docs/modules/data_connection/document_transformers/text_splitters/recursive_text_splitter"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 2,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "I7VS1bPr1vmt",
+        "outputId": "72299230-26c4-4d80-d61f-138616e2173b"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Listing available documents ... ['resources/nke-10k-2023.pdf', 'resources/amzn-10k-2023.pdf', 'resources/metrics_2500_0.csv', 'resources/jnj-10k-2023.pdf', 'resources/aapl-10k-2023.pdf', 'resources/testset_15.csv', 'resources/retrieval_basic_rag_test.csv', 'resources/2022-chevy-colorado-ebrochure.pdf', 'resources/nvd-10k-2023.pdf', 'resources/testset.csv', 'resources/msft-10k-2023.pdf', 'resources/propositions.json', 'resources/generation_basic_rag_test.csv']\n"
+          ]
+        }
+      ],
+      "source": [
+        "from langchain.text_splitter import RecursiveCharacterTextSplitter\n",
+        "from langchain.document_loaders import UnstructuredFileLoader\n",
+        "\n",
+        "# Load list of pdfs from a folder\n",
+        "data_path = \"resources/\"\n",
+        "docs = [os.path.join(data_path, file) for file in os.listdir(data_path)]\n",
+        "\n",
+        "print(\"Listing available documents ...\", docs)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 3,
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "/var/folders/_g/rr4lnxxx1_z7m78lz89dhvsm0000gp/T/ipykernel_45325/1931079106.py:8: LangChainDeprecationWarning: The class `UnstructuredFileLoader` was deprecated in LangChain 0.2.8 and will be removed in 1.0. An updated version of the class exists in the :class:`~langchain-unstructured package and should be used instead. To use it run `pip install -U :class:`~langchain-unstructured` and import as `from :class:`~langchain_unstructured import UnstructuredLoader``.\n",
+            "  loader = UnstructuredFileLoader(\n"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Done preprocessing. Created 179 chunks of the original pdf resources/nke-10k-2023.pdf\n"
+          ]
+        }
+      ],
+      "source": [
+        "# pick out the Nike doc for this exercise\n",
+        "doc = [doc for doc in docs if \"nke\" in doc][0]\n",
+        "\n",
+        "# set up the file loader/extractor and text splitter to create chunks\n",
+        "text_splitter = RecursiveCharacterTextSplitter(\n",
+        "    chunk_size=2500, chunk_overlap=0\n",
+        ")\n",
+        "loader = UnstructuredFileLoader(\n",
+        "    doc, mode=\"single\", strategy=\"fast\"\n",
+        ")\n",
+        "\n",
+        "# extract, load, and make chunks\n",
+        "chunks = loader.load_and_split(text_splitter)\n",
+        "\n",
+        "print(\"Done preprocessing. Created\", len(chunks), \"chunks of the original pdf\", doc)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "96BzcyW31vmw"
+      },
+      "source": [
+        "### Initialize Embeddings Model\n",
+        "Here we will use LangChain's built in embedding engine so that it will work seemlessly with the LangChain VectorStore classes."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 4,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 465,
+          "referenced_widgets": [
+            "e822a189950844309e630f3e428d5a9a",
+            "d3e5c2097a8e44f481e91646e0410e62",
+            "b1e8dcf4ead64c5b8155594fd1d20632",
+            "bd042dad15084b098dfbf7c9277d3581",
+            "54c512a0bb9f485a9612f088c717eec8",
+            "e769ce42211749599822ffc3a18e7292",
+            "0d6362898099436abb80e52eac043c4f",
+            "e3afaca826464f94b6b904e68c827cab",
+            "27ba4306f92c4d659cadcd5c1e0ab787",
+            "15378b3263a449fabf00643fdd23565e",
+            "aee906bc037849e2be3ac68955281892",
+            "2e3997001c494151829379467dde2182",
+            "0281867e8ce8433fb665e287505d0404",
+            "d6ff7f1d2a6b44ff829212b67613e03b",
+            "3402b3afe4304aec81a1e4389e2eafec",
+            "fc32fd51efd2488e9bff38274079d7e5",
+            "07a6bd4b6a484dbebda92c366f3a6740",
+            "13fb05f6cbe24acba47be67e8b0a69a6",
+            "3d30fc25d10e4ce18d50320a88b0a2ec",
+            "ebe649c53e4d48fda0d4ea9a46ec5613",
+            "843c2b0500ee4219841c959f3af20542",
+            "d84881099d4f4f1fa8a481ea9f9dafdd",
+            "04c8bb6bb7c8425b92e0f3fab63d8362",
+            "4d54077e8c38411080b1ef9bfb42e3f8",
+            "b8c9c7fb7b6e4dcfb717f96da1639553",
+            "52961d70221846f78523df1414eb3436",
+            "008e25d7de5e4e548d80be81e26bdb8f",
+            "b0d11b0e853740b7b8e49e5158c940e5",
+            "ac450c103bb44f549a7103f67634f9bf",
+            "99204cde99b348ccb4f45589802f5a38",
+            "2860317abc5b41fab94f8fefe9cb6b3b",
+            "30ebda1e38294648b014354009c17269",
+            "755e63baf4ad4a289fd756d662d9a0bf",
+            "723ef31f042343bd94217075e1857989",
+            "820afc900ef34cdc82f4e5d7c38fb67f",
+            "f06938274c0d4b4591b6cfa2e7a8d183",
+            "1ab52b039fdb4cab909eb439a4ea3524",
+            "d1e27bbac128455e9a0e959ba251eedd",
+            "ff4297f185ce4f2eaf340a422b721774",
+            "168314c6ae1044d6810def7ff06f80c2",
+            "dad25775795b46ec9e7bb788b1d25f82",
+            "4e74d1276be141c9b0f2601ce4c7246a",
+            "2dff47a7d6364e2ba73f057e9b17a705",
+            "f4b4bc8eeef84da2abcf1691e174a080",
+            "6dbbd3a5f81b46d99c9c897dba53d6a5",
+            "b63b4da89d0f45819ad0aead03833f4c",
+            "27725152494c4f0b85e48bf081113764",
+            "8d8356cdf3b54b2daa02fe6d06c2b372",
+            "e61f0ecfe4794a4d929b76b8a5434800",
+            "b1e6fa50486c4973b44b20e29c4837a9",
+            "5d3f0bfd81b34819a6edce0496958f5a",
+            "266abb8c7e064dbea106c6c2903404c3",
+            "59317d931ba14c409d7f9baae6b4b2fc",
+            "da5242e187fd4d6c950e7a75cebb33fa",
+            "a28d8e8eedf34026afe93d2105d7d779",
+            "b4683c36fb744ac18ed8f98f1d352d16",
+            "a68f0e29f8f745fab98bd16b4835956a",
+            "d7791474a31b4ef7bffecdd264cbd0a5",
+            "e49064443c9549ebb7a6d0710d2ad02e",
+            "ee0db8230ae64f1b94e246e2947682a3",
+            "cff28f0f731c48e88de8ccad15146e2f",
+            "af1f8d072046449d9437cb10ccdb2218",
+            "a1f692c86e6d4c668f31bcb4f4189f48",
+            "a8b7b5ad3c954b94bda03987653ce1c8",
+            "32a5f8335e3a4312aea8bb83505b4ed3",
+            "0d4624d3273d46268299e37d96c0d85d",
+            "7c1867628e4742868ba1e1fa322b948e",
+            "35e9d31c8cfb41199df0e4636537a9c0",
+            "f1fff6bb909d4fcbbe0a7582fe5a09d4",
+            "0b3b28fae35d497886c72e4222470629",
+            "bfd29912ee224c4e93ec37f545339586",
+            "d335cf6ac50b46f5a50870069a14a066",
+            "5b7765acd2024e04ba423edc346fe021",
+            "96c778b21e154c77952c3b6456831f6a",
+            "67730a22939d42db8894a633483fd412",
+            "c3e15e863ece4df88d1ad4fa4601fb43",
+            "ce7fbbb4b844429aa16d60c6524bb6ca",
+            "0d1bc800782745a9b89e93bb992e0ce0",
+            "369c5197fd23479c8aa79ac72cbea260",
+            "5317c63c5168499eb992b4d764761dfc",
+            "364519d35ab848199a6fb3e15906318a",
+            "8b7e8c8ff5f3478aa064f5b79ffaaadf",
+            "ccb27092ee314285add51fd91e5ca49d",
+            "61f3b41fdcf04cff88dd08b36a4a5f41",
+            "816a516fa90f43a18dfda92374c2f4ed",
+            "7d8e2e3c678642afba660b450d5f3201",
+            "872caf759d1f45439397ee35c8cf5dc0",
+            "74b0c9b3b9944eab80f16b2789d6c041",
+            "27b3516e55614d1e91ce4c87c022ee0a",
+            "3991f774ac7f492993002be26cd67f18",
+            "d6804472f88d4254925b7b006a97b2c8",
+            "e0cae801b89e43598bab0ce7f38d7042",
+            "09049b516bc545ea844a770021f6812a",
+            "6a3ae2fa53c942edbb1b29a86717ad89",
+            "3da15201c5da4e40b0b3ac999552723a",
+            "bda924a0e1364f89a7f6c9c5ceb03b62",
+            "7a83acfd4fb240c181f127fc7ee07d48",
+            "d6ebd756685b4a589332a3598a25cd89",
+            "f3d585528e6a4962bfb93afbe92b6312",
+            "879c273bd3924ec0acaec655a92350e0",
+            "744ba6e1b34e4883b49c138ab1bdbebc",
+            "d449ea30c72044f986ffc3e1f9a128d8",
+            "976d3f30f0654d48b096a5c39a8dece5",
+            "41685bf8cb4344368edf161b66ae15b2",
+            "7034b97b70c84a01a3d48e316814b555",
+            "39a239df60004a039de689a69c571afc",
+            "1b2f3f0c7afd419e88f061d0c3280989",
+            "701d2879a67c4b86b9f9de76ff675e7c",
+            "955d7c1b76b348549daceb8482a8e825",
+            "2d0a785ceb884a1f9ee020d22c987fa1",
+            "543e7442413d4035bb6949ccbab5cb6b",
+            "5d47f3871bf44a469dcfd0e456d3dae0",
+            "bbb1a53611e14dcb9b028fe82d71e317",
+            "0d31b15287954c3094750dd36a10d47a",
+            "9818040fcf844fd9b00cd0e438209d40",
+            "7c269846386c4f14bfafde1d5c0e871e",
+            "b11227ec73784e09871e0c25131b9f86",
+            "4083110114e3443c920cbeb8c396d4da",
+            "366cf22df75b42509e5610ff9c9b1d3d",
+            "ff231927834c41088becbe8f94f96f7b",
+            "6e3f1af22a534a7ebdb9752acb7f1b96",
+            "7a6e695c3dcf417f9f53ceb019e37111",
+            "5bf9cc6f60614542bf0628586b8560dd",
+            "d08483b9393840cfb36dd504514043c4",
+            "d36c28d414af4712b16a7f0543f61fc9",
+            "00b534687273409fbc18960bb7db0907",
+            "a27b96cc3ce944549ba2d26f5d7338c2",
+            "75f27178134f477db58ef7cfc487897b",
+            "e2816b9d2a21443c82b547466c3347d1",
+            "0a9b8aa436604adc85c1f9a86a9889a6",
+            "37e5517b0c7b45e0ad3366d4daf5b668",
+            "58f9c1e1f51f49c48c6dc6b441078218",
+            "a8114c2300b74599b0652601806b080e",
+            "e211cf2a0e6d4d1096bfb9dfaae00cbb",
+            "f63c59800b0845b8bc8d9c2cce8bafc0",
+            "1f7ba17ad64c4ab68fe963eaf7a1efa7",
+            "05d146ed0f084dac8845c32c4bb28cff",
+            "d05d9073ecd2434da541da9d71c3a907",
+            "52a56e10c8084ce999802b6db17ab78e",
+            "84e4dc1690b642b7b00f5e1cedff91e8",
+            "0ab7b921de994f6980493fb89d3b8572",
+            "6ff193e5c339435cba696e69b4a1ea20",
+            "7ebc91105d344011898341ce4f7edce0",
+            "ae72de3e05a4461d9c2b0c1f953894b2",
+            "69d7c03c926e441a9bccfbe86fd5731d",
+            "9e0ba3c3e2a84f43ae708c89203c814a",
+            "b2b8a580aa1944e6a00106f47070935c",
+            "cf7adc55be354c75b64d9a94285ea8f9",
+            "770d6b0784674359a669f3f1836a5876",
+            "c60fc7a6181a40d489ff43af79ff29b4",
+            "4ffcc071ec56449ba865c876bc5cff5c",
+            "a9c792cb80884e0899da0f40d9472e97",
+            "7ba192f9998e41b782db482b60655f86",
+            "737a0eaff10c4237a67cbd680160ee91"
+          ]
+        },
+        "id": "_h1e-L9yZfaY",
+        "outputId": "fd540dd7-a0aa-4827-e001-f6d4ef603c6a"
+      },
+      "outputs": [],
+      "source": [
+        "from langchain_huggingface import HuggingFaceEmbeddings\n",
+        "\n",
+        "embeddings = HuggingFaceEmbeddings(model_name=\"sentence-transformers/all-MiniLM-L6-v2\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "Qrj-jeGmBRTL"
+      },
+      "source": [
+        "## Vector Search with LangChain\n",
+        "### Create Redis vector store instance\n",
+        "\n",
+        "We also need to create a schema for the vector index so we can take advantage of the metadata along with the vectors.\n",
+        "\n",
+        "**Important Note**: LangChain does not support JSON data types yet. Only supports HASH for now. This update should be coming soon."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 5,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "yY69FViAjNv1",
+        "outputId": "ab7b212b-3c55-44b1-cf72-6eb926cf302f"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "16:18:04 redisvl.index.index INFO   Index already exists, not overwriting.\n"
+          ]
+        }
+      ],
+      "source": [
+        "from langchain_redis import RedisVectorStore\n",
+        "\n",
+        "index_name = \"langchain_ex\"\n",
+        "\n",
+        "# construct the vector store class from texts and metadata\n",
+        "rds = RedisVectorStore.from_documents(\n",
+        "    chunks,\n",
+        "    embeddings,\n",
+        "    index_name=index_name,\n",
+        "    redis_url=REDIS_URL,\n",
+        "    metadata_schema=[\n",
+        "        {\n",
+        "            \"name\": \"source\",\n",
+        "            \"type\": \"text\"\n",
+        "        },\n",
+        "    ]\n",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 6,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "gntcxF1P1vmx",
+        "outputId": "3bef4861-8778-4ab7-fb61-710aba655f2c"
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "1123"
+            ]
+          },
+          "execution_count": 6,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "# access underlying redis client to see how many docs have been stores\n",
+        "rds._index.client.dbsize()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "61xV5qyp1vmy"
+      },
+      "source": [
+        "### Query the database\n",
+        "Now we can use the LangChain vector store class to perform similarity search operations on Redis"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 7,
+      "metadata": {
+        "id": "Gv6SxKOB1vmy"
+      },
+      "outputs": [],
+      "source": [
+        "from redisvl.query.filter import Text"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 8,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "Q3pH3MPD1vmy",
+        "outputId": "2754347f-be31-4a38-d356-31ecc235ffe8"
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "[(Document(metadata={'source': 'resources/nke-10k-2023.pdf'}, page_content=\"(Dollars in millions, except per share data)\\n\\nRevenues Cost of sales\\n\\nGross profit Gross margin\\n\\nDemand creation expense Operating overhead expense\\n\\nTotal selling and administrative expense % of revenues\\n\\nInterest expense (income), net\\n\\nOther (income) expense, net Income before income taxes\\n\\nIncome tax expense Effective tax rate\\n\\nNET INCOME Diluted earnings per common share\\n\\n$\\n\\n$ $\\n\\nFISCAL 2023\\n\\n51,217 28,925\\n\\n22,292\\n\\n43.5 %\\n\\n4,060 12,317\\n\\n16,377\\n\\n32.0 % (6)\\n\\n(280) 6,201\\n\\n1,131\\n\\n18.2 %\\n\\n5,070 3.23\\n\\n$\\n\\n$ $\\n\\nFISCAL 2022\\n\\n46,710 25,231\\n\\n21,479\\n\\n46.0 %\\n\\n3,850 10,954\\n\\n14,804\\n\\n31.7 % 205\\n\\n(181) 6,651\\n\\n605 9.1 %\\n\\n6,046 3.75\\n\\n% CHANGE\\n\\n10 % $ 15 %\\n\\n4 %\\n\\n5 % 12 %\\n\\n11 %\\n\\n—\\n\\n— -7 %\\n\\n87 %\\n\\n16 % $ -14 % $\\n\\nFISCAL 2021\\n\\n% CHANGE\\n\\n44,538 24,576\\n\\n5 % 3 %\\n\\n19,962\\n\\n8 %\\n\\n44.8 %\\n\\n3,114 9,911\\n\\n24 % 11 %\\n\\n13,025\\n\\n14 %\\n\\n29.2 % 262\\n\\n—\\n\\n14 6,661\\n\\n— 0 %\\n\\n934 14.0 %\\n\\n35 %\\n\\n5,727 3.56\\n\\n6 % 5 %\\n\\n2023 FORM 10-K 31\\n\\nTable of Contents\\n\\nCONSOLIDATED OPERATING RESULTS REVENUES\\n\\n(Dollars in millions)\\n\\nFISCAL 2023\\n\\nFISCAL 2022\\n\\n% CHANGE\\n\\n% CHANGE EXCLUDING CURRENCY (1) CHANGES\\n\\nFISCAL 2021\\n\\n% CHANGE\\n\\nNIKE, Inc. Revenues:\\n\\nNIKE Brand Revenues by:\\n\\nFootwear Apparel\\n\\n$\\n\\n33,135 $ 13,843\\n\\n29,143 13,567\\n\\n14 % 2 %\\n\\n20 % $ 8 %\\n\\n28,021 12,865\\n\\n4 % 5 %\\n\\nEquipment Global Brand Divisions\\n\\n(2)\\n\\nTotal NIKE Brand Revenues\\n\\n$\\n\\n1,727 58\\n\\n48,763 $\\n\\n1,624 102 44,436\\n\\n6 % -43 % 10 %\\n\\n13 % -43 % 16 % $\\n\\n1,382 25 42,293\\n\\n18 % 308 % 5 %\\n\\nConverse Corporate\\n\\n(3)\\n\\n2,427 27\\n\\n2,346 (72)\\n\\n3 % —\\n\\n8 % —\\n\\n2,205 40\\n\\n6 % —\\n\\nTOTAL NIKE, INC. REVENUES\\n\\n$\\n\\n51,217 $\\n\\n46,710\\n\\n10 %\\n\\n16 % $\\n\\n44,538\\n\\n5 %\\n\\nSupplemental NIKE Brand Revenues Details: NIKE Brand Revenues by:\\n\\nSales to Wholesale Customers\\n\\n$\\n\\n27,397 $\\n\\n25,608\\n\\n7 %\\n\\n14 % $\\n\\n25,898\\n\\n1 %\\n\\nSales through NIKE Direct Global Brand Divisions\\n\\n(2)\\n\\n21,308 58\\n\\n18,726 102\\n\\n14 % -43 %\\n\\n20 % -43 %\\n\\n16,370 25\\n\\n14 % 308 %\\n\\nTOTAL NIKE BRAND REVENUES (1) NIKE Brand Revenues on a Wholesale Equivalent Basis :\\n\\n$\\n\\n48,763 $\\n\\n44,436\\n\\n10 %\\n\\n16 % $\\n\\n42,293\\n\\n5 %\\n\\nSales to Wholesale Customers Sales from our Wholesale Operations to NIKE Direct Operations\\n\\nTOTAL NIKE BRAND WHOLESALE EQUIVALENT REVENUES NIKE Brand Wholesale Equivalent Revenues by:\\n\\n(1),(4)\\n\\n$\\n\\n$\\n\\n27,397 $ 12,730\\n\\n40,127 $\\n\\n25,608 10,543\\n\\n36,151\\n\\n7 % 21 %\\n\\n11 %\\n\\n14 % $ 27 %\\n\\n18 % $\\n\\n25,898 9,872\\n\\n35,770\\n\\n1 % 7 % 1 %\\n\\nMen's Women's NIKE Kids'\\n\\n$\\n\\n20,733 $ 8,606 5,038\\n\\n18,797 8,273 4,874\\n\\n10 % 4 % 3 %\\n\\n17 % $ 11 % 10 %\\n\\n18,391 8,225 4,882\\n\\n2 % 1 % 0 %\\n\\nJordan Brand (5) Others\\n\\n6,589 (839)\\n\\n5,122 (915)\\n\\n29 % 8 %\\n\\n35 % -3 %\"),\n",
+              "  0.499011814594),\n",
+              " (Document(metadata={'source': 'resources/nke-10k-2023.pdf'}, page_content=\"(Dollars in millions, except per share data)\\n\\nRevenues Cost of sales\\n\\nGross profit Gross margin\\n\\nDemand creation expense Operating overhead expense\\n\\nTotal selling and administrative expense % of revenues\\n\\nInterest expense (income), net\\n\\nOther (income) expense, net Income before income taxes\\n\\nIncome tax expense Effective tax rate\\n\\nNET INCOME Diluted earnings per common share\\n\\n$\\n\\n$ $\\n\\nFISCAL 2023\\n\\n51,217 28,925\\n\\n22,292\\n\\n43.5 %\\n\\n4,060 12,317\\n\\n16,377\\n\\n32.0 % (6)\\n\\n(280) 6,201\\n\\n1,131\\n\\n18.2 %\\n\\n5,070 3.23\\n\\n$\\n\\n$ $\\n\\nFISCAL 2022\\n\\n46,710 25,231\\n\\n21,479\\n\\n46.0 %\\n\\n3,850 10,954\\n\\n14,804\\n\\n31.7 % 205\\n\\n(181) 6,651\\n\\n605 9.1 %\\n\\n6,046 3.75\\n\\n% CHANGE\\n\\n10 % $ 15 %\\n\\n4 %\\n\\n5 % 12 %\\n\\n11 %\\n\\n—\\n\\n— -7 %\\n\\n87 %\\n\\n16 % $ -14 % $\\n\\nFISCAL 2021\\n\\n% CHANGE\\n\\n44,538 24,576\\n\\n5 % 3 %\\n\\n19,962\\n\\n8 %\\n\\n44.8 %\\n\\n3,114 9,911\\n\\n24 % 11 %\\n\\n13,025\\n\\n14 %\\n\\n29.2 % 262\\n\\n—\\n\\n14 6,661\\n\\n— 0 %\\n\\n934 14.0 %\\n\\n35 %\\n\\n5,727 3.56\\n\\n6 % 5 %\\n\\n2023 FORM 10-K 31\\n\\nTable of Contents\\n\\nCONSOLIDATED OPERATING RESULTS REVENUES\\n\\n(Dollars in millions)\\n\\nFISCAL 2023\\n\\nFISCAL 2022\\n\\n% CHANGE\\n\\n% CHANGE EXCLUDING CURRENCY (1) CHANGES\\n\\nFISCAL 2021\\n\\n% CHANGE\\n\\nNIKE, Inc. Revenues:\\n\\nNIKE Brand Revenues by:\\n\\nFootwear Apparel\\n\\n$\\n\\n33,135 $ 13,843\\n\\n29,143 13,567\\n\\n14 % 2 %\\n\\n20 % $ 8 %\\n\\n28,021 12,865\\n\\n4 % 5 %\\n\\nEquipment Global Brand Divisions\\n\\n(2)\\n\\nTotal NIKE Brand Revenues\\n\\n$\\n\\n1,727 58\\n\\n48,763 $\\n\\n1,624 102 44,436\\n\\n6 % -43 % 10 %\\n\\n13 % -43 % 16 % $\\n\\n1,382 25 42,293\\n\\n18 % 308 % 5 %\\n\\nConverse Corporate\\n\\n(3)\\n\\n2,427 27\\n\\n2,346 (72)\\n\\n3 % —\\n\\n8 % —\\n\\n2,205 40\\n\\n6 % —\\n\\nTOTAL NIKE, INC. REVENUES\\n\\n$\\n\\n51,217 $\\n\\n46,710\\n\\n10 %\\n\\n16 % $\\n\\n44,538\\n\\n5 %\\n\\nSupplemental NIKE Brand Revenues Details: NIKE Brand Revenues by:\\n\\nSales to Wholesale Customers\\n\\n$\\n\\n27,397 $\\n\\n25,608\\n\\n7 %\\n\\n14 % $\\n\\n25,898\\n\\n1 %\\n\\nSales through NIKE Direct Global Brand Divisions\\n\\n(2)\\n\\n21,308 58\\n\\n18,726 102\\n\\n14 % -43 %\\n\\n20 % -43 %\\n\\n16,370 25\\n\\n14 % 308 %\\n\\nTOTAL NIKE BRAND REVENUES (1) NIKE Brand Revenues on a Wholesale Equivalent Basis :\\n\\n$\\n\\n48,763 $\\n\\n44,436\\n\\n10 %\\n\\n16 % $\\n\\n42,293\\n\\n5 %\\n\\nSales to Wholesale Customers Sales from our Wholesale Operations to NIKE Direct Operations\\n\\nTOTAL NIKE BRAND WHOLESALE EQUIVALENT REVENUES NIKE Brand Wholesale Equivalent Revenues by:\\n\\n(1),(4)\\n\\n$\\n\\n$\\n\\n27,397 $ 12,730\\n\\n40,127 $\\n\\n25,608 10,543\\n\\n36,151\\n\\n7 % 21 %\\n\\n11 %\\n\\n14 % $ 27 %\\n\\n18 % $\\n\\n25,898 9,872\\n\\n35,770\\n\\n1 % 7 % 1 %\\n\\nMen's Women's NIKE Kids'\\n\\n$\\n\\n20,733 $ 8,606 5,038\\n\\n18,797 8,273 4,874\\n\\n10 % 4 % 3 %\\n\\n17 % $ 11 % 10 %\\n\\n18,391 8,225 4,882\\n\\n2 % 1 % 0 %\\n\\nJordan Brand (5) Others\\n\\n6,589 (839)\\n\\n5,122 (915)\\n\\n29 % 8 %\\n\\n35 % -3 %\"),\n",
+              "  0.499011814594),\n",
+              " (Document(metadata={'source': 'resources/nke-10k-2023.pdf'}, page_content=\"(Dollars in millions, except per share data)\\n\\nRevenues Cost of sales\\n\\nGross profit Gross margin\\n\\nDemand creation expense Operating overhead expense\\n\\nTotal selling and administrative expense % of revenues\\n\\nInterest expense (income), net\\n\\nOther (income) expense, net Income before income taxes\\n\\nIncome tax expense Effective tax rate\\n\\nNET INCOME Diluted earnings per common share\\n\\n$\\n\\n$ $\\n\\nFISCAL 2023\\n\\n51,217 28,925\\n\\n22,292\\n\\n43.5 %\\n\\n4,060 12,317\\n\\n16,377\\n\\n32.0 % (6)\\n\\n(280) 6,201\\n\\n1,131\\n\\n18.2 %\\n\\n5,070 3.23\\n\\n$\\n\\n$ $\\n\\nFISCAL 2022\\n\\n46,710 25,231\\n\\n21,479\\n\\n46.0 %\\n\\n3,850 10,954\\n\\n14,804\\n\\n31.7 % 205\\n\\n(181) 6,651\\n\\n605 9.1 %\\n\\n6,046 3.75\\n\\n% CHANGE\\n\\n10 % $ 15 %\\n\\n4 %\\n\\n5 % 12 %\\n\\n11 %\\n\\n—\\n\\n— -7 %\\n\\n87 %\\n\\n16 % $ -14 % $\\n\\nFISCAL 2021\\n\\n% CHANGE\\n\\n44,538 24,576\\n\\n5 % 3 %\\n\\n19,962\\n\\n8 %\\n\\n44.8 %\\n\\n3,114 9,911\\n\\n24 % 11 %\\n\\n13,025\\n\\n14 %\\n\\n29.2 % 262\\n\\n—\\n\\n14 6,661\\n\\n— 0 %\\n\\n934 14.0 %\\n\\n35 %\\n\\n5,727 3.56\\n\\n6 % 5 %\\n\\n2023 FORM 10-K 31\\n\\nTable of Contents\\n\\nCONSOLIDATED OPERATING RESULTS REVENUES\\n\\n(Dollars in millions)\\n\\nFISCAL 2023\\n\\nFISCAL 2022\\n\\n% CHANGE\\n\\n% CHANGE EXCLUDING CURRENCY (1) CHANGES\\n\\nFISCAL 2021\\n\\n% CHANGE\\n\\nNIKE, Inc. Revenues:\\n\\nNIKE Brand Revenues by:\\n\\nFootwear Apparel\\n\\n$\\n\\n33,135 $ 13,843\\n\\n29,143 13,567\\n\\n14 % 2 %\\n\\n20 % $ 8 %\\n\\n28,021 12,865\\n\\n4 % 5 %\\n\\nEquipment Global Brand Divisions\\n\\n(2)\\n\\nTotal NIKE Brand Revenues\\n\\n$\\n\\n1,727 58\\n\\n48,763 $\\n\\n1,624 102 44,436\\n\\n6 % -43 % 10 %\\n\\n13 % -43 % 16 % $\\n\\n1,382 25 42,293\\n\\n18 % 308 % 5 %\\n\\nConverse Corporate\\n\\n(3)\\n\\n2,427 27\\n\\n2,346 (72)\\n\\n3 % —\\n\\n8 % —\\n\\n2,205 40\\n\\n6 % —\\n\\nTOTAL NIKE, INC. REVENUES\\n\\n$\\n\\n51,217 $\\n\\n46,710\\n\\n10 %\\n\\n16 % $\\n\\n44,538\\n\\n5 %\\n\\nSupplemental NIKE Brand Revenues Details: NIKE Brand Revenues by:\\n\\nSales to Wholesale Customers\\n\\n$\\n\\n27,397 $\\n\\n25,608\\n\\n7 %\\n\\n14 % $\\n\\n25,898\\n\\n1 %\\n\\nSales through NIKE Direct Global Brand Divisions\\n\\n(2)\\n\\n21,308 58\\n\\n18,726 102\\n\\n14 % -43 %\\n\\n20 % -43 %\\n\\n16,370 25\\n\\n14 % 308 %\\n\\nTOTAL NIKE BRAND REVENUES (1) NIKE Brand Revenues on a Wholesale Equivalent Basis :\\n\\n$\\n\\n48,763 $\\n\\n44,436\\n\\n10 %\\n\\n16 % $\\n\\n42,293\\n\\n5 %\\n\\nSales to Wholesale Customers Sales from our Wholesale Operations to NIKE Direct Operations\\n\\nTOTAL NIKE BRAND WHOLESALE EQUIVALENT REVENUES NIKE Brand Wholesale Equivalent Revenues by:\\n\\n(1),(4)\\n\\n$\\n\\n$\\n\\n27,397 $ 12,730\\n\\n40,127 $\\n\\n25,608 10,543\\n\\n36,151\\n\\n7 % 21 %\\n\\n11 %\\n\\n14 % $ 27 %\\n\\n18 % $\\n\\n25,898 9,872\\n\\n35,770\\n\\n1 % 7 % 1 %\\n\\nMen's Women's NIKE Kids'\\n\\n$\\n\\n20,733 $ 8,606 5,038\\n\\n18,797 8,273 4,874\\n\\n10 % 4 % 3 %\\n\\n17 % $ 11 % 10 %\\n\\n18,391 8,225 4,882\\n\\n2 % 1 % 0 %\\n\\nJordan Brand (5) Others\\n\\n6,589 (839)\\n\\n5,122 (915)\\n\\n29 % 8 %\\n\\n35 % -3 %\"),\n",
+              "  0.499011814594),\n",
+              " (Document(metadata={'source': 'resources/nke-10k-2023.pdf'}, page_content=\"Tax (expense) benefit Gain (loss) net of tax\\n\\n5 (14)\\n\\n(9) 22\\n\\nTotal net gain (loss) reclassified for the period\\n\\n$\\n\\n463 $\\n\\n30\\n\\n2023 FORM 10-K 82\\n\\nTable of Contents\\n\\nNOTE 14 — REVENUES\\n\\nDISAGGREGATION OF REVENUES The following tables present the Company's Revenues disaggregated by reportable operating segment, major product line and distribution channel:\\n\\n(Dollars in millions)\\n\\nNORTH AMERICA\\n\\nEUROPE, MIDDLE EAST & AFRICA\\n\\nGREATER CHINA\\n\\nYEAR ENDED MAY 31, 2023 ASIA PACIFIC & LATIN (1)\\n\\nGLOBAL BRAND DIVISIONS\\n\\nTOTAL NIKE\\n\\nAMERICA\\n\\nBRAND CONVERSE CORPORATE\\n\\nTOTAL NIKE, INC.\\n\\nRevenues by: Footwear\\n\\n$\\n\\n14,897 $\\n\\n8,260 $\\n\\n5,435 $\\n\\n4,543 $\\n\\n— $\\n\\n33,135 $\\n\\n2,155 $\\n\\n— $\\n\\n35,290\\n\\nApparel Equipment Other\\n\\n5,947 764 —\\n\\n4,566 592 —\\n\\n1,666 147 —\\n\\n1,664 224 —\\n\\n— — 58\\n\\n13,843 1,727 58\\n\\n90 28 154\\n\\n— — 27\\n\\n13,933 1,755 239\\n\\nTOTAL REVENUES\\n\\n$\\n\\n21,608 $\\n\\n13,418 $\\n\\n7,248 $\\n\\n6,431 $\\n\\n58 $\\n\\n48,763 $\\n\\n2,427 $\\n\\n27 $\\n\\n51,217\\n\\nRevenues by:\\n\\nSales to Wholesale Customers Sales through Direct to Consumer\\n\\n$\\n\\n11,273 $ 10,335\\n\\n8,522 $ 4,896\\n\\n3,866 $ 3,382\\n\\n3,736 $ 2,695\\n\\n— $ —\\n\\n27,397 $ 21,308\\n\\n1,299 $ 974\\n\\n— $ —\\n\\n28,696 22,282\\n\\nOther\\n\\nTOTAL REVENUES\\n\\n$\\n\\n—\\n\\n21,608 $\\n\\n—\\n\\n13,418 $\\n\\n— 7,248 $\\n\\n— 6,431 $\\n\\n58 58 $\\n\\n58\\n\\n48,763 $\\n\\n154 2,427 $\\n\\n27 27 $\\n\\n239 51,217\\n\\n(1) Refer to Note 18 — Acquisitions and Divestitures for additional information on the transition of the Company's NIKE Brand businesses in its CASA territory to third-party distributors.\\n\\nYEAR ENDED MAY 31, 2022\\n\\n(Dollars in millions)\\n\\nNORTH AMERICA\\n\\nEUROPE, MIDDLE EAST & AFRICA\\n\\nGREATER CHINA\\n\\nASIA PACIFIC & LATIN AMERICA\\n\\nGLOBAL BRAND DIVISIONS\\n\\nTOTAL NIKE\\n\\nBRAND CONVERSE CORPORATE\\n\\nTOTAL NIKE, INC.\\n\\nRevenues by: Footwear Apparel\\n\\n$\\n\\n12,228 $ 5,492\\n\\n7,388 $ 4,527\\n\\n5,416 $ 1,938\\n\\n4,111 $ 1,610\\n\\n— $ —\\n\\n29,143 $ 13,567\\n\\n2,094 $ 103\\n\\n— $ —\\n\\n31,237 13,670\\n\\nEquipment Other\\n\\n633 —\\n\\n564 —\\n\\n193 —\\n\\n234 —\\n\\n— 102\\n\\n1,624 102\\n\\n26 123\\n\\n— (72)\\n\\n1,650 153\\n\\nTOTAL REVENUES Revenues by:\\n\\n$\\n\\n18,353 $\\n\\n12,479 $\\n\\n7,547 $\\n\\n5,955 $\\n\\n102 $\\n\\n44,436 $\\n\\n2,346 $\\n\\n(72) $\\n\\n46,710\\n\\nSales to Wholesale Customers Sales through Direct to Consumer Other\\n\\n$\\n\\n9,621 $ 8,732 —\\n\\n8,377 $ 4,102 —\\n\\n4,081 $ 3,466 —\\n\\n3,529 $ 2,426 —\\n\\n— $ — 102\\n\\n25,608 $ 18,726 102\\n\\n1,292 $ 931 123\\n\\n— $ — (72)\\n\\n26,900 19,657 153\\n\\nTOTAL REVENUES\\n\\n$\\n\\n18,353 $\\n\\n12,479 $\\n\\n7,547 $\\n\\n5,955 $\\n\\n102 $\\n\\n44,436 $\\n\\n2,346 $\\n\\n(72) $\\n\\n46,710\\n\\n2023 FORM 10-K 83\\n\\nTable of Contents\\n\\nYEAR ENDED MAY 31, 2021\\n\\n(Dollars in millions)\\n\\nNORTH AMERICA\\n\\nEUROPE, MIDDLE EAST & AFRICA\\n\\nGREATER CHINA\"),\n",
+              "  0.529603242874)]"
+            ]
+          },
+          "execution_count": 8,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "# basic \"top 4\" vector search on a given query\n",
+        "rds.similarity_search_with_score(query=\"Profit margins\", k=4)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 9,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "od6Wqmya1vmy",
+        "outputId": "5dbac581-4a07-45b0-d630-995342e91dc7"
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "[(Document(metadata={'source': 'resources/nke-10k-2023.pdf'}, page_content=\"(Dollars in millions, except per share data)\\n\\nRevenues Cost of sales\\n\\nGross profit Gross margin\\n\\nDemand creation expense Operating overhead expense\\n\\nTotal selling and administrative expense % of revenues\\n\\nInterest expense (income), net\\n\\nOther (income) expense, net Income before income taxes\\n\\nIncome tax expense Effective tax rate\\n\\nNET INCOME Diluted earnings per common share\\n\\n$\\n\\n$ $\\n\\nFISCAL 2023\\n\\n51,217 28,925\\n\\n22,292\\n\\n43.5 %\\n\\n4,060 12,317\\n\\n16,377\\n\\n32.0 % (6)\\n\\n(280) 6,201\\n\\n1,131\\n\\n18.2 %\\n\\n5,070 3.23\\n\\n$\\n\\n$ $\\n\\nFISCAL 2022\\n\\n46,710 25,231\\n\\n21,479\\n\\n46.0 %\\n\\n3,850 10,954\\n\\n14,804\\n\\n31.7 % 205\\n\\n(181) 6,651\\n\\n605 9.1 %\\n\\n6,046 3.75\\n\\n% CHANGE\\n\\n10 % $ 15 %\\n\\n4 %\\n\\n5 % 12 %\\n\\n11 %\\n\\n—\\n\\n— -7 %\\n\\n87 %\\n\\n16 % $ -14 % $\\n\\nFISCAL 2021\\n\\n% CHANGE\\n\\n44,538 24,576\\n\\n5 % 3 %\\n\\n19,962\\n\\n8 %\\n\\n44.8 %\\n\\n3,114 9,911\\n\\n24 % 11 %\\n\\n13,025\\n\\n14 %\\n\\n29.2 % 262\\n\\n—\\n\\n14 6,661\\n\\n— 0 %\\n\\n934 14.0 %\\n\\n35 %\\n\\n5,727 3.56\\n\\n6 % 5 %\\n\\n2023 FORM 10-K 31\\n\\nTable of Contents\\n\\nCONSOLIDATED OPERATING RESULTS REVENUES\\n\\n(Dollars in millions)\\n\\nFISCAL 2023\\n\\nFISCAL 2022\\n\\n% CHANGE\\n\\n% CHANGE EXCLUDING CURRENCY (1) CHANGES\\n\\nFISCAL 2021\\n\\n% CHANGE\\n\\nNIKE, Inc. Revenues:\\n\\nNIKE Brand Revenues by:\\n\\nFootwear Apparel\\n\\n$\\n\\n33,135 $ 13,843\\n\\n29,143 13,567\\n\\n14 % 2 %\\n\\n20 % $ 8 %\\n\\n28,021 12,865\\n\\n4 % 5 %\\n\\nEquipment Global Brand Divisions\\n\\n(2)\\n\\nTotal NIKE Brand Revenues\\n\\n$\\n\\n1,727 58\\n\\n48,763 $\\n\\n1,624 102 44,436\\n\\n6 % -43 % 10 %\\n\\n13 % -43 % 16 % $\\n\\n1,382 25 42,293\\n\\n18 % 308 % 5 %\\n\\nConverse Corporate\\n\\n(3)\\n\\n2,427 27\\n\\n2,346 (72)\\n\\n3 % —\\n\\n8 % —\\n\\n2,205 40\\n\\n6 % —\\n\\nTOTAL NIKE, INC. REVENUES\\n\\n$\\n\\n51,217 $\\n\\n46,710\\n\\n10 %\\n\\n16 % $\\n\\n44,538\\n\\n5 %\\n\\nSupplemental NIKE Brand Revenues Details: NIKE Brand Revenues by:\\n\\nSales to Wholesale Customers\\n\\n$\\n\\n27,397 $\\n\\n25,608\\n\\n7 %\\n\\n14 % $\\n\\n25,898\\n\\n1 %\\n\\nSales through NIKE Direct Global Brand Divisions\\n\\n(2)\\n\\n21,308 58\\n\\n18,726 102\\n\\n14 % -43 %\\n\\n20 % -43 %\\n\\n16,370 25\\n\\n14 % 308 %\\n\\nTOTAL NIKE BRAND REVENUES (1) NIKE Brand Revenues on a Wholesale Equivalent Basis :\\n\\n$\\n\\n48,763 $\\n\\n44,436\\n\\n10 %\\n\\n16 % $\\n\\n42,293\\n\\n5 %\\n\\nSales to Wholesale Customers Sales from our Wholesale Operations to NIKE Direct Operations\\n\\nTOTAL NIKE BRAND WHOLESALE EQUIVALENT REVENUES NIKE Brand Wholesale Equivalent Revenues by:\\n\\n(1),(4)\\n\\n$\\n\\n$\\n\\n27,397 $ 12,730\\n\\n40,127 $\\n\\n25,608 10,543\\n\\n36,151\\n\\n7 % 21 %\\n\\n11 %\\n\\n14 % $ 27 %\\n\\n18 % $\\n\\n25,898 9,872\\n\\n35,770\\n\\n1 % 7 % 1 %\\n\\nMen's Women's NIKE Kids'\\n\\n$\\n\\n20,733 $ 8,606 5,038\\n\\n18,797 8,273 4,874\\n\\n10 % 4 % 3 %\\n\\n17 % $ 11 % 10 %\\n\\n18,391 8,225 4,882\\n\\n2 % 1 % 0 %\\n\\nJordan Brand (5) Others\\n\\n6,589 (839)\\n\\n5,122 (915)\\n\\n29 % 8 %\\n\\n35 % -3 %\"),\n",
+              "  0.499011814594),\n",
+              " (Document(metadata={'source': 'resources/nke-10k-2023.pdf'}, page_content=\"(Dollars in millions, except per share data)\\n\\nRevenues Cost of sales\\n\\nGross profit Gross margin\\n\\nDemand creation expense Operating overhead expense\\n\\nTotal selling and administrative expense % of revenues\\n\\nInterest expense (income), net\\n\\nOther (income) expense, net Income before income taxes\\n\\nIncome tax expense Effective tax rate\\n\\nNET INCOME Diluted earnings per common share\\n\\n$\\n\\n$ $\\n\\nFISCAL 2023\\n\\n51,217 28,925\\n\\n22,292\\n\\n43.5 %\\n\\n4,060 12,317\\n\\n16,377\\n\\n32.0 % (6)\\n\\n(280) 6,201\\n\\n1,131\\n\\n18.2 %\\n\\n5,070 3.23\\n\\n$\\n\\n$ $\\n\\nFISCAL 2022\\n\\n46,710 25,231\\n\\n21,479\\n\\n46.0 %\\n\\n3,850 10,954\\n\\n14,804\\n\\n31.7 % 205\\n\\n(181) 6,651\\n\\n605 9.1 %\\n\\n6,046 3.75\\n\\n% CHANGE\\n\\n10 % $ 15 %\\n\\n4 %\\n\\n5 % 12 %\\n\\n11 %\\n\\n—\\n\\n— -7 %\\n\\n87 %\\n\\n16 % $ -14 % $\\n\\nFISCAL 2021\\n\\n% CHANGE\\n\\n44,538 24,576\\n\\n5 % 3 %\\n\\n19,962\\n\\n8 %\\n\\n44.8 %\\n\\n3,114 9,911\\n\\n24 % 11 %\\n\\n13,025\\n\\n14 %\\n\\n29.2 % 262\\n\\n—\\n\\n14 6,661\\n\\n— 0 %\\n\\n934 14.0 %\\n\\n35 %\\n\\n5,727 3.56\\n\\n6 % 5 %\\n\\n2023 FORM 10-K 31\\n\\nTable of Contents\\n\\nCONSOLIDATED OPERATING RESULTS REVENUES\\n\\n(Dollars in millions)\\n\\nFISCAL 2023\\n\\nFISCAL 2022\\n\\n% CHANGE\\n\\n% CHANGE EXCLUDING CURRENCY (1) CHANGES\\n\\nFISCAL 2021\\n\\n% CHANGE\\n\\nNIKE, Inc. Revenues:\\n\\nNIKE Brand Revenues by:\\n\\nFootwear Apparel\\n\\n$\\n\\n33,135 $ 13,843\\n\\n29,143 13,567\\n\\n14 % 2 %\\n\\n20 % $ 8 %\\n\\n28,021 12,865\\n\\n4 % 5 %\\n\\nEquipment Global Brand Divisions\\n\\n(2)\\n\\nTotal NIKE Brand Revenues\\n\\n$\\n\\n1,727 58\\n\\n48,763 $\\n\\n1,624 102 44,436\\n\\n6 % -43 % 10 %\\n\\n13 % -43 % 16 % $\\n\\n1,382 25 42,293\\n\\n18 % 308 % 5 %\\n\\nConverse Corporate\\n\\n(3)\\n\\n2,427 27\\n\\n2,346 (72)\\n\\n3 % —\\n\\n8 % —\\n\\n2,205 40\\n\\n6 % —\\n\\nTOTAL NIKE, INC. REVENUES\\n\\n$\\n\\n51,217 $\\n\\n46,710\\n\\n10 %\\n\\n16 % $\\n\\n44,538\\n\\n5 %\\n\\nSupplemental NIKE Brand Revenues Details: NIKE Brand Revenues by:\\n\\nSales to Wholesale Customers\\n\\n$\\n\\n27,397 $\\n\\n25,608\\n\\n7 %\\n\\n14 % $\\n\\n25,898\\n\\n1 %\\n\\nSales through NIKE Direct Global Brand Divisions\\n\\n(2)\\n\\n21,308 58\\n\\n18,726 102\\n\\n14 % -43 %\\n\\n20 % -43 %\\n\\n16,370 25\\n\\n14 % 308 %\\n\\nTOTAL NIKE BRAND REVENUES (1) NIKE Brand Revenues on a Wholesale Equivalent Basis :\\n\\n$\\n\\n48,763 $\\n\\n44,436\\n\\n10 %\\n\\n16 % $\\n\\n42,293\\n\\n5 %\\n\\nSales to Wholesale Customers Sales from our Wholesale Operations to NIKE Direct Operations\\n\\nTOTAL NIKE BRAND WHOLESALE EQUIVALENT REVENUES NIKE Brand Wholesale Equivalent Revenues by:\\n\\n(1),(4)\\n\\n$\\n\\n$\\n\\n27,397 $ 12,730\\n\\n40,127 $\\n\\n25,608 10,543\\n\\n36,151\\n\\n7 % 21 %\\n\\n11 %\\n\\n14 % $ 27 %\\n\\n18 % $\\n\\n25,898 9,872\\n\\n35,770\\n\\n1 % 7 % 1 %\\n\\nMen's Women's NIKE Kids'\\n\\n$\\n\\n20,733 $ 8,606 5,038\\n\\n18,797 8,273 4,874\\n\\n10 % 4 % 3 %\\n\\n17 % $ 11 % 10 %\\n\\n18,391 8,225 4,882\\n\\n2 % 1 % 0 %\\n\\nJordan Brand (5) Others\\n\\n6,589 (839)\\n\\n5,122 (915)\\n\\n29 % 8 %\\n\\n35 % -3 %\"),\n",
+              "  0.499011814594),\n",
+              " (Document(metadata={'source': 'resources/nke-10k-2023.pdf'}, page_content=\"(Dollars in millions, except per share data)\\n\\nRevenues Cost of sales\\n\\nGross profit Gross margin\\n\\nDemand creation expense Operating overhead expense\\n\\nTotal selling and administrative expense % of revenues\\n\\nInterest expense (income), net\\n\\nOther (income) expense, net Income before income taxes\\n\\nIncome tax expense Effective tax rate\\n\\nNET INCOME Diluted earnings per common share\\n\\n$\\n\\n$ $\\n\\nFISCAL 2023\\n\\n51,217 28,925\\n\\n22,292\\n\\n43.5 %\\n\\n4,060 12,317\\n\\n16,377\\n\\n32.0 % (6)\\n\\n(280) 6,201\\n\\n1,131\\n\\n18.2 %\\n\\n5,070 3.23\\n\\n$\\n\\n$ $\\n\\nFISCAL 2022\\n\\n46,710 25,231\\n\\n21,479\\n\\n46.0 %\\n\\n3,850 10,954\\n\\n14,804\\n\\n31.7 % 205\\n\\n(181) 6,651\\n\\n605 9.1 %\\n\\n6,046 3.75\\n\\n% CHANGE\\n\\n10 % $ 15 %\\n\\n4 %\\n\\n5 % 12 %\\n\\n11 %\\n\\n—\\n\\n— -7 %\\n\\n87 %\\n\\n16 % $ -14 % $\\n\\nFISCAL 2021\\n\\n% CHANGE\\n\\n44,538 24,576\\n\\n5 % 3 %\\n\\n19,962\\n\\n8 %\\n\\n44.8 %\\n\\n3,114 9,911\\n\\n24 % 11 %\\n\\n13,025\\n\\n14 %\\n\\n29.2 % 262\\n\\n—\\n\\n14 6,661\\n\\n— 0 %\\n\\n934 14.0 %\\n\\n35 %\\n\\n5,727 3.56\\n\\n6 % 5 %\\n\\n2023 FORM 10-K 31\\n\\nTable of Contents\\n\\nCONSOLIDATED OPERATING RESULTS REVENUES\\n\\n(Dollars in millions)\\n\\nFISCAL 2023\\n\\nFISCAL 2022\\n\\n% CHANGE\\n\\n% CHANGE EXCLUDING CURRENCY (1) CHANGES\\n\\nFISCAL 2021\\n\\n% CHANGE\\n\\nNIKE, Inc. Revenues:\\n\\nNIKE Brand Revenues by:\\n\\nFootwear Apparel\\n\\n$\\n\\n33,135 $ 13,843\\n\\n29,143 13,567\\n\\n14 % 2 %\\n\\n20 % $ 8 %\\n\\n28,021 12,865\\n\\n4 % 5 %\\n\\nEquipment Global Brand Divisions\\n\\n(2)\\n\\nTotal NIKE Brand Revenues\\n\\n$\\n\\n1,727 58\\n\\n48,763 $\\n\\n1,624 102 44,436\\n\\n6 % -43 % 10 %\\n\\n13 % -43 % 16 % $\\n\\n1,382 25 42,293\\n\\n18 % 308 % 5 %\\n\\nConverse Corporate\\n\\n(3)\\n\\n2,427 27\\n\\n2,346 (72)\\n\\n3 % —\\n\\n8 % —\\n\\n2,205 40\\n\\n6 % —\\n\\nTOTAL NIKE, INC. REVENUES\\n\\n$\\n\\n51,217 $\\n\\n46,710\\n\\n10 %\\n\\n16 % $\\n\\n44,538\\n\\n5 %\\n\\nSupplemental NIKE Brand Revenues Details: NIKE Brand Revenues by:\\n\\nSales to Wholesale Customers\\n\\n$\\n\\n27,397 $\\n\\n25,608\\n\\n7 %\\n\\n14 % $\\n\\n25,898\\n\\n1 %\\n\\nSales through NIKE Direct Global Brand Divisions\\n\\n(2)\\n\\n21,308 58\\n\\n18,726 102\\n\\n14 % -43 %\\n\\n20 % -43 %\\n\\n16,370 25\\n\\n14 % 308 %\\n\\nTOTAL NIKE BRAND REVENUES (1) NIKE Brand Revenues on a Wholesale Equivalent Basis :\\n\\n$\\n\\n48,763 $\\n\\n44,436\\n\\n10 %\\n\\n16 % $\\n\\n42,293\\n\\n5 %\\n\\nSales to Wholesale Customers Sales from our Wholesale Operations to NIKE Direct Operations\\n\\nTOTAL NIKE BRAND WHOLESALE EQUIVALENT REVENUES NIKE Brand Wholesale Equivalent Revenues by:\\n\\n(1),(4)\\n\\n$\\n\\n$\\n\\n27,397 $ 12,730\\n\\n40,127 $\\n\\n25,608 10,543\\n\\n36,151\\n\\n7 % 21 %\\n\\n11 %\\n\\n14 % $ 27 %\\n\\n18 % $\\n\\n25,898 9,872\\n\\n35,770\\n\\n1 % 7 % 1 %\\n\\nMen's Women's NIKE Kids'\\n\\n$\\n\\n20,733 $ 8,606 5,038\\n\\n18,797 8,273 4,874\\n\\n10 % 4 % 3 %\\n\\n17 % $ 11 % 10 %\\n\\n18,391 8,225 4,882\\n\\n2 % 1 % 0 %\\n\\nJordan Brand (5) Others\\n\\n6,589 (839)\\n\\n5,122 (915)\\n\\n29 % 8 %\\n\\n35 % -3 %\"),\n",
+              "  0.499011814594),\n",
+              " (Document(metadata={'source': 'resources/nke-10k-2023.pdf'}, page_content='From time to time, we may invest in technology, business infrastructure, new businesses or capabilities, product offering and manufacturing innovation and expansion of existing businesses, such as our NIKE Direct operations, which require substantial cash investments and management attention. We believe cost-effective investments are essential to business growth and profitability; however, significant investments are subject to typical risks and uncertainties inherent in developing a new business or expanding an existing business. The failure of any significant investment to provide expected returns or profitability could have a material adverse effect on our financial results and divert management attention from more profitable business operations. See also \"Our NIKE Direct operations have required and will continue to require a substantial investment and commitment of resources and are subject to numerous risks and uncertainties.\"\\n\\nThe sale of a large number of shares of common stock by our principal shareholder could depress the market price of our common stock.\\n\\nAs of June 30, 2023, Swoosh, LLC beneficially owned approximately 77% of our Class A Common Stock. If, on June 30, 2023, all of these shares were converted into Class B Common Stock, Swoosh, LLC\\'s commensurate ownership percentage of our Class B Common Stock would be approximately 16%. The shares are available for resale, subject to the requirements of the U.S. securities laws and the terms of the limited liability company agreement governing Swoosh, LLC. The sale or prospect of a sale of a substantial number of these shares could have an adverse effect on the market price of our common stock. Swoosh, LLC was formed by Philip H. Knight, our Chairman Emeritus, to hold the majority of his shares of Class A Common Stock. Mr. Knight does not have voting rights with respect to Swoosh, LLC, although Travis Knight, his son and a NIKE director, has a significant role in the management of the Class A Common Stock owned by Swoosh, LLC.\\n\\nChanges in our credit ratings or macroeconomic conditions may affect our liquidity, increasing borrowing costs and limiting our financing options.'),\n",
+              "  0.604557394981)]"
+            ]
+          },
+          "execution_count": 9,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "# vector search with metadata filtering\n",
+        "f = Text(\"text\") % \"profit\"\n",
+        "rds.similarity_search_with_score(query=\"Profit margins\", k=4, filter=f)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 10,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "DT9sPHw51vmy",
+        "outputId": "7d2b8969-91b8-4ff7-81ba-9d0cb6280edc"
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "[(Document(metadata={'source': 'resources/nke-10k-2023.pdf'}, page_content='As discussed in Note 15 — Operating Segments and Related Information in the accompanying Notes to the Consolidated Financial Statements, our operating segments are evidence of the structure of the Company\\'s internal organization. The NIKE Brand segments are defined by geographic regions for operations participating in NIKE Brand sales activity.\\n\\nThe breakdown of Revenues is as follows:\\n\\n(Dollars in millions)\\n\\nFISCAL 2023 FISCAL 2022\\n\\n% CHANGE\\n\\n% CHANGE EXCLUDING CURRENCY (1) CHANGES FISCAL 2021\\n\\n% CHANGE\\n\\nNorth America Europe, Middle East & Africa Greater China\\n\\n$\\n\\n21,608 $ 13,418 7,248\\n\\n18,353 12,479 7,547\\n\\n18 % 8 % -4 %\\n\\n18 % $ 21 % 4 %\\n\\n17,179 11,456 8,290\\n\\n7 % 9 % -9 %\\n\\nAsia Pacific & Latin America Global Brand Divisions\\n\\n(3)\\n\\n(2)\\n\\n6,431 58\\n\\n5,955 102\\n\\n8 % -43 %\\n\\n17 % -43 %\\n\\n5,343 25\\n\\n11 % 308 %\\n\\nTOTAL NIKE BRAND Converse\\n\\n$\\n\\n48,763 $ 2,427\\n\\n44,436 2,346\\n\\n10 % 3 %\\n\\n16 % $ 8 %\\n\\n42,293 2,205\\n\\n5 % 6 %\\n\\n(4)\\n\\nCorporate TOTAL NIKE, INC. REVENUES\\n\\n$\\n\\n27\\n\\n51,217 $\\n\\n(72) 46,710\\n\\n— 10 %\\n\\n— 16 % $\\n\\n40 44,538\\n\\n— 5 %\\n\\n(1) The percent change excluding currency changes represents a non-GAAP financial measure. For further information, see \"Use of Non-GAAP Financial Measures\".\\n\\n(2) For additional information on the transition of our NIKE Brand businesses within our CASA territory to a third-party distributor, see Note 18 — Acquisitions and Divestitures of the Notes to Consolidated\\n\\nFinancial Statements contained in Item 8 of this Annual Report.\\n\\n(3) Global Brand Divisions revenues include NIKE Brand licensing and other miscellaneous revenues that are not part of a geographic operating segment.\\n\\n(4) Corporate revenues primarily consist of foreign currency hedge gains and losses related to revenues generated by entities within the NIKE Brand geographic operating segments and Converse, but\\n\\nmanaged through our central foreign exchange risk management program.\\n\\nThe primary financial measure used by the Company to evaluate performance is Earnings Before Interest and Taxes (\"EBIT\"). As discussed in Note 15 — Operating Segments and Related Information in the accompanying Notes to the Consolidated Financial Statements, certain corporate costs are not included in EBIT.\\n\\nThe breakdown of EBIT is as follows:\\n\\n(Dollars in millions)\\n\\nFISCAL 2023\\n\\nFISCAL 2022\\n\\n% CHANGE\\n\\nFISCAL 2021\\n\\nNorth America Europe, Middle East & Africa Greater China\\n\\n$\\n\\n5,454 3,531 2,283\\n\\n$\\n\\n5,114 3,293 2,365\\n\\n7 % $ 7 % -3 %\\n\\n5,089 2,435 3,243\\n\\nAsia Pacific & Latin America Global Brand Divisions (1)'),\n",
+              "  0.233286499977),\n",
+              " (Document(metadata={'source': 'resources/nke-10k-2023.pdf'}, page_content='As discussed in Note 15 — Operating Segments and Related Information in the accompanying Notes to the Consolidated Financial Statements, our operating segments are evidence of the structure of the Company\\'s internal organization. The NIKE Brand segments are defined by geographic regions for operations participating in NIKE Brand sales activity.\\n\\nThe breakdown of Revenues is as follows:\\n\\n(Dollars in millions)\\n\\nFISCAL 2023 FISCAL 2022\\n\\n% CHANGE\\n\\n% CHANGE EXCLUDING CURRENCY (1) CHANGES FISCAL 2021\\n\\n% CHANGE\\n\\nNorth America Europe, Middle East & Africa Greater China\\n\\n$\\n\\n21,608 $ 13,418 7,248\\n\\n18,353 12,479 7,547\\n\\n18 % 8 % -4 %\\n\\n18 % $ 21 % 4 %\\n\\n17,179 11,456 8,290\\n\\n7 % 9 % -9 %\\n\\nAsia Pacific & Latin America Global Brand Divisions\\n\\n(3)\\n\\n(2)\\n\\n6,431 58\\n\\n5,955 102\\n\\n8 % -43 %\\n\\n17 % -43 %\\n\\n5,343 25\\n\\n11 % 308 %\\n\\nTOTAL NIKE BRAND Converse\\n\\n$\\n\\n48,763 $ 2,427\\n\\n44,436 2,346\\n\\n10 % 3 %\\n\\n16 % $ 8 %\\n\\n42,293 2,205\\n\\n5 % 6 %\\n\\n(4)\\n\\nCorporate TOTAL NIKE, INC. REVENUES\\n\\n$\\n\\n27\\n\\n51,217 $\\n\\n(72) 46,710\\n\\n— 10 %\\n\\n— 16 % $\\n\\n40 44,538\\n\\n— 5 %\\n\\n(1) The percent change excluding currency changes represents a non-GAAP financial measure. For further information, see \"Use of Non-GAAP Financial Measures\".\\n\\n(2) For additional information on the transition of our NIKE Brand businesses within our CASA territory to a third-party distributor, see Note 18 — Acquisitions and Divestitures of the Notes to Consolidated\\n\\nFinancial Statements contained in Item 8 of this Annual Report.\\n\\n(3) Global Brand Divisions revenues include NIKE Brand licensing and other miscellaneous revenues that are not part of a geographic operating segment.\\n\\n(4) Corporate revenues primarily consist of foreign currency hedge gains and losses related to revenues generated by entities within the NIKE Brand geographic operating segments and Converse, but\\n\\nmanaged through our central foreign exchange risk management program.\\n\\nThe primary financial measure used by the Company to evaluate performance is Earnings Before Interest and Taxes (\"EBIT\"). As discussed in Note 15 — Operating Segments and Related Information in the accompanying Notes to the Consolidated Financial Statements, certain corporate costs are not included in EBIT.\\n\\nThe breakdown of EBIT is as follows:\\n\\n(Dollars in millions)\\n\\nFISCAL 2023\\n\\nFISCAL 2022\\n\\n% CHANGE\\n\\nFISCAL 2021\\n\\nNorth America Europe, Middle East & Africa Greater China\\n\\n$\\n\\n5,454 3,531 2,283\\n\\n$\\n\\n5,114 3,293 2,365\\n\\n7 % $ 7 % -3 %\\n\\n5,089 2,435 3,243\\n\\nAsia Pacific & Latin America Global Brand Divisions (1)'),\n",
+              "  0.233286499977),\n",
+              " (Document(metadata={'source': 'resources/nke-10k-2023.pdf'}, page_content='As discussed in Note 15 — Operating Segments and Related Information in the accompanying Notes to the Consolidated Financial Statements, our operating segments are evidence of the structure of the Company\\'s internal organization. The NIKE Brand segments are defined by geographic regions for operations participating in NIKE Brand sales activity.\\n\\nThe breakdown of Revenues is as follows:\\n\\n(Dollars in millions)\\n\\nFISCAL 2023 FISCAL 2022\\n\\n% CHANGE\\n\\n% CHANGE EXCLUDING CURRENCY (1) CHANGES FISCAL 2021\\n\\n% CHANGE\\n\\nNorth America Europe, Middle East & Africa Greater China\\n\\n$\\n\\n21,608 $ 13,418 7,248\\n\\n18,353 12,479 7,547\\n\\n18 % 8 % -4 %\\n\\n18 % $ 21 % 4 %\\n\\n17,179 11,456 8,290\\n\\n7 % 9 % -9 %\\n\\nAsia Pacific & Latin America Global Brand Divisions\\n\\n(3)\\n\\n(2)\\n\\n6,431 58\\n\\n5,955 102\\n\\n8 % -43 %\\n\\n17 % -43 %\\n\\n5,343 25\\n\\n11 % 308 %\\n\\nTOTAL NIKE BRAND Converse\\n\\n$\\n\\n48,763 $ 2,427\\n\\n44,436 2,346\\n\\n10 % 3 %\\n\\n16 % $ 8 %\\n\\n42,293 2,205\\n\\n5 % 6 %\\n\\n(4)\\n\\nCorporate TOTAL NIKE, INC. REVENUES\\n\\n$\\n\\n27\\n\\n51,217 $\\n\\n(72) 46,710\\n\\n— 10 %\\n\\n— 16 % $\\n\\n40 44,538\\n\\n— 5 %\\n\\n(1) The percent change excluding currency changes represents a non-GAAP financial measure. For further information, see \"Use of Non-GAAP Financial Measures\".\\n\\n(2) For additional information on the transition of our NIKE Brand businesses within our CASA territory to a third-party distributor, see Note 18 — Acquisitions and Divestitures of the Notes to Consolidated\\n\\nFinancial Statements contained in Item 8 of this Annual Report.\\n\\n(3) Global Brand Divisions revenues include NIKE Brand licensing and other miscellaneous revenues that are not part of a geographic operating segment.\\n\\n(4) Corporate revenues primarily consist of foreign currency hedge gains and losses related to revenues generated by entities within the NIKE Brand geographic operating segments and Converse, but\\n\\nmanaged through our central foreign exchange risk management program.\\n\\nThe primary financial measure used by the Company to evaluate performance is Earnings Before Interest and Taxes (\"EBIT\"). As discussed in Note 15 — Operating Segments and Related Information in the accompanying Notes to the Consolidated Financial Statements, certain corporate costs are not included in EBIT.\\n\\nThe breakdown of EBIT is as follows:\\n\\n(Dollars in millions)\\n\\nFISCAL 2023\\n\\nFISCAL 2022\\n\\n% CHANGE\\n\\nFISCAL 2021\\n\\nNorth America Europe, Middle East & Africa Greater China\\n\\n$\\n\\n5,454 3,531 2,283\\n\\n$\\n\\n5,114 3,293 2,365\\n\\n7 % $ 7 % -3 %\\n\\n5,089 2,435 3,243\\n\\nAsia Pacific & Latin America Global Brand Divisions (1)'),\n",
+              "  0.233286499977),\n",
+              " (Document(metadata={'source': 'resources/nke-10k-2023.pdf'}, page_content=\"Tax (expense) benefit Gain (loss) net of tax\\n\\n5 (14)\\n\\n(9) 22\\n\\nTotal net gain (loss) reclassified for the period\\n\\n$\\n\\n463 $\\n\\n30\\n\\n2023 FORM 10-K 82\\n\\nTable of Contents\\n\\nNOTE 14 — REVENUES\\n\\nDISAGGREGATION OF REVENUES The following tables present the Company's Revenues disaggregated by reportable operating segment, major product line and distribution channel:\\n\\n(Dollars in millions)\\n\\nNORTH AMERICA\\n\\nEUROPE, MIDDLE EAST & AFRICA\\n\\nGREATER CHINA\\n\\nYEAR ENDED MAY 31, 2023 ASIA PACIFIC & LATIN (1)\\n\\nGLOBAL BRAND DIVISIONS\\n\\nTOTAL NIKE\\n\\nAMERICA\\n\\nBRAND CONVERSE CORPORATE\\n\\nTOTAL NIKE, INC.\\n\\nRevenues by: Footwear\\n\\n$\\n\\n14,897 $\\n\\n8,260 $\\n\\n5,435 $\\n\\n4,543 $\\n\\n— $\\n\\n33,135 $\\n\\n2,155 $\\n\\n— $\\n\\n35,290\\n\\nApparel Equipment Other\\n\\n5,947 764 —\\n\\n4,566 592 —\\n\\n1,666 147 —\\n\\n1,664 224 —\\n\\n— — 58\\n\\n13,843 1,727 58\\n\\n90 28 154\\n\\n— — 27\\n\\n13,933 1,755 239\\n\\nTOTAL REVENUES\\n\\n$\\n\\n21,608 $\\n\\n13,418 $\\n\\n7,248 $\\n\\n6,431 $\\n\\n58 $\\n\\n48,763 $\\n\\n2,427 $\\n\\n27 $\\n\\n51,217\\n\\nRevenues by:\\n\\nSales to Wholesale Customers Sales through Direct to Consumer\\n\\n$\\n\\n11,273 $ 10,335\\n\\n8,522 $ 4,896\\n\\n3,866 $ 3,382\\n\\n3,736 $ 2,695\\n\\n— $ —\\n\\n27,397 $ 21,308\\n\\n1,299 $ 974\\n\\n— $ —\\n\\n28,696 22,282\\n\\nOther\\n\\nTOTAL REVENUES\\n\\n$\\n\\n—\\n\\n21,608 $\\n\\n—\\n\\n13,418 $\\n\\n— 7,248 $\\n\\n— 6,431 $\\n\\n58 58 $\\n\\n58\\n\\n48,763 $\\n\\n154 2,427 $\\n\\n27 27 $\\n\\n239 51,217\\n\\n(1) Refer to Note 18 — Acquisitions and Divestitures for additional information on the transition of the Company's NIKE Brand businesses in its CASA territory to third-party distributors.\\n\\nYEAR ENDED MAY 31, 2022\\n\\n(Dollars in millions)\\n\\nNORTH AMERICA\\n\\nEUROPE, MIDDLE EAST & AFRICA\\n\\nGREATER CHINA\\n\\nASIA PACIFIC & LATIN AMERICA\\n\\nGLOBAL BRAND DIVISIONS\\n\\nTOTAL NIKE\\n\\nBRAND CONVERSE CORPORATE\\n\\nTOTAL NIKE, INC.\\n\\nRevenues by: Footwear Apparel\\n\\n$\\n\\n12,228 $ 5,492\\n\\n7,388 $ 4,527\\n\\n5,416 $ 1,938\\n\\n4,111 $ 1,610\\n\\n— $ —\\n\\n29,143 $ 13,567\\n\\n2,094 $ 103\\n\\n— $ —\\n\\n31,237 13,670\\n\\nEquipment Other\\n\\n633 —\\n\\n564 —\\n\\n193 —\\n\\n234 —\\n\\n— 102\\n\\n1,624 102\\n\\n26 123\\n\\n— (72)\\n\\n1,650 153\\n\\nTOTAL REVENUES Revenues by:\\n\\n$\\n\\n18,353 $\\n\\n12,479 $\\n\\n7,547 $\\n\\n5,955 $\\n\\n102 $\\n\\n44,436 $\\n\\n2,346 $\\n\\n(72) $\\n\\n46,710\\n\\nSales to Wholesale Customers Sales through Direct to Consumer Other\\n\\n$\\n\\n9,621 $ 8,732 —\\n\\n8,377 $ 4,102 —\\n\\n4,081 $ 3,466 —\\n\\n3,529 $ 2,426 —\\n\\n— $ — 102\\n\\n25,608 $ 18,726 102\\n\\n1,292 $ 931 123\\n\\n— $ — (72)\\n\\n26,900 19,657 153\\n\\nTOTAL REVENUES\\n\\n$\\n\\n18,353 $\\n\\n12,479 $\\n\\n7,547 $\\n\\n5,955 $\\n\\n102 $\\n\\n44,436 $\\n\\n2,346 $\\n\\n(72) $\\n\\n46,710\\n\\n2023 FORM 10-K 83\\n\\nTable of Contents\\n\\nYEAR ENDED MAY 31, 2021\\n\\n(Dollars in millions)\\n\\nNORTH AMERICA\\n\\nEUROPE, MIDDLE EAST & AFRICA\\n\\nGREATER CHINA\"),\n",
+              "  0.261225402355)]"
+            ]
+          },
+          "execution_count": 10,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "# vector search with combinations of metadata filtering\n",
+        "\n",
+        "f = (Text(\"text\") % \"profit\") | (Text(\"text\") % \"revenue\")\n",
+        "rds.similarity_search_with_score(query=\"Nike company revenue\", k=4, filter=f)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 11,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "kIoGJOop1vmz",
+        "outputId": "9abbf5fd-77de-4094-a2e8-fba2fc5a3a05"
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "[(Document(metadata={'source': 'resources/nke-10k-2023.pdf'}, page_content='As discussed in Note 15 — Operating Segments and Related Information in the accompanying Notes to the Consolidated Financial Statements, our operating segments are evidence of the structure of the Company\\'s internal organization. The NIKE Brand segments are defined by geographic regions for operations participating in NIKE Brand sales activity.\\n\\nThe breakdown of Revenues is as follows:\\n\\n(Dollars in millions)\\n\\nFISCAL 2023 FISCAL 2022\\n\\n% CHANGE\\n\\n% CHANGE EXCLUDING CURRENCY (1) CHANGES FISCAL 2021\\n\\n% CHANGE\\n\\nNorth America Europe, Middle East & Africa Greater China\\n\\n$\\n\\n21,608 $ 13,418 7,248\\n\\n18,353 12,479 7,547\\n\\n18 % 8 % -4 %\\n\\n18 % $ 21 % 4 %\\n\\n17,179 11,456 8,290\\n\\n7 % 9 % -9 %\\n\\nAsia Pacific & Latin America Global Brand Divisions\\n\\n(3)\\n\\n(2)\\n\\n6,431 58\\n\\n5,955 102\\n\\n8 % -43 %\\n\\n17 % -43 %\\n\\n5,343 25\\n\\n11 % 308 %\\n\\nTOTAL NIKE BRAND Converse\\n\\n$\\n\\n48,763 $ 2,427\\n\\n44,436 2,346\\n\\n10 % 3 %\\n\\n16 % $ 8 %\\n\\n42,293 2,205\\n\\n5 % 6 %\\n\\n(4)\\n\\nCorporate TOTAL NIKE, INC. REVENUES\\n\\n$\\n\\n27\\n\\n51,217 $\\n\\n(72) 46,710\\n\\n— 10 %\\n\\n— 16 % $\\n\\n40 44,538\\n\\n— 5 %\\n\\n(1) The percent change excluding currency changes represents a non-GAAP financial measure. For further information, see \"Use of Non-GAAP Financial Measures\".\\n\\n(2) For additional information on the transition of our NIKE Brand businesses within our CASA territory to a third-party distributor, see Note 18 — Acquisitions and Divestitures of the Notes to Consolidated\\n\\nFinancial Statements contained in Item 8 of this Annual Report.\\n\\n(3) Global Brand Divisions revenues include NIKE Brand licensing and other miscellaneous revenues that are not part of a geographic operating segment.\\n\\n(4) Corporate revenues primarily consist of foreign currency hedge gains and losses related to revenues generated by entities within the NIKE Brand geographic operating segments and Converse, but\\n\\nmanaged through our central foreign exchange risk management program.\\n\\nThe primary financial measure used by the Company to evaluate performance is Earnings Before Interest and Taxes (\"EBIT\"). As discussed in Note 15 — Operating Segments and Related Information in the accompanying Notes to the Consolidated Financial Statements, certain corporate costs are not included in EBIT.\\n\\nThe breakdown of EBIT is as follows:\\n\\n(Dollars in millions)\\n\\nFISCAL 2023\\n\\nFISCAL 2022\\n\\n% CHANGE\\n\\nFISCAL 2021\\n\\nNorth America Europe, Middle East & Africa Greater China\\n\\n$\\n\\n5,454 3,531 2,283\\n\\n$\\n\\n5,114 3,293 2,365\\n\\n7 % $ 7 % -3 %\\n\\n5,089 2,435 3,243\\n\\nAsia Pacific & Latin America Global Brand Divisions (1)'),\n",
+              "  0.233286499977),\n",
+              " (Document(metadata={'source': 'resources/nke-10k-2023.pdf'}, page_content='As discussed in Note 15 — Operating Segments and Related Information in the accompanying Notes to the Consolidated Financial Statements, our operating segments are evidence of the structure of the Company\\'s internal organization. The NIKE Brand segments are defined by geographic regions for operations participating in NIKE Brand sales activity.\\n\\nThe breakdown of Revenues is as follows:\\n\\n(Dollars in millions)\\n\\nFISCAL 2023 FISCAL 2022\\n\\n% CHANGE\\n\\n% CHANGE EXCLUDING CURRENCY (1) CHANGES FISCAL 2021\\n\\n% CHANGE\\n\\nNorth America Europe, Middle East & Africa Greater China\\n\\n$\\n\\n21,608 $ 13,418 7,248\\n\\n18,353 12,479 7,547\\n\\n18 % 8 % -4 %\\n\\n18 % $ 21 % 4 %\\n\\n17,179 11,456 8,290\\n\\n7 % 9 % -9 %\\n\\nAsia Pacific & Latin America Global Brand Divisions\\n\\n(3)\\n\\n(2)\\n\\n6,431 58\\n\\n5,955 102\\n\\n8 % -43 %\\n\\n17 % -43 %\\n\\n5,343 25\\n\\n11 % 308 %\\n\\nTOTAL NIKE BRAND Converse\\n\\n$\\n\\n48,763 $ 2,427\\n\\n44,436 2,346\\n\\n10 % 3 %\\n\\n16 % $ 8 %\\n\\n42,293 2,205\\n\\n5 % 6 %\\n\\n(4)\\n\\nCorporate TOTAL NIKE, INC. REVENUES\\n\\n$\\n\\n27\\n\\n51,217 $\\n\\n(72) 46,710\\n\\n— 10 %\\n\\n— 16 % $\\n\\n40 44,538\\n\\n— 5 %\\n\\n(1) The percent change excluding currency changes represents a non-GAAP financial measure. For further information, see \"Use of Non-GAAP Financial Measures\".\\n\\n(2) For additional information on the transition of our NIKE Brand businesses within our CASA territory to a third-party distributor, see Note 18 — Acquisitions and Divestitures of the Notes to Consolidated\\n\\nFinancial Statements contained in Item 8 of this Annual Report.\\n\\n(3) Global Brand Divisions revenues include NIKE Brand licensing and other miscellaneous revenues that are not part of a geographic operating segment.\\n\\n(4) Corporate revenues primarily consist of foreign currency hedge gains and losses related to revenues generated by entities within the NIKE Brand geographic operating segments and Converse, but\\n\\nmanaged through our central foreign exchange risk management program.\\n\\nThe primary financial measure used by the Company to evaluate performance is Earnings Before Interest and Taxes (\"EBIT\"). As discussed in Note 15 — Operating Segments and Related Information in the accompanying Notes to the Consolidated Financial Statements, certain corporate costs are not included in EBIT.\\n\\nThe breakdown of EBIT is as follows:\\n\\n(Dollars in millions)\\n\\nFISCAL 2023\\n\\nFISCAL 2022\\n\\n% CHANGE\\n\\nFISCAL 2021\\n\\nNorth America Europe, Middle East & Africa Greater China\\n\\n$\\n\\n5,454 3,531 2,283\\n\\n$\\n\\n5,114 3,293 2,365\\n\\n7 % $ 7 % -3 %\\n\\n5,089 2,435 3,243\\n\\nAsia Pacific & Latin America Global Brand Divisions (1)'),\n",
+              "  0.233286499977),\n",
+              " (Document(metadata={'source': 'resources/nke-10k-2023.pdf'}, page_content='As discussed in Note 15 — Operating Segments and Related Information in the accompanying Notes to the Consolidated Financial Statements, our operating segments are evidence of the structure of the Company\\'s internal organization. The NIKE Brand segments are defined by geographic regions for operations participating in NIKE Brand sales activity.\\n\\nThe breakdown of Revenues is as follows:\\n\\n(Dollars in millions)\\n\\nFISCAL 2023 FISCAL 2022\\n\\n% CHANGE\\n\\n% CHANGE EXCLUDING CURRENCY (1) CHANGES FISCAL 2021\\n\\n% CHANGE\\n\\nNorth America Europe, Middle East & Africa Greater China\\n\\n$\\n\\n21,608 $ 13,418 7,248\\n\\n18,353 12,479 7,547\\n\\n18 % 8 % -4 %\\n\\n18 % $ 21 % 4 %\\n\\n17,179 11,456 8,290\\n\\n7 % 9 % -9 %\\n\\nAsia Pacific & Latin America Global Brand Divisions\\n\\n(3)\\n\\n(2)\\n\\n6,431 58\\n\\n5,955 102\\n\\n8 % -43 %\\n\\n17 % -43 %\\n\\n5,343 25\\n\\n11 % 308 %\\n\\nTOTAL NIKE BRAND Converse\\n\\n$\\n\\n48,763 $ 2,427\\n\\n44,436 2,346\\n\\n10 % 3 %\\n\\n16 % $ 8 %\\n\\n42,293 2,205\\n\\n5 % 6 %\\n\\n(4)\\n\\nCorporate TOTAL NIKE, INC. REVENUES\\n\\n$\\n\\n27\\n\\n51,217 $\\n\\n(72) 46,710\\n\\n— 10 %\\n\\n— 16 % $\\n\\n40 44,538\\n\\n— 5 %\\n\\n(1) The percent change excluding currency changes represents a non-GAAP financial measure. For further information, see \"Use of Non-GAAP Financial Measures\".\\n\\n(2) For additional information on the transition of our NIKE Brand businesses within our CASA territory to a third-party distributor, see Note 18 — Acquisitions and Divestitures of the Notes to Consolidated\\n\\nFinancial Statements contained in Item 8 of this Annual Report.\\n\\n(3) Global Brand Divisions revenues include NIKE Brand licensing and other miscellaneous revenues that are not part of a geographic operating segment.\\n\\n(4) Corporate revenues primarily consist of foreign currency hedge gains and losses related to revenues generated by entities within the NIKE Brand geographic operating segments and Converse, but\\n\\nmanaged through our central foreign exchange risk management program.\\n\\nThe primary financial measure used by the Company to evaluate performance is Earnings Before Interest and Taxes (\"EBIT\"). As discussed in Note 15 — Operating Segments and Related Information in the accompanying Notes to the Consolidated Financial Statements, certain corporate costs are not included in EBIT.\\n\\nThe breakdown of EBIT is as follows:\\n\\n(Dollars in millions)\\n\\nFISCAL 2023\\n\\nFISCAL 2022\\n\\n% CHANGE\\n\\nFISCAL 2021\\n\\nNorth America Europe, Middle East & Africa Greater China\\n\\n$\\n\\n5,454 3,531 2,283\\n\\n$\\n\\n5,114 3,293 2,365\\n\\n7 % $ 7 % -3 %\\n\\n5,089 2,435 3,243\\n\\nAsia Pacific & Latin America Global Brand Divisions (1)'),\n",
+              "  0.233286499977),\n",
+              " (Document(metadata={'source': 'resources/nke-10k-2023.pdf'}, page_content=\"Tax (expense) benefit Gain (loss) net of tax\\n\\n5 (14)\\n\\n(9) 22\\n\\nTotal net gain (loss) reclassified for the period\\n\\n$\\n\\n463 $\\n\\n30\\n\\n2023 FORM 10-K 82\\n\\nTable of Contents\\n\\nNOTE 14 — REVENUES\\n\\nDISAGGREGATION OF REVENUES The following tables present the Company's Revenues disaggregated by reportable operating segment, major product line and distribution channel:\\n\\n(Dollars in millions)\\n\\nNORTH AMERICA\\n\\nEUROPE, MIDDLE EAST & AFRICA\\n\\nGREATER CHINA\\n\\nYEAR ENDED MAY 31, 2023 ASIA PACIFIC & LATIN (1)\\n\\nGLOBAL BRAND DIVISIONS\\n\\nTOTAL NIKE\\n\\nAMERICA\\n\\nBRAND CONVERSE CORPORATE\\n\\nTOTAL NIKE, INC.\\n\\nRevenues by: Footwear\\n\\n$\\n\\n14,897 $\\n\\n8,260 $\\n\\n5,435 $\\n\\n4,543 $\\n\\n— $\\n\\n33,135 $\\n\\n2,155 $\\n\\n— $\\n\\n35,290\\n\\nApparel Equipment Other\\n\\n5,947 764 —\\n\\n4,566 592 —\\n\\n1,666 147 —\\n\\n1,664 224 —\\n\\n— — 58\\n\\n13,843 1,727 58\\n\\n90 28 154\\n\\n— — 27\\n\\n13,933 1,755 239\\n\\nTOTAL REVENUES\\n\\n$\\n\\n21,608 $\\n\\n13,418 $\\n\\n7,248 $\\n\\n6,431 $\\n\\n58 $\\n\\n48,763 $\\n\\n2,427 $\\n\\n27 $\\n\\n51,217\\n\\nRevenues by:\\n\\nSales to Wholesale Customers Sales through Direct to Consumer\\n\\n$\\n\\n11,273 $ 10,335\\n\\n8,522 $ 4,896\\n\\n3,866 $ 3,382\\n\\n3,736 $ 2,695\\n\\n— $ —\\n\\n27,397 $ 21,308\\n\\n1,299 $ 974\\n\\n— $ —\\n\\n28,696 22,282\\n\\nOther\\n\\nTOTAL REVENUES\\n\\n$\\n\\n—\\n\\n21,608 $\\n\\n—\\n\\n13,418 $\\n\\n— 7,248 $\\n\\n— 6,431 $\\n\\n58 58 $\\n\\n58\\n\\n48,763 $\\n\\n154 2,427 $\\n\\n27 27 $\\n\\n239 51,217\\n\\n(1) Refer to Note 18 — Acquisitions and Divestitures for additional information on the transition of the Company's NIKE Brand businesses in its CASA territory to third-party distributors.\\n\\nYEAR ENDED MAY 31, 2022\\n\\n(Dollars in millions)\\n\\nNORTH AMERICA\\n\\nEUROPE, MIDDLE EAST & AFRICA\\n\\nGREATER CHINA\\n\\nASIA PACIFIC & LATIN AMERICA\\n\\nGLOBAL BRAND DIVISIONS\\n\\nTOTAL NIKE\\n\\nBRAND CONVERSE CORPORATE\\n\\nTOTAL NIKE, INC.\\n\\nRevenues by: Footwear Apparel\\n\\n$\\n\\n12,228 $ 5,492\\n\\n7,388 $ 4,527\\n\\n5,416 $ 1,938\\n\\n4,111 $ 1,610\\n\\n— $ —\\n\\n29,143 $ 13,567\\n\\n2,094 $ 103\\n\\n— $ —\\n\\n31,237 13,670\\n\\nEquipment Other\\n\\n633 —\\n\\n564 —\\n\\n193 —\\n\\n234 —\\n\\n— 102\\n\\n1,624 102\\n\\n26 123\\n\\n— (72)\\n\\n1,650 153\\n\\nTOTAL REVENUES Revenues by:\\n\\n$\\n\\n18,353 $\\n\\n12,479 $\\n\\n7,547 $\\n\\n5,955 $\\n\\n102 $\\n\\n44,436 $\\n\\n2,346 $\\n\\n(72) $\\n\\n46,710\\n\\nSales to Wholesale Customers Sales through Direct to Consumer Other\\n\\n$\\n\\n9,621 $ 8,732 —\\n\\n8,377 $ 4,102 —\\n\\n4,081 $ 3,466 —\\n\\n3,529 $ 2,426 —\\n\\n— $ — 102\\n\\n25,608 $ 18,726 102\\n\\n1,292 $ 931 123\\n\\n— $ — (72)\\n\\n26,900 19,657 153\\n\\nTOTAL REVENUES\\n\\n$\\n\\n18,353 $\\n\\n12,479 $\\n\\n7,547 $\\n\\n5,955 $\\n\\n102 $\\n\\n44,436 $\\n\\n2,346 $\\n\\n(72) $\\n\\n46,710\\n\\n2023 FORM 10-K 83\\n\\nTable of Contents\\n\\nYEAR ENDED MAY 31, 2021\\n\\n(Dollars in millions)\\n\\nNORTH AMERICA\\n\\nEUROPE, MIDDLE EAST & AFRICA\\n\\nGREATER CHINA\"),\n",
+              "  0.261225402355)]"
+            ]
+          },
+          "execution_count": 11,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "# filter results to a certain distance threshold\n",
+        "rds.similarity_search_with_score(query=\"Nike company revenue\", k=4, distance_threshold=0.3)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "XdzQa112Bf2b"
+      },
+      "source": [
+        "## RAG with LangChain\n",
+        "LangChain makes it easy to now take this vector store and build retireval augmented generation (RAG) applications over your data."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "collapsed": false,
+        "id": "CU2aFQPW1vmz"
+      },
+      "source": [
+        "### Initialize OpenAI\n",
+        "\n",
+        "You need to supply an OpenAI API key (starts with `sk-...`) when prompted. If the key is in your env -- great, otherwise enter it when prompted below. You can find your API key at https://platform.openai.com/account/api-keys"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 12,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "GSpH-cur1vmz",
+        "outputId": "b00de5c7-1684-4e8e-c146-6d402910cdc5"
+      },
+      "outputs": [],
+      "source": [
+        "import getpass\n",
+        "from langchain_openai import ChatOpenAI\n",
+        "\n",
+        "llm = ChatOpenAI(openai_api_key=os.getenv(\"OPENAI_API_KEY\") or getpass.getpass(prompt=\"OpenAI API Key:\"))"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "-SQXQB-c1vmz"
+      },
+      "source": [
+        "### Setup prompt"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 13,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "from langchain_core.output_parsers import StrOutputParser\n",
+        "from langchain_core.prompts import ChatPromptTemplate\n",
+        "from langchain_core.runnables import RunnablePassthrough\n",
+        "\n",
+        "prompt_template = \"\"\"\n",
+        "    Use the following pieces of context from financial 10k filings data to answer the user question at the end. \n",
+        "    If you don't know the answer, say that you don't know, don't try to make up an answer.\n",
+        "\n",
+        "    Context:\n",
+        "    ---------\n",
+        "    {context}\n",
+        "    ---------\n",
+        "    Question:\n",
+        "    {question}\n",
+        "    Answer:\n",
+        "\"\"\"\n",
+        "\n",
+        "def format_docs(docs):\n",
+        "    return \"\\n\\n\".join(doc.page_content for doc in docs)\n",
+        "\n",
+        "prompt = ChatPromptTemplate.from_template(prompt_template)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "xgEXBujxG1dO"
+      },
+      "source": [
+        "### Putting it all together\n",
+        "\n",
+        "This is where the Langchain brings all the components together in a form of a simple RAG application with the financial PDF document."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 14,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "rag_chain = (\n",
+        "    {\n",
+        "        \"context\": rds.as_retriever() | format_docs,\n",
+        "        \"question\": RunnablePassthrough()\n",
+        "    }\n",
+        "    | prompt\n",
+        "    | llm\n",
+        "    | StrOutputParser()\n",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "SURTtVbYBFGc"
+      },
+      "source": [
+        "### Finally - let's ask questions!\n",
+        "\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 15,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 52
+        },
+        "id": "0JkswfOHZu9h",
+        "outputId": "813fffe6-3d8b-4df7-a035-c54e421c0856"
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "\"Nike's revenue last year was $44,538 million, and this year it was $51,217 million.\""
+            ]
+          },
+          "execution_count": 15,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "query = \"What was Nike's revenue last year compared to this year??\"\n",
+        "rag_chain.invoke(query)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 16,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 52
+        },
+        "id": "ZvioUduS1vm0",
+        "outputId": "a8ba0e5d-c06b-4848-d066-c26884b3caee"
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "'The exact number of products Nike offers is not explicitly stated in the provided context. However, Nike is part of the athletic footwear, apparel, and equipment industry, which is highly competitive both in the United States and worldwide.'"
+            ]
+          },
+          "execution_count": 16,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "query = \"How many products does Nike offer? What is the industry that Nike is part of?\"\n",
+        "rag_chain.invoke(query)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 17,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 35
+        },
+        "id": "Q9mE5z-61vm1",
+        "outputId": "e3860d3e-e68b-489b-9897-c7118377c7bb"
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "'Based on the provided information, there is no specific mention or data that directly addresses the ethical practices of Nike as a company. Therefore, it is not possible to determine if Nike is an ethical company based on the provided context.'"
+            ]
+          },
+          "execution_count": 17,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "query = \"Is Nike an ethical company?\"\n",
+        "rag_chain.invoke(query)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "5itk4UPF1vm1"
+      },
+      "source": [
+        "## Cleanup\n",
+        "\n",
+        "Cleanup the index and data."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 18,
+      "metadata": {
+        "id": "DtZi-mQ61vm-"
+      },
+      "outputs": [
+        {
+          "ename": "ValueError",
+          "evalue": "REDIS_URL env var not set",
+          "output_type": "error",
+          "traceback": [
+            "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+            "\u001b[0;31mValueError\u001b[0m                                Traceback (most recent call last)",
+            "Cell \u001b[0;32mIn[18], line 3\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[38;5;28;01mfrom\u001b[39;00m \u001b[38;5;21;01mredisvl\u001b[39;00m\u001b[38;5;21;01m.\u001b[39;00m\u001b[38;5;21;01mindex\u001b[39;00m \u001b[38;5;28;01mimport\u001b[39;00m SearchIndex\n\u001b[0;32m----> 3\u001b[0m idx \u001b[38;5;241m=\u001b[39m \u001b[43mSearchIndex\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mfrom_existing\u001b[49m\u001b[43m(\u001b[49m\n\u001b[1;32m      4\u001b[0m \u001b[43m    \u001b[49m\u001b[43mindex_name\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m      5\u001b[0m \u001b[43m    \u001b[49m\u001b[43mredis_url\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mREDIS_URL\u001b[49m\n\u001b[1;32m      6\u001b[0m \u001b[43m)\u001b[49m\n\u001b[1;32m      8\u001b[0m idx\u001b[38;5;241m.\u001b[39mdelete()\n",
+            "File \u001b[0;32m~/.pyenv/versions/3.11.9/lib/python3.11/site-packages/redisvl/index/index.py:322\u001b[0m, in \u001b[0;36mSearchIndex.from_existing\u001b[0;34m(cls, name, redis_client, redis_url, **kwargs)\u001b[0m\n\u001b[1;32m    320\u001b[0m \u001b[38;5;28;01mtry\u001b[39;00m:\n\u001b[1;32m    321\u001b[0m     \u001b[38;5;28;01mif\u001b[39;00m redis_url:\n\u001b[0;32m--> 322\u001b[0m         redis_client \u001b[38;5;241m=\u001b[39m \u001b[43mRedisConnectionFactory\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mget_redis_connection\u001b[49m\u001b[43m(\u001b[49m\n\u001b[1;32m    323\u001b[0m \u001b[43m            \u001b[49m\u001b[43mredis_url\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mredis_url\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    324\u001b[0m \u001b[43m            \u001b[49m\u001b[43mrequired_modules\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mREQUIRED_MODULES_FOR_INTROSPECTION\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    325\u001b[0m \u001b[43m            \u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43mkwargs\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    326\u001b[0m \u001b[43m        \u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    327\u001b[0m     \u001b[38;5;28;01melif\u001b[39;00m redis_client:\n\u001b[1;32m    328\u001b[0m         RedisConnectionFactory\u001b[38;5;241m.\u001b[39mvalidate_sync_redis(\n\u001b[1;32m    329\u001b[0m             redis_client, required_modules\u001b[38;5;241m=\u001b[39mREQUIRED_MODULES_FOR_INTROSPECTION\n\u001b[1;32m    330\u001b[0m         )\n",
+            "File \u001b[0;32m~/.pyenv/versions/3.11.9/lib/python3.11/site-packages/redisvl/redis/connection.py:248\u001b[0m, in \u001b[0;36mRedisConnectionFactory.get_redis_connection\u001b[0;34m(url, required_modules, **kwargs)\u001b[0m\n\u001b[1;32m    224\u001b[0m \u001b[38;5;129m@staticmethod\u001b[39m\n\u001b[1;32m    225\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mget_redis_connection\u001b[39m(\n\u001b[1;32m    226\u001b[0m     url: Optional[\u001b[38;5;28mstr\u001b[39m] \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;01mNone\u001b[39;00m,\n\u001b[1;32m    227\u001b[0m     required_modules: Optional[List[Dict[\u001b[38;5;28mstr\u001b[39m, Any]]] \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;01mNone\u001b[39;00m,\n\u001b[1;32m    228\u001b[0m     \u001b[38;5;241m*\u001b[39m\u001b[38;5;241m*\u001b[39mkwargs,\n\u001b[1;32m    229\u001b[0m ) \u001b[38;5;241m-\u001b[39m\u001b[38;5;241m>\u001b[39m Redis:\n\u001b[1;32m    230\u001b[0m \u001b[38;5;250m    \u001b[39m\u001b[38;5;124;03m\"\"\"Creates and returns a synchronous Redis client.\u001b[39;00m\n\u001b[1;32m    231\u001b[0m \n\u001b[1;32m    232\u001b[0m \u001b[38;5;124;03m    Args:\u001b[39;00m\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    246\u001b[0m \u001b[38;5;124;03m        RedisModuleVersionError: If required Redis modules are not installed.\u001b[39;00m\n\u001b[1;32m    247\u001b[0m \u001b[38;5;124;03m    \"\"\"\u001b[39;00m\n\u001b[0;32m--> 248\u001b[0m     url \u001b[38;5;241m=\u001b[39m url \u001b[38;5;129;01mor\u001b[39;00m \u001b[43mget_address_from_env\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    249\u001b[0m     client \u001b[38;5;241m=\u001b[39m Redis\u001b[38;5;241m.\u001b[39mfrom_url(url, \u001b[38;5;241m*\u001b[39m\u001b[38;5;241m*\u001b[39mkwargs)\n\u001b[1;32m    251\u001b[0m     RedisConnectionFactory\u001b[38;5;241m.\u001b[39mvalidate_sync_redis(\n\u001b[1;32m    252\u001b[0m         client, required_modules\u001b[38;5;241m=\u001b[39mrequired_modules\n\u001b[1;32m    253\u001b[0m     )\n",
+            "File \u001b[0;32m~/.pyenv/versions/3.11.9/lib/python3.11/site-packages/redisvl/redis/connection.py:61\u001b[0m, in \u001b[0;36mget_address_from_env\u001b[0;34m()\u001b[0m\n\u001b[1;32m     55\u001b[0m \u001b[38;5;250m\u001b[39m\u001b[38;5;124;03m\"\"\"Get a redis connection from environment variables.\u001b[39;00m\n\u001b[1;32m     56\u001b[0m \n\u001b[1;32m     57\u001b[0m \u001b[38;5;124;03mReturns:\u001b[39;00m\n\u001b[1;32m     58\u001b[0m \u001b[38;5;124;03m    str: Redis URL\u001b[39;00m\n\u001b[1;32m     59\u001b[0m \u001b[38;5;124;03m\"\"\"\u001b[39;00m\n\u001b[1;32m     60\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mREDIS_URL\u001b[39m\u001b[38;5;124m\"\u001b[39m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;129;01min\u001b[39;00m os\u001b[38;5;241m.\u001b[39menviron:\n\u001b[0;32m---> 61\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mValueError\u001b[39;00m(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mREDIS_URL env var not set\u001b[39m\u001b[38;5;124m\"\u001b[39m)\n\u001b[1;32m     62\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m os\u001b[38;5;241m.\u001b[39menviron[\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mREDIS_URL\u001b[39m\u001b[38;5;124m\"\u001b[39m]\n",
+            "\u001b[0;31mValueError\u001b[0m: REDIS_URL env var not set"
+          ]
+        }
+      ],
+      "source": [
+        "from redisvl.index import SearchIndex\n",
+        "\n",
+        "idx = SearchIndex.from_existing(\n",
+        "    index_name,\n",
+        "    redis_url=REDIS_URL\n",
+        ")\n",
+        "\n",
+        "idx.delete()"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 19,
+      "metadata": {},
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "'0.4.0'"
+            ]
+          },
+          "execution_count": 19,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "import redisvl\n",
+        "\n",
+        "redisvl.__version__"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 20,
+      "metadata": {},
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "'5.2.1'"
+            ]
+          },
+          "execution_count": 20,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "import redis\n",
+        "\n",
+        "redis.__version__"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 21,
+      "metadata": {},
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "'redis://:@localhost:6379'"
+            ]
+          },
+          "execution_count": 21,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "REDIS_URL"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": []
     }
-   ],
-   "source": [
-    "REDIS_URL"
-   ]
+  ],
+  "metadata": {
+    "accelerator": "GPU",
+    "colab": {
+      "gpuType": "T4",
+      "provenance": []
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.11.9"
+    }
   },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  }
- ],
- "metadata": {
-  "accelerator": "GPU",
-  "colab": {
-   "gpuType": "T4",
-   "provenance": []
-  },
-  "kernelspec": {
-   "display_name": "Python 3",
-   "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.11.9"
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 0
+  "nbformat": 4,
+  "nbformat_minor": 0
 }

--- a/python-recipes/RAG/04_advanced_redisvl.ipynb
+++ b/python-recipes/RAG/04_advanced_redisvl.ipynb
@@ -86,14 +86,12 @@
      "output_type": "stream",
      "text": [
       "\n",
-      "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m A new release of pip is available: \u001b[0m\u001b[31;49m24.0\u001b[0m\u001b[39;49m -> \u001b[0m\u001b[32;49m24.3.1\u001b[0m\n",
-      "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m To update, run: \u001b[0m\u001b[32;49mpip install --upgrade pip\u001b[0m\n"
+      "\u001B[1m[\u001B[0m\u001B[34;49mnotice\u001B[0m\u001B[1;39;49m]\u001B[0m\u001B[39;49m A new release of pip is available: \u001B[0m\u001B[31;49m24.0\u001B[0m\u001B[39;49m -> \u001B[0m\u001B[32;49m24.3.1\u001B[0m\n",
+      "\u001B[1m[\u001B[0m\u001B[34;49mnotice\u001B[0m\u001B[1;39;49m]\u001B[0m\u001B[39;49m To update, run: \u001B[0m\u001B[32;49mpip install --upgrade pip\u001B[0m\n"
      ]
     }
    ],
-   "source": [
-    "%pip install -q \"redisvl>=0.6.0\" pandas \"unstructured[pdf]\" sentence-transformers langchain langchain-community \"openai>=1.57.0\" tqdm"
-   ]
+   "source": "%pip install -q \"redisvl>=0.6.0\" pandas \"unstructured[pdf]\" sentence-transformers langchain langchain-community \"openai>=1.57.0\" tqdm"
   },
   {
    "cell_type": "markdown",
@@ -213,7 +211,7 @@
     }
    ],
    "source": [
-    "from langchain.text_splitter import RecursiveCharacterTextSplitter\n",
+    "from langchain_text_splitters import RecursiveCharacterTextSplitter\n",
     "from langchain_community.document_loaders import PyPDFLoader\n",
     "\n",
     "# pdf to load\n",

--- a/python-recipes/RAG/05_nvidia_ai_rag_redis.ipynb
+++ b/python-recipes/RAG/05_nvidia_ai_rag_redis.ipynb
@@ -1,617 +1,617 @@
 {
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "aiHV6ip2f5id"
-      },
-      "source": [
-        "# Accelerating RAG with NVIDIA and Redis\n",
-        "\n",
-        "[NVIDIA AI Foundation Endpoints](https://www.nvidia.com/en-us/ai-data-science/foundation-models/) give users easy access to NVIDIA hosted API endpoints for NVIDIA AI Foundation Models like Mixtral 8x7B.\n",
-        "\n",
-        "These models, hosted on the NVIDIA API catalog, are optimized, tested, and hosted on the NVIDIA AI platform, making them fast and easy to evaluate, further customize, and seamlessly run at peak performance on any accelerated stack.\n",
-        "\n",
-        "This demo showcases a RAG stack using LangChain, NVIDIA for model serving. Mistral *(Mixtral 8x7B model)*, and Redis.\n",
-        "\n",
-        "**Get Started Here:**\n",
-        "\n",
-        "<a href=\"https://colab.research.google.com/github/redis-developer/redis-ai-resources/blob/main/python-recipes/RAG/nvidia_ai_rag_redis.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "37rbBPKdL09o"
-      },
-      "source": [
-        "## 1. Setup\n",
-        "Before we begin, we must install some required libraries, authenticate with NVIDIA, create a Redis database, and initialize other required components.\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "7MMyrImcPPBo"
-      },
-      "source": [
-        "### Install required libraries"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "collapsed": true,
-        "id": "jUI0oAbuTjui",
-        "outputId": "ad28b925-5e50-4644-a38b-6de80450153a"
-      },
-      "outputs": [],
-      "source": [
-        "%pip install --upgrade -q langchain-core langchain-community langchain-nvidia-ai-endpoints\n",
-        "%pip install -q \"unstructured[pdf]\" sentence-transformers\n",
-        "%pip install -q \"redisvl>=0.4.1\""
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "collapsed": true,
-        "id": "pc-IxYu3wnQm"
-      },
-      "outputs": [],
-      "source": [
-        "import IPython\n",
-        "\n",
-        "app = IPython.Application.instance()\n",
-        "app.kernel.do_shutdown(True)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "THynXaAhPRNb"
-      },
-      "source": [
-        "### Connect to NVIDIA hosted LLM and embedding models"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "8HnbKLcdU_1r",
-        "outputId": "6df45f69-eb9c-4e83-bbe7-2069471d31e6"
-      },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Enter your NVIDIA API key: ··········\n"
-          ]
-        }
-      ],
-      "source": [
-        "import getpass\n",
-        "import os\n",
-        "\n",
-        "if not os.environ.get(\"NVIDIA_API_KEY\", \"\").startswith(\"nvapi-\"):\n",
-        "    nvapi_key = getpass.getpass(\"Enter your NVIDIA API key: \")\n",
-        "    assert nvapi_key.startswith(\"nvapi-\"), f\"{nvapi_key[:5]}... is not a valid key\"\n",
-        "    os.environ[\"NVIDIA_API_KEY\"] = nvapi_key"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "4DvCWkLrUIbG"
-      },
-      "outputs": [],
-      "source": [
-        "from langchain_core.messages import ChatMessage\n",
-        "from langchain_core.output_parsers import StrOutputParser\n",
-        "from langchain_core.prompts import ChatPromptTemplate\n",
-        "from langchain_nvidia_ai_endpoints import ChatNVIDIA\n",
-        "\n",
-        "# Create LLM instance with the Mistral model\n",
-        "llm = ChatNVIDIA(\n",
-        "    model=\"mistralai/mixtral-8x22b-instruct-v0.1\",\n",
-        "    temperature=0.1,\n",
-        "    top_p=1.0,\n",
-        ")"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 52
-        },
-        "id": "8OT2wUiHU3rR",
-        "outputId": "e60cf9f7-fc6b-4927-bb31-88b7884cc9c0"
-      },
-      "outputs": [
-        {
-          "data": {
-            "application/vnd.google.colaboratory.intrinsic+json": {
-              "type": "string"
-            },
-            "text/plain": [
-              "' \"Remember, every step you take, no matter how small, is a step towards your goal; keep going, you\\'re doing great!\"'"
-            ]
-          },
-          "execution_count": 19,
-          "metadata": {},
-          "output_type": "execute_result"
-        }
-      ],
-      "source": [
-        "llm.invoke(\"Write me a one sentence encouragement.\").content"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "Df3349oQWRAB"
-      },
-      "outputs": [],
-      "source": [
-        "from langchain_nvidia_ai_endpoints import NVIDIAEmbeddings\n",
-        "\n",
-        "emb = NVIDIAEmbeddings()"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "tAzka0TNWVrz",
-        "outputId": "4ecd5744-cfd4-4601-cd9c-93a2874fe1a7"
-      },
-      "outputs": [
-        {
-          "data": {
-            "text/plain": [
-              "1024"
-            ]
-          },
-          "execution_count": 9,
-          "metadata": {},
-          "output_type": "execute_result"
-        }
-      ],
-      "source": [
-        "len(emb.embed_documents([\"test\"])[0])"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "PucGDUf4fHn2"
-      },
-      "source": [
-        "### Fetch sample dataset\n",
-        "\n",
-        "For the demo we will focus on a chevy colorado truck brochure.\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "IeNQp1k3fJk1",
-        "outputId": "fa11df08-4094-407c-8509-1fb2d41466fc"
-      },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "--2024-05-23 16:48:12--  https://raw.githubusercontent.com/redis-developer/LLM-Document-Chat/main/docs/2022-chevrolet-colorado-ebrochure.pdf\n",
-            "Resolving raw.githubusercontent.com (raw.githubusercontent.com)... 185.199.108.133, 185.199.109.133, 185.199.110.133, ...\n",
-            "Connecting to raw.githubusercontent.com (raw.githubusercontent.com)|185.199.108.133|:443... connected.\n",
-            "HTTP request sent, awaiting response... 200 OK\n",
-            "Length: 3566101 (3.4M) [application/octet-stream]\n",
-            "Saving to: ‘data/2022-chevrolet-colorado-ebrochure.pdf’\n",
-            "\n",
-            "data/2022-chevrolet 100%[===================>]   3.40M  --.-KB/s    in 0.1s    \n",
-            "\n",
-            "2024-05-23 16:48:12 (29.8 MB/s) - ‘data/2022-chevrolet-colorado-ebrochure.pdf’ saved [3566101/3566101]\n",
-            "\n"
-          ]
-        }
-      ],
-      "source": [
-        "!mkdir -p 'data/'\n",
-        "!wget 'https://raw.githubusercontent.com/redis-developer/LLM-Document-Chat/main/docs/2022-chevrolet-colorado-ebrochure.pdf' -O 'data/2022-chevrolet-colorado-ebrochure.pdf'"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "p5kx9ePDwwp6"
-      },
-      "source": [
-        "### Install Redis locally\n",
-        "If you have a Redis db running elsewhere with [Redis Stack](https://redis.io/docs/about/about-stack/) installed, you don't need to run it on this machine."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "vs4KZURX4XpT",
-        "outputId": "16754e79-10f1-4122-8ca8-8b14fd3bd205"
-      },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "deb [signed-by=/usr/share/keyrings/redis-archive-keyring.gpg] https://packages.redis.io/deb jammy main\n",
-            "Starting redis-stack-server, database path /var/lib/redis-stack\n"
-          ]
-        }
-      ],
-      "source": [
-        "%%sh\n",
-        "curl -fsSL https://packages.redis.io/gpg | sudo gpg --dearmor -o /usr/share/keyrings/redis-archive-keyring.gpg\n",
-        "echo \"deb [signed-by=/usr/share/keyrings/redis-archive-keyring.gpg] https://packages.redis.io/deb $(lsb_release -cs) main\" | sudo tee /etc/apt/sources.list.d/redis.list\n",
-        "sudo apt-get update  > /dev/null 2>&1\n",
-        "sudo apt-get install redis-stack-server  > /dev/null 2>&1\n",
-        "redis-stack-server --daemonize yes"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "VsNJn75A0VJm"
-      },
-      "source": [
-        "\n",
-        "\n",
-        "\n",
-        "## RAG with NVIDIA hosted LLM and Redis\n",
-        "\n",
-        "\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "QkNqSckkbYVm"
-      },
-      "source": [
-        "### Prepare document for RAG"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "HG_w_jPSmXVb",
-        "outputId": "b1a0e4ce-eea4-49e5-ffb0-8086655fe4a3"
-      },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Listing available documents ... ['data/2022-chevrolet-colorado-ebrochure.pdf']\n"
-          ]
-        }
-      ],
-      "source": [
-        "from langchain.text_splitter import SentenceTransformersTokenTextSplitter\n",
-        "from langchain.document_loaders import UnstructuredFileLoader\n",
-        "\n",
-        "# Load list of pdfs from a folder\n",
-        "data_path = f\"data/\"\n",
-        "docs = [os.path.join(data_path, file) for file in os.listdir(data_path)]\n",
-        "\n",
-        "print(\"Listing available documents ...\", docs)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "BtTSE4ZmmDt5",
-        "outputId": "c77a1d49-5faf-4fda-b4ff-9f23a1fe86da"
-      },
-      "outputs": [
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "/usr/local/lib/python3.10/dist-packages/huggingface_hub/file_download.py:1132: FutureWarning: `resume_download` is deprecated and will be removed in version 1.0.0. Downloads always resume when possible. If you want to force a new download, use `force_download=True`.\n",
-            "  warnings.warn(\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Done preprocessing. Created 35 chunks\n"
-          ]
-        }
-      ],
-      "source": [
-        "text_splitter = SentenceTransformersTokenTextSplitter()\n",
-        "\n",
-        "loader = UnstructuredFileLoader(\n",
-        "    docs[0], mode=\"single\", strategy=\"fast\"\n",
-        ")\n",
-        "\n",
-        "# extract, load, and make chunks\n",
-        "chunks = loader.load_and_split(text_splitter)\n",
-        "\n",
-        "print(\"Done preprocessing. Created\", len(chunks), \"chunks\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "XMEf_sdvcIT7"
-      },
-      "source": [
-        "### Load documents to Redis vector database"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "ZJuXwbodbwD5"
-      },
-      "outputs": [],
-      "source": [
-        "from langchain_community.vectorstores.redis import Redis\n",
-        "\n",
-        "vectordb = Redis.from_documents(\n",
-        "    documents=chunks,\n",
-        "    embedding=emb,\n",
-        "    redis_url=\"redis://localhost:6379\"\n",
-        "  )"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "5RXQF_fRcD8i"
-      },
-      "outputs": [],
-      "source": [
-        "retriever = vectordb.as_retriever(\n",
-        "    search_type=\"similarity_distance_threshold\",\n",
-        "    search_kwargs={\"distance_threshold\":0.4}\n",
-        ")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "cLxoFY9Y1iIv"
-      },
-      "source": [
-        "### Design RAG prompt\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "JfJ_DdvL1hdQ"
-      },
-      "outputs": [],
-      "source": [
-        "from langchain_core.prompts import ChatPromptTemplate\n",
-        "\n",
-        "prompt = ChatPromptTemplate.from_template(\n",
-        "    \"\"\"You are an intelligent assistant specializing in the Chevy Colorado\n",
-        "    2022. You have access to the car manual and production information and should help\n",
-        "    answer users questions based on provided context below. Be truthful and honest --\n",
-        "    do not make anything up if it's not clearly provided in the context below.\n",
-        "\n",
-        "    User Question: {question}\n",
-        "\n",
-        "    Context:\\n{context}\n",
-        "\n",
-        "    Answer:\"\"\"\n",
-        ")\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "-7jDDXTjdFqy"
-      },
-      "source": [
-        "### Build RAG chain"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "5IiIEF1G1wLM"
-      },
-      "outputs": [],
-      "source": [
-        "# Build the RAG chain using LCEL\n",
-        "from langchain_core.runnables import RunnableParallel, RunnablePassthrough\n",
-        "from langchain_core.pydantic_v1 import BaseModel\n",
-        "\n",
-        "\n",
-        "def format_docs(docs):\n",
-        "    return \"\\n\\n\".join(doc.page_content for doc in docs)\n",
-        "\n",
-        "\n",
-        "chain = (\n",
-        "    RunnableParallel({\"context\": retriever | format_docs, \"question\": RunnablePassthrough()})\n",
-        "    | prompt\n",
-        "    | llm\n",
-        "    | StrOutputParser()\n",
-        ")\n",
-        "\n",
-        "\n",
-        "# Add typing for input\n",
-        "class Question(BaseModel):\n",
-        "    __root__: str\n",
-        "\n",
-        "\n",
-        "chain = chain.with_types(input_type=Question)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "u5lsMVKc2TsF"
-      },
-      "source": [
-        "Let's test this out."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 104
-        },
-        "id": "VAhZYyf22bW9",
-        "outputId": "71c51e6c-bf22-45b3-dcaa-4c21bc9e6cc0"
-      },
-      "outputs": [
-        {
-          "data": {
-            "application/vnd.google.colaboratory.intrinsic+json": {
-              "type": "string"
-            },
-            "text/plain": [
-              "' The 2022 Chevy Colorado is available in four models: WT, LT, Z71, and ZR2. These models can come in either an extended cab or crew cab configuration. The engines available are a 2.5L 4-cylinder, a 3.6L V6, and a Duramax 2.8L turbo-diesel engine. The Duramax engine provides up to 7,700 lbs. of towing capacity and can deliver up to 30 mpg on the highway. The ZR2 model is an off-road beast with the capability to conquer tough trails. Additionally, there is an available ZR2 Bison Edition which includes 17-inch AEV.'"
-            ]
-          },
-          "execution_count": 49,
-          "metadata": {},
-          "output_type": "execute_result"
-        }
-      ],
-      "source": [
-        "chain.invoke(\"What models are available for the chevy colorado?\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "oSRYapAa4Oue"
-      },
-      "source": [
-        "Now we can apply this same logic to nodes from our pdf document."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "WepiLB5Bd7e2"
-      },
-      "source": [
-        "### Add sources to the response"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "qQ5FrIo5d-pM"
-      },
-      "outputs": [],
-      "source": [
-        "rag_chain_from_docs = (\n",
-        "    RunnablePassthrough.assign(context=(lambda x: format_docs(x[\"context\"])))\n",
-        "    | prompt\n",
-        "    | llm\n",
-        "    | StrOutputParser()\n",
-        ")\n",
-        "\n",
-        "rag_chain_with_source = RunnableParallel(\n",
-        "    {\"context\": retriever, \"question\": RunnablePassthrough()}\n",
-        ").assign(answer=rag_chain_from_docs)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "8HqAYMIdd-rd",
-        "outputId": "5fe227e5-21ce-4065-b3ae-cd1a9b62862b"
-      },
-      "outputs": [
-        {
-          "data": {
-            "text/plain": [
-              "{'context': [Document(page_content='2022 colorado choose your adventure. the 2022 colorado delivers everything you could ask for in a midsize pickup. engine choices that are powerful and efficient, including an available gm - exclusive duramax® 2. 8l turbo - diesel engine that provides up to 7, 700 lbs. of towing1, 2 muscle. a zr2 off - road beast with the capability to conquer tough trails. and a comfortable interior filled with convenience and technology features. so go ahead. choose your best life in colorado. colorado crew cab zr2 in sand dune metallic with available zr2 dusk special edition. vehicle shown can tow up to 5, 000 lbs. 2, 3 1 requires colorado crew cab short box lt 2wd with available trailering package, lt convenience package and safety package. 2 maximum trailering ratings are intended for comparison purposes only. before you buy a vehicle or use it for trailering, carefully review the trailering section of the owner ’ s manual. the trailering capacity of your specific vehicle may vary. the weight of passengers, cargo and options or accessories may reduce the amount you can trailer. 3 requires available trailering package and automatic locking rear differential on lt ; requires available trailering package on z71. due to current supply chain shortages, certain features shown have limited or late availability, or are no longer available. see the window label or a dealer regarding the features on an individual vehicle. introducing colorado colorado at a glance. four models : wt, lt, z71 and zr2 extended cab or crew cab three engines 2. 5l 4 - cylinder 3. 6l v6 duramax 2. 8l turbo - diesel 30 mpg highway 1 with available diesel engine 7, 700 lbs. maximum trailering weight2 with available diesel engine apple carplay®3 and android auto™4 compatibility available zr2 bison edition includes 17 - inch aev', metadata={'id': 'doc:5313bad541f24eb58d856c7ca8f04fc4:17319c587eaa4dd69eacd57b50ff1a5e', 'source': 'data/2022-chevrolet-colorado-ebrochure.pdf'})],\n",
-              " 'question': 'What models are available for the chevy colorado?',\n",
-              " 'answer': ' The 2022 Chevy Colorado is available in four models: WT, LT, Z71, and ZR2. These models can come in either an extended cab or crew cab configuration. The engines available are a 2.5L 4-cylinder, a 3.6L V6, and a Duramax 2.8L turbo-diesel. The Colorado can achieve up to 30 mpg on the highway with the available diesel engine. The maximum trailering weight is 7,700 lbs with the available diesel engine. The Colorado also offers Apple CarPlay® and Android Auto™ compatibility. Additionally, there is an available ZR2 Bison Edition which includes 17-inch AEV.'}"
-            ]
-          },
-          "execution_count": 48,
-          "metadata": {},
-          "output_type": "execute_result"
-        }
-      ],
-      "source": [
-        "rag_chain_with_source.invoke(\"What models are available for the chevy colorado?\")"
-      ]
-    }
-  ],
-  "metadata": {
-    "colab": {
-      "gpuType": "T4",
-      "provenance": [],
-      "toc_visible": true
-    },
-    "kernelspec": {
-      "display_name": "Python 3",
-      "name": "python3"
-    },
-    "language_info": {
-      "name": "python",
-      "version": "3.11.9"
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "aiHV6ip2f5id"
+   },
+   "source": [
+    "# Accelerating RAG with NVIDIA and Redis\n",
+    "\n",
+    "[NVIDIA AI Foundation Endpoints](https://www.nvidia.com/en-us/ai-data-science/foundation-models/) give users easy access to NVIDIA hosted API endpoints for NVIDIA AI Foundation Models like Mixtral 8x7B.\n",
+    "\n",
+    "These models, hosted on the NVIDIA API catalog, are optimized, tested, and hosted on the NVIDIA AI platform, making them fast and easy to evaluate, further customize, and seamlessly run at peak performance on any accelerated stack.\n",
+    "\n",
+    "This demo showcases a RAG stack using LangChain, NVIDIA for model serving. Mistral *(Mixtral 8x7B model)*, and Redis.\n",
+    "\n",
+    "**Get Started Here:**\n",
+    "\n",
+    "<a href=\"https://colab.research.google.com/github/redis-developer/redis-ai-resources/blob/main/python-recipes/RAG/nvidia_ai_rag_redis.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n"
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 0
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "37rbBPKdL09o"
+   },
+   "source": [
+    "## 1. Setup\n",
+    "Before we begin, we must install some required libraries, authenticate with NVIDIA, create a Redis database, and initialize other required components.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "7MMyrImcPPBo"
+   },
+   "source": [
+    "### Install required libraries"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "collapsed": true,
+    "id": "jUI0oAbuTjui",
+    "outputId": "ad28b925-5e50-4644-a38b-6de80450153a"
+   },
+   "outputs": [],
+   "source": [
+    "%pip install --upgrade -q langchain-core langchain-community langchain-nvidia-ai-endpoints\n",
+    "%pip install -q \"unstructured[pdf]\" sentence-transformers\n",
+    "%pip install -q \"redisvl>=0.4.1\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true,
+    "id": "pc-IxYu3wnQm"
+   },
+   "outputs": [],
+   "source": [
+    "import IPython\n",
+    "\n",
+    "app = IPython.Application.instance()\n",
+    "app.kernel.do_shutdown(True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "THynXaAhPRNb"
+   },
+   "source": [
+    "### Connect to NVIDIA hosted LLM and embedding models"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "8HnbKLcdU_1r",
+    "outputId": "6df45f69-eb9c-4e83-bbe7-2069471d31e6"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Enter your NVIDIA API key: ··········\n"
+     ]
+    }
+   ],
+   "source": [
+    "import getpass\n",
+    "import os\n",
+    "\n",
+    "if not os.environ.get(\"NVIDIA_API_KEY\", \"\").startswith(\"nvapi-\"):\n",
+    "    nvapi_key = getpass.getpass(\"Enter your NVIDIA API key: \")\n",
+    "    assert nvapi_key.startswith(\"nvapi-\"), f\"{nvapi_key[:5]}... is not a valid key\"\n",
+    "    os.environ[\"NVIDIA_API_KEY\"] = nvapi_key"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "4DvCWkLrUIbG"
+   },
+   "outputs": [],
+   "source": [
+    "from langchain_core.messages import ChatMessage\n",
+    "from langchain_core.output_parsers import StrOutputParser\n",
+    "from langchain_core.prompts import ChatPromptTemplate\n",
+    "from langchain_nvidia_ai_endpoints import ChatNVIDIA\n",
+    "\n",
+    "# Create LLM instance with the Mistral model\n",
+    "llm = ChatNVIDIA(\n",
+    "    model=\"mistralai/mixtral-8x22b-instruct-v0.1\",\n",
+    "    temperature=0.1,\n",
+    "    top_p=1.0,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 52
+    },
+    "id": "8OT2wUiHU3rR",
+    "outputId": "e60cf9f7-fc6b-4927-bb31-88b7884cc9c0"
+   },
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.google.colaboratory.intrinsic+json": {
+       "type": "string"
+      },
+      "text/plain": [
+       "' \"Remember, every step you take, no matter how small, is a step towards your goal; keep going, you\\'re doing great!\"'"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "llm.invoke(\"Write me a one sentence encouragement.\").content"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "Df3349oQWRAB"
+   },
+   "outputs": [],
+   "source": [
+    "from langchain_nvidia_ai_endpoints import NVIDIAEmbeddings\n",
+    "\n",
+    "emb = NVIDIAEmbeddings()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "tAzka0TNWVrz",
+    "outputId": "4ecd5744-cfd4-4601-cd9c-93a2874fe1a7"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "1024"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "len(emb.embed_documents([\"test\"])[0])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "PucGDUf4fHn2"
+   },
+   "source": [
+    "### Fetch sample dataset\n",
+    "\n",
+    "For the demo we will focus on a chevy colorado truck brochure.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "IeNQp1k3fJk1",
+    "outputId": "fa11df08-4094-407c-8509-1fb2d41466fc"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "--2024-05-23 16:48:12--  https://raw.githubusercontent.com/redis-developer/LLM-Document-Chat/main/docs/2022-chevrolet-colorado-ebrochure.pdf\n",
+      "Resolving raw.githubusercontent.com (raw.githubusercontent.com)... 185.199.108.133, 185.199.109.133, 185.199.110.133, ...\n",
+      "Connecting to raw.githubusercontent.com (raw.githubusercontent.com)|185.199.108.133|:443... connected.\n",
+      "HTTP request sent, awaiting response... 200 OK\n",
+      "Length: 3566101 (3.4M) [application/octet-stream]\n",
+      "Saving to: ‘data/2022-chevrolet-colorado-ebrochure.pdf’\n",
+      "\n",
+      "data/2022-chevrolet 100%[===================>]   3.40M  --.-KB/s    in 0.1s    \n",
+      "\n",
+      "2024-05-23 16:48:12 (29.8 MB/s) - ‘data/2022-chevrolet-colorado-ebrochure.pdf’ saved [3566101/3566101]\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "!mkdir -p 'data/'\n",
+    "!wget 'https://raw.githubusercontent.com/redis-developer/LLM-Document-Chat/main/docs/2022-chevrolet-colorado-ebrochure.pdf' -O 'data/2022-chevrolet-colorado-ebrochure.pdf'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "p5kx9ePDwwp6"
+   },
+   "source": [
+    "### Install Redis locally\n",
+    "If you have a Redis db running elsewhere with [Redis Stack](https://redis.io/docs/about/about-stack/) installed, you don't need to run it on this machine."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "vs4KZURX4XpT",
+    "outputId": "16754e79-10f1-4122-8ca8-8b14fd3bd205"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "deb [signed-by=/usr/share/keyrings/redis-archive-keyring.gpg] https://packages.redis.io/deb jammy main\n",
+      "Starting redis-stack-server, database path /var/lib/redis-stack\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%sh\n",
+    "curl -fsSL https://packages.redis.io/gpg | sudo gpg --dearmor -o /usr/share/keyrings/redis-archive-keyring.gpg\n",
+    "echo \"deb [signed-by=/usr/share/keyrings/redis-archive-keyring.gpg] https://packages.redis.io/deb $(lsb_release -cs) main\" | sudo tee /etc/apt/sources.list.d/redis.list\n",
+    "sudo apt-get update  > /dev/null 2>&1\n",
+    "sudo apt-get install redis-stack-server  > /dev/null 2>&1\n",
+    "redis-stack-server --daemonize yes"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "VsNJn75A0VJm"
+   },
+   "source": [
+    "\n",
+    "\n",
+    "\n",
+    "## RAG with NVIDIA hosted LLM and Redis\n",
+    "\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "QkNqSckkbYVm"
+   },
+   "source": [
+    "### Prepare document for RAG"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "HG_w_jPSmXVb",
+    "outputId": "b1a0e4ce-eea4-49e5-ffb0-8086655fe4a3"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Listing available documents ... ['data/2022-chevrolet-colorado-ebrochure.pdf']\n"
+     ]
+    }
+   ],
+   "source": [
+    "from langchain_text_splitters import SentenceTransformersTokenTextSplitter\n",
+    "from langchain_community.document_loaders import UnstructuredFileLoader\n",
+    "\n",
+    "# Load list of pdfs from a folder\n",
+    "data_path = f\"data/\"\n",
+    "docs = [os.path.join(data_path, file) for file in os.listdir(data_path)]\n",
+    "\n",
+    "print(\"Listing available documents ...\", docs)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "BtTSE4ZmmDt5",
+    "outputId": "c77a1d49-5faf-4fda-b4ff-9f23a1fe86da"
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/usr/local/lib/python3.10/dist-packages/huggingface_hub/file_download.py:1132: FutureWarning: `resume_download` is deprecated and will be removed in version 1.0.0. Downloads always resume when possible. If you want to force a new download, use `force_download=True`.\n",
+      "  warnings.warn(\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Done preprocessing. Created 35 chunks\n"
+     ]
+    }
+   ],
+   "source": [
+    "text_splitter = SentenceTransformersTokenTextSplitter()\n",
+    "\n",
+    "loader = UnstructuredFileLoader(\n",
+    "    docs[0], mode=\"single\", strategy=\"fast\"\n",
+    ")\n",
+    "\n",
+    "# extract, load, and make chunks\n",
+    "chunks = loader.load_and_split(text_splitter)\n",
+    "\n",
+    "print(\"Done preprocessing. Created\", len(chunks), \"chunks\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "XMEf_sdvcIT7"
+   },
+   "source": [
+    "### Load documents to Redis vector database"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "ZJuXwbodbwD5"
+   },
+   "outputs": [],
+   "source": [
+    "from langchain_community.vectorstores.redis import Redis\n",
+    "\n",
+    "vectordb = Redis.from_documents(\n",
+    "    documents=chunks,\n",
+    "    embedding=emb,\n",
+    "    redis_url=\"redis://localhost:6379\"\n",
+    "  )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "5RXQF_fRcD8i"
+   },
+   "outputs": [],
+   "source": [
+    "retriever = vectordb.as_retriever(\n",
+    "    search_type=\"similarity_distance_threshold\",\n",
+    "    search_kwargs={\"distance_threshold\":0.4}\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "cLxoFY9Y1iIv"
+   },
+   "source": [
+    "### Design RAG prompt\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "JfJ_DdvL1hdQ"
+   },
+   "outputs": [],
+   "source": [
+    "from langchain_core.prompts import ChatPromptTemplate\n",
+    "\n",
+    "prompt = ChatPromptTemplate.from_template(\n",
+    "    \"\"\"You are an intelligent assistant specializing in the Chevy Colorado\n",
+    "    2022. You have access to the car manual and production information and should help\n",
+    "    answer users questions based on provided context below. Be truthful and honest --\n",
+    "    do not make anything up if it's not clearly provided in the context below.\n",
+    "\n",
+    "    User Question: {question}\n",
+    "\n",
+    "    Context:\\n{context}\n",
+    "\n",
+    "    Answer:\"\"\"\n",
+    ")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "-7jDDXTjdFqy"
+   },
+   "source": [
+    "### Build RAG chain"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "5IiIEF1G1wLM"
+   },
+   "outputs": [],
+   "source": [
+    "# Build the RAG chain using LCEL\n",
+    "from langchain_core.runnables import RunnableParallel, RunnablePassthrough\n",
+    "from langchain_core.pydantic_v1 import BaseModel\n",
+    "\n",
+    "\n",
+    "def format_docs(docs):\n",
+    "    return \"\\n\\n\".join(doc.page_content for doc in docs)\n",
+    "\n",
+    "\n",
+    "chain = (\n",
+    "    RunnableParallel({\"context\": retriever | format_docs, \"question\": RunnablePassthrough()})\n",
+    "    | prompt\n",
+    "    | llm\n",
+    "    | StrOutputParser()\n",
+    ")\n",
+    "\n",
+    "\n",
+    "# Add typing for input\n",
+    "class Question(BaseModel):\n",
+    "    __root__: str\n",
+    "\n",
+    "\n",
+    "chain = chain.with_types(input_type=Question)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "u5lsMVKc2TsF"
+   },
+   "source": [
+    "Let's test this out."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 104
+    },
+    "id": "VAhZYyf22bW9",
+    "outputId": "71c51e6c-bf22-45b3-dcaa-4c21bc9e6cc0"
+   },
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.google.colaboratory.intrinsic+json": {
+       "type": "string"
+      },
+      "text/plain": [
+       "' The 2022 Chevy Colorado is available in four models: WT, LT, Z71, and ZR2. These models can come in either an extended cab or crew cab configuration. The engines available are a 2.5L 4-cylinder, a 3.6L V6, and a Duramax 2.8L turbo-diesel engine. The Duramax engine provides up to 7,700 lbs. of towing capacity and can deliver up to 30 mpg on the highway. The ZR2 model is an off-road beast with the capability to conquer tough trails. Additionally, there is an available ZR2 Bison Edition which includes 17-inch AEV.'"
+      ]
+     },
+     "execution_count": 49,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "chain.invoke(\"What models are available for the chevy colorado?\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "oSRYapAa4Oue"
+   },
+   "source": [
+    "Now we can apply this same logic to nodes from our pdf document."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "WepiLB5Bd7e2"
+   },
+   "source": [
+    "### Add sources to the response"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "qQ5FrIo5d-pM"
+   },
+   "outputs": [],
+   "source": [
+    "rag_chain_from_docs = (\n",
+    "    RunnablePassthrough.assign(context=(lambda x: format_docs(x[\"context\"])))\n",
+    "    | prompt\n",
+    "    | llm\n",
+    "    | StrOutputParser()\n",
+    ")\n",
+    "\n",
+    "rag_chain_with_source = RunnableParallel(\n",
+    "    {\"context\": retriever, \"question\": RunnablePassthrough()}\n",
+    ").assign(answer=rag_chain_from_docs)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "8HqAYMIdd-rd",
+    "outputId": "5fe227e5-21ce-4065-b3ae-cd1a9b62862b"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'context': [Document(page_content='2022 colorado choose your adventure. the 2022 colorado delivers everything you could ask for in a midsize pickup. engine choices that are powerful and efficient, including an available gm - exclusive duramax® 2. 8l turbo - diesel engine that provides up to 7, 700 lbs. of towing1, 2 muscle. a zr2 off - road beast with the capability to conquer tough trails. and a comfortable interior filled with convenience and technology features. so go ahead. choose your best life in colorado. colorado crew cab zr2 in sand dune metallic with available zr2 dusk special edition. vehicle shown can tow up to 5, 000 lbs. 2, 3 1 requires colorado crew cab short box lt 2wd with available trailering package, lt convenience package and safety package. 2 maximum trailering ratings are intended for comparison purposes only. before you buy a vehicle or use it for trailering, carefully review the trailering section of the owner ’ s manual. the trailering capacity of your specific vehicle may vary. the weight of passengers, cargo and options or accessories may reduce the amount you can trailer. 3 requires available trailering package and automatic locking rear differential on lt ; requires available trailering package on z71. due to current supply chain shortages, certain features shown have limited or late availability, or are no longer available. see the window label or a dealer regarding the features on an individual vehicle. introducing colorado colorado at a glance. four models : wt, lt, z71 and zr2 extended cab or crew cab three engines 2. 5l 4 - cylinder 3. 6l v6 duramax 2. 8l turbo - diesel 30 mpg highway 1 with available diesel engine 7, 700 lbs. maximum trailering weight2 with available diesel engine apple carplay®3 and android auto™4 compatibility available zr2 bison edition includes 17 - inch aev', metadata={'id': 'doc:5313bad541f24eb58d856c7ca8f04fc4:17319c587eaa4dd69eacd57b50ff1a5e', 'source': 'data/2022-chevrolet-colorado-ebrochure.pdf'})],\n",
+       " 'question': 'What models are available for the chevy colorado?',\n",
+       " 'answer': ' The 2022 Chevy Colorado is available in four models: WT, LT, Z71, and ZR2. These models can come in either an extended cab or crew cab configuration. The engines available are a 2.5L 4-cylinder, a 3.6L V6, and a Duramax 2.8L turbo-diesel. The Colorado can achieve up to 30 mpg on the highway with the available diesel engine. The maximum trailering weight is 7,700 lbs with the available diesel engine. The Colorado also offers Apple CarPlay® and Android Auto™ compatibility. Additionally, there is an available ZR2 Bison Edition which includes 17-inch AEV.'}"
+      ]
+     },
+     "execution_count": 48,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "rag_chain_with_source.invoke(\"What models are available for the chevy colorado?\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "gpuType": "T4",
+   "provenance": [],
+   "toc_visible": true
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
 }

--- a/python-recipes/RAG/06_ragas_evaluation.ipynb
+++ b/python-recipes/RAG/06_ragas_evaluation.ipynb
@@ -1,1229 +1,1227 @@
 {
-    "cells": [
-        {
-            "cell_type": "markdown",
-            "metadata": {},
-            "source": [
-                "![Redis](https://redis.io/wp-content/uploads/2024/04/Logotype.svg?auto=webp&quality=85,75&width=120)\n",
-                "# Evaluating RAG\n",
-                "\n",
-                "This notebook uses the [ragas library](https://docs.ragas.io/en/stable/getstarted/index.html) and [Redis](https://redis.com) to evaluate the performance of sample RAG application. Also see the original [source paper](https://arxiv.org/pdf/2309.15217) to build a more detailed understanding.\n",
-                "\n",
-                "## Let's Begin!\n",
-                "<a href=\"https://colab.research.google.com/github/redis-developer/redis-ai-resources/blob/main/python-recipes/RAG/06_ragas_evaluation.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "metadata": {},
-            "source": [
-                "To start, we need a RAG app to evaluate. Let's create one using LangChain and connect it with Redis as the vector DB.\n",
-                "\n",
-                "## Init redis, data prep, and populating the vector DB"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": 1,
-            "metadata": {},
-            "outputs": [
-                {
-                    "name": "stdout",
-                    "output_type": "stream",
-                    "text": [
-                        "\n",
-                        "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m A new release of pip is available: \u001b[0m\u001b[31;49m24.0\u001b[0m\u001b[39;49m -> \u001b[0m\u001b[32;49m24.2\u001b[0m\n",
-                        "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m To update, run: \u001b[0m\u001b[32;49mpip install --upgrade pip\u001b[0m\n",
-                        "Note: you may need to restart the kernel to use updated packages.\n"
-                    ]
-                }
-            ],
-            "source": [
-                "%pip install -q redis \"unstructured[pdf]\" sentence-transformers langchain \"langchain-redis>=0.2.0\" langchain-huggingface langchain-openai ragas datasets"
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "metadata": {},
-            "source": [
-                "#### Running Redis in Colab\n",
-                "Use the shell script below to download, extract, and install [Redis Stack](https://redis.io/docs/getting-started/install-stack/) directly from the Redis package archive."
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "# NBVAL_SKIP\n",
-                "%%sh\n",
-                "curl -fsSL https://packages.redis.io/gpg | sudo gpg --dearmor -o /usr/share/keyrings/redis-archive-keyring.gpg\n",
-                "echo \"deb [signed-by=/usr/share/keyrings/redis-archive-keyring.gpg] https://packages.redis.io/deb $(lsb_release -cs) main\" | sudo tee /etc/apt/sources.list.d/redis.list\n",
-                "sudo apt-get update  > /dev/null 2>&1\n",
-                "sudo apt-get install redis-stack-server  > /dev/null 2>&1\n",
-                "redis-stack-server --daemonize yes"
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "metadata": {},
-            "source": [
-                "#### For Alternative Environments\n",
-                "There are many ways to get the necessary redis-stack instance running\n",
-                "1. On cloud, deploy a [FREE instance of Redis in the cloud](https://redis.com/try-free/). Or, if you have your\n",
-                "own version of Redis Enterprise running, that works too!\n",
-                "2. Per OS, [see the docs](https://redis.io/docs/latest/operate/oss_and_stack/install/install-stack/)\n",
-                "3. With docker: `docker run -d --name redis-stack-server -p 6379:6379 redis/redis-stack-server:latest`"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": 1,
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "import os\n",
-                "import warnings\n",
-                "warnings.filterwarnings('ignore')\n",
-                "\n",
-                "# Replace values below with your own if using Redis Cloud instance\n",
-                "REDIS_HOST = os.getenv(\"REDIS_HOST\", \"localhost\") # ex: \"redis-18374.c253.us-central1-1.gce.cloud.redislabs.com\"\n",
-                "REDIS_PORT = os.getenv(\"REDIS_PORT\", \"6379\")      # ex: 18374\n",
-                "REDIS_PASSWORD = os.getenv(\"REDIS_PASSWORD\", \"\")  # ex: \"1TNxTEdYRDgIDKM2gDfasupCADXXXX\"\n",
-                "\n",
-                "# If SSL is enabled on the endpoint, use rediss:// as the URL prefix\n",
-                "REDIS_URL = f\"redis://:{REDIS_PASSWORD}@{REDIS_HOST}:{REDIS_PORT}\""
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": 2,
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "from langchain.text_splitter import RecursiveCharacterTextSplitter\n",
-                "from langchain_community.document_loaders import PyPDFLoader\n",
-                "\n",
-                "CHUNK_SIZE = 2500\n",
-                "CHUNK_OVERLAP = 0\n",
-                "\n",
-                "# pdf to load\n",
-                "path = 'resources/nke-10k-2023.pdf'\n",
-                "assert os.path.exists(path), f\"File not found: {path}\"\n",
-                "\n",
-                "# load and split\n",
-                "loader = PyPDFLoader(path)\n",
-                "pages = loader.load()\n",
-                "text_splitter = RecursiveCharacterTextSplitter(chunk_size=CHUNK_SIZE, chunk_overlap=CHUNK_OVERLAP)\n",
-                "chunks = text_splitter.split_documents(pages)\n",
-                "\n",
-                "print(\"Done preprocessing. Created\", len(chunks), \"chunks of the original pdf\", path)"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": 95,
-            "metadata": {},
-            "outputs": [
-                {
-                    "data": {
-                        "text/plain": [
-                            "Document(metadata={'source': 'resources/nke-10k-2023.pdf'}, page_content=\"Table of ContentsUNITED STATESSECURITIES AND EXCHANGE COMMISSIONWashington, D.C. 20549FORM 10-K(Mark One)☑ ANNUAL REPORT PURSUANT TO SECTION 13 OR 15(D) OF THE SECURITIES EXCHANGE ACT OF 1934FOR THE FISCAL YEAR ENDED MAY 31, 2023OR☐ TRANSITION REPORT PURSUANT TO SECTION 13 OR 15(D) OF THE SECURITIES EXCHANGE ACT OF 1934FOR THE TRANSITION PERIOD FROM TO .Commission File No. 1-10635\\n\\nAs of November 30, 2022, the aggregate market values of the Registrant's Common Stock held by non-affiliates were:Class A$7,831,564,572 Class B136,467,702,472 $144,299,267,044\\n\\nNIKE, Inc.(Exact name of Registrant as specified in its charter)Oregon93-0584541(State or other jurisdiction of incorporation)(IRS Employer Identification No.)One Bowerman Drive, Beaverton, Oregon 97005-6453(Address of principal executive offices and zip code)(503) 671-6453(Registrant's telephone number, including area code)SECURITIES REGISTERED PURSUANT TO SECTION 12(B) OF THE ACT:Class B Common StockNKENew York Stock Exchange(Title of each class)(Trading symbol)(Name of each exchange on which registered)SECURITIES REGISTERED PURSUANT TO SECTION 12(G) OF THE ACT:NONE\")"
-                        ]
-                    },
-                    "execution_count": 95,
-                    "metadata": {},
-                    "output_type": "execute_result"
-                }
-            ],
-            "source": [
-                "chunks[0]"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": 96,
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "from langchain_huggingface import HuggingFaceEmbeddings\n",
-                "\n",
-                "embeddings = HuggingFaceEmbeddings(model_name=\"sentence-transformers/all-MiniLM-L6-v2\")"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": 97,
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "from langchain_redis import RedisVectorStore\n",
-                "\n",
-                "# set the index name for this example\n",
-                "index_name = \"ragas_ex\"\n",
-                "\n",
-                "# construct the vector store class from texts and metadata\n",
-                "rds = RedisVectorStore.from_documents(\n",
-                "    chunks,\n",
-                "    embeddings,\n",
-                "    index_name=index_name,\n",
-                "    redis_url=REDIS_URL,\n",
-                "    metadata_schema=[\n",
-                "        {\n",
-                "            \"name\": \"source\",\n",
-                "            \"type\": \"text\"\n",
-                "        },\n",
-                "    ]\n",
-                ")"
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "metadata": {},
-            "source": [
-                "## Test the vector store"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": 98,
-            "metadata": {},
-            "outputs": [
-                {
-                    "data": {
-                        "text/plain": [
-                            "'As discussed in Note 15 — Operating Segments and Related Information in the accompanying Notes to the Consolidated Financial Statements, our operating segments are evidence of the structure of the Company\\'s internal organization. The NIKE Brand segments are defined by geographic regions for operations participating in NIKE Brand sales activity.\\n\\nThe breakdown of Revenues is as follows:\\n\\n(Dollars in millions)\\n\\nFISCAL 2023 FISCAL 2022\\n\\n% CHANGE\\n\\n% CHANGE EXCLUDING CURRENCY (1) CHANGES FISCAL 2021\\n\\n% CHANGE\\n\\nNorth America Europe, Middle East & Africa Greater China\\n\\n$\\n\\n21,608 $ 13,418 7,248\\n\\n18,353 12,479 7,547\\n\\n18 % 8 % -4 %\\n\\n18 % $ 21 % 4 %\\n\\n17,179 11,456 8,290\\n\\n7 % 9 % -9 %\\n\\nAsia Pacific & Latin America Global Brand Divisions\\n\\n(3)\\n\\n(2)\\n\\n6,431 58\\n\\n5,955 102\\n\\n8 % -43 %\\n\\n17 % -43 %\\n\\n5,343 25\\n\\n11 % 308 %\\n\\nTOTAL NIKE BRAND Converse\\n\\n$\\n\\n48,763 $ 2,427\\n\\n44,436 2,346\\n\\n10 % 3 %\\n\\n16 % $ 8 %\\n\\n42,293 2,205\\n\\n5 % 6 %\\n\\n(4)\\n\\nCorporate TOTAL NIKE, INC. REVENUES\\n\\n$\\n\\n27\\n\\n51,217 $\\n\\n(72) 46,710\\n\\n— 10 %\\n\\n— 16 % $\\n\\n40 44,538\\n\\n— 5 %\\n\\n(1) The percent change excluding currency changes represents a non-GAAP financial measure. For further information, see \"Use of Non-GAAP Financial Measures\".\\n\\n(2) For additional information on the transition of our NIKE Brand businesses within our CASA territory to a third-party distributor, see Note 18 — Acquisitions and Divestitures of the Notes to Consolidated\\n\\nFinancial Statements contained in Item 8 of this Annual Report.\\n\\n(3) Global Brand Divisions revenues include NIKE Brand licensing and other miscellaneous revenues that are not part of a geographic operating segment.\\n\\n(4) Corporate revenues primarily consist of foreign currency hedge gains and losses related to revenues generated by entities within the NIKE Brand geographic operating segments and Converse, but\\n\\nmanaged through our central foreign exchange risk management program.\\n\\nThe primary financial measure used by the Company to evaluate performance is Earnings Before Interest and Taxes (\"EBIT\"). As discussed in Note 15 — Operating Segments and Related Information in the accompanying Notes to the Consolidated Financial Statements, certain corporate costs are not included in EBIT.\\n\\nThe breakdown of EBIT is as follows:\\n\\n(Dollars in millions)\\n\\nFISCAL 2023\\n\\nFISCAL 2022\\n\\n% CHANGE\\n\\nFISCAL 2021\\n\\nNorth America Europe, Middle East & Africa Greater China\\n\\n$\\n\\n5,454 3,531 2,283\\n\\n$\\n\\n5,114 3,293 2,365\\n\\n7 % $ 7 % -3 %\\n\\n5,089 2,435 3,243\\n\\nAsia Pacific & Latin America Global Brand Divisions (1)'"
-                        ]
-                    },
-                    "execution_count": 98,
-                    "metadata": {},
-                    "output_type": "execute_result"
-                }
-            ],
-            "source": [
-                "rds.similarity_search(\"What was nike's revenue last year?\")[0].page_content"
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "metadata": {},
-            "source": [
-                "## Setup RAG\n",
-                "\n",
-                "Now that the vector db is populated let's initialize our RAG app."
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": 99,
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "import getpass\n",
-                "from langchain_openai import ChatOpenAI\n",
-                "\n",
-                "if \"OPENAI_API_KEY\" not in os.environ:\n",
-                "    os.environ[\"OPENAI_API_KEY\"] = getpass.getpass(\"OPENAI_API_KEY\")\n",
-                "\n",
-                "llm = ChatOpenAI(\n",
-                "    openai_api_key=os.environ[\"OPENAI_API_KEY\"],\n",
-                "    model=\"gpt-3.5-turbo-16k\",\n",
-                "    max_tokens=None\n",
-                ")"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": 108,
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "from langchain_core.prompts import ChatPromptTemplate\n",
-                "\n",
-                "system_prompt = \"\"\"\n",
-                "    Use the following pieces of context from financial 10k filings data to answer the user question at the end. \n",
-                "    If you don't know the answer, say that you don't know, don't try to make up an answer.\n",
-                "\n",
-                "    Context:\n",
-                "    ---------\n",
-                "    {context}\n",
-                "\"\"\"\n",
-                "\n",
-                "def format_docs(docs):\n",
-                "    return \"\\n\\n\".join(doc.page_content for doc in docs)\n",
-                "\n",
-                "prompt = ChatPromptTemplate.from_messages(\n",
-                "    [\n",
-                "        (\"system\", system_prompt),\n",
-                "        (\"human\", \"{input}\")\n",
-                "    ]\n",
-                ")\n"
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "metadata": {},
-            "source": [
-                "## Test it out"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": 109,
-            "metadata": {},
-            "outputs": [
-                {
-                    "data": {
-                        "text/plain": [
-                            "{'input': \"What was nike's revenue last year?\",\n",
-                            " 'context': [Document(metadata={'source': 'resources/nke-10k-2023.pdf'}, page_content='As discussed in Note 15 — Operating Segments and Related Information in the accompanying Notes to the Consolidated Financial Statements, our operating segments are evidence of the structure of the Company\\'s internal organization. The NIKE Brand segments are defined by geographic regions for operations participating in NIKE Brand sales activity.\\n\\nThe breakdown of Revenues is as follows:\\n\\n(Dollars in millions)\\n\\nFISCAL 2023 FISCAL 2022\\n\\n% CHANGE\\n\\n% CHANGE EXCLUDING CURRENCY (1) CHANGES FISCAL 2021\\n\\n% CHANGE\\n\\nNorth America Europe, Middle East & Africa Greater China\\n\\n$\\n\\n21,608 $ 13,418 7,248\\n\\n18,353 12,479 7,547\\n\\n18 % 8 % -4 %\\n\\n18 % $ 21 % 4 %\\n\\n17,179 11,456 8,290\\n\\n7 % 9 % -9 %\\n\\nAsia Pacific & Latin America Global Brand Divisions\\n\\n(3)\\n\\n(2)\\n\\n6,431 58\\n\\n5,955 102\\n\\n8 % -43 %\\n\\n17 % -43 %\\n\\n5,343 25\\n\\n11 % 308 %\\n\\nTOTAL NIKE BRAND Converse\\n\\n$\\n\\n48,763 $ 2,427\\n\\n44,436 2,346\\n\\n10 % 3 %\\n\\n16 % $ 8 %\\n\\n42,293 2,205\\n\\n5 % 6 %\\n\\n(4)\\n\\nCorporate TOTAL NIKE, INC. REVENUES\\n\\n$\\n\\n27\\n\\n51,217 $\\n\\n(72) 46,710\\n\\n— 10 %\\n\\n— 16 % $\\n\\n40 44,538\\n\\n— 5 %\\n\\n(1) The percent change excluding currency changes represents a non-GAAP financial measure. For further information, see \"Use of Non-GAAP Financial Measures\".\\n\\n(2) For additional information on the transition of our NIKE Brand businesses within our CASA territory to a third-party distributor, see Note 18 — Acquisitions and Divestitures of the Notes to Consolidated\\n\\nFinancial Statements contained in Item 8 of this Annual Report.\\n\\n(3) Global Brand Divisions revenues include NIKE Brand licensing and other miscellaneous revenues that are not part of a geographic operating segment.\\n\\n(4) Corporate revenues primarily consist of foreign currency hedge gains and losses related to revenues generated by entities within the NIKE Brand geographic operating segments and Converse, but\\n\\nmanaged through our central foreign exchange risk management program.\\n\\nThe primary financial measure used by the Company to evaluate performance is Earnings Before Interest and Taxes (\"EBIT\"). As discussed in Note 15 — Operating Segments and Related Information in the accompanying Notes to the Consolidated Financial Statements, certain corporate costs are not included in EBIT.\\n\\nThe breakdown of EBIT is as follows:\\n\\n(Dollars in millions)\\n\\nFISCAL 2023\\n\\nFISCAL 2022\\n\\n% CHANGE\\n\\nFISCAL 2021\\n\\nNorth America Europe, Middle East & Africa Greater China\\n\\n$\\n\\n5,454 3,531 2,283\\n\\n$\\n\\n5,114 3,293 2,365\\n\\n7 % $ 7 % -3 %\\n\\n5,089 2,435 3,243\\n\\nAsia Pacific & Latin America Global Brand Divisions (1)'),\n",
-                            "  Document(metadata={'source': 'resources/nke-10k-2023.pdf'}, page_content=\"NIKE, INC. CONSOLIDATED STATEMENTS OF INCOME\\n\\n(In millions, except per share data)\\n\\nRevenues Cost of sales\\n\\nGross profit\\n\\nDemand creation expense Operating overhead expense\\n\\nTotal selling and administrative expense\\n\\nInterest expense (income), net\\n\\nOther (income) expense, net Income before income taxes\\n\\nIncome tax expense NET INCOME\\n\\nEarnings per common share:\\n\\nBasic Diluted\\n\\nWeighted average common shares outstanding:\\n\\nBasic Diluted\\n\\nThe accompanying Notes to the Consolidated Financial Statements are an integral part of this statement.\\n\\n$\\n\\n$\\n\\n$ $\\n\\nYEAR ENDED MAY 31,\\n\\n2023\\n\\n2022\\n\\n2021\\n\\n51,217 $ 28,925\\n\\n46,710 $ 25,231\\n\\n44,538 24,576\\n\\n22,292 4,060 12,317\\n\\n21,479 3,850 10,954\\n\\n19,962 3,114 9,911\\n\\n16,377 (6)\\n\\n14,804 205\\n\\n13,025 262\\n\\n(280) 6,201\\n\\n(181) 6,651\\n\\n14 6,661\\n\\n1,131 5,070 $\\n\\n605 6,046 $\\n\\n934 5,727\\n\\n3.27 $ 3.23 $\\n\\n3.83 $ 3.75 $\\n\\n3.64 3.56\\n\\n1,551.6 1,569.8\\n\\n1,578.8 1,610.8\\n\\n1,573.0 1,609.4\\n\\n2023 FORM 10-K 55\\n\\nTable of Contents\\n\\nNIKE, INC. CONSOLIDATED STATEMENTS OF COMPREHENSIVE INCOME\\n\\nYEAR ENDED MAY 31,\\n\\n(Dollars in millions)\\n\\n2023\\n\\n2022\\n\\nNet income Other comprehensive income (loss), net of tax:\\n\\n$\\n\\n5,070 $\\n\\n6,046 $\\n\\nChange in net foreign currency translation adjustment\\n\\n267\\n\\n(522)\\n\\nChange in net gains (losses) on cash flow hedges Change in net gains (losses) on other\\n\\n(348) (6)\\n\\n1,214 6\\n\\nTotal other comprehensive income (loss), net of tax TOTAL COMPREHENSIVE INCOME\\n\\n$\\n\\n(87) 4,983 $\\n\\n698 6,744 $\\n\\nThe accompanying Notes to the Consolidated Financial Statements are an integral part of this statement.\\n\\n2023 FORM 10-K 56\\n\\n2021\\n\\n5,727\\n\\n496\\n\\n(825) 5\\n\\n(324) 5,403\\n\\nTable of Contents\\n\\nNIKE, INC. CONSOLIDATED BALANCE SHEETS\\n\\n(In millions)\\n\\nASSETS\\n\\nCurrent assets:\\n\\nCash and equivalents Short-term investments\\n\\nAccounts receivable, net Inventories Prepaid expenses and other current assets\\n\\nTotal current assets\\n\\nProperty, plant and equipment, net\\n\\nOperating lease right-of-use assets, net Identifiable intangible assets, net Goodwill\\n\\nDeferred income taxes and other assets\\n\\nTOTAL ASSETS\\n\\nLIABILITIES AND SHAREHOLDERS' EQUITY Current liabilities:\\n\\nCurrent portion of long-term debt Notes payable Accounts payable\\n\\nCurrent portion of operating lease liabilities Accrued liabilities Income taxes payable\\n\\nTotal current liabilities\\n\\nLong-term debt\\n\\nOperating lease liabilities Deferred income taxes and other liabilities Commitments and contingencies (Note 16)\\n\\nRedeemable preferred stock Shareholders' equity: Common stock at stated value:\"),\n",
-                            "  Document(metadata={'source': 'resources/nke-10k-2023.pdf'}, page_content=\"Tax (expense) benefit Gain (loss) net of tax\\n\\n5 (14)\\n\\n(9) 22\\n\\nTotal net gain (loss) reclassified for the period\\n\\n$\\n\\n463 $\\n\\n30\\n\\n2023 FORM 10-K 82\\n\\nTable of Contents\\n\\nNOTE 14 — REVENUES\\n\\nDISAGGREGATION OF REVENUES The following tables present the Company's Revenues disaggregated by reportable operating segment, major product line and distribution channel:\\n\\n(Dollars in millions)\\n\\nNORTH AMERICA\\n\\nEUROPE, MIDDLE EAST & AFRICA\\n\\nGREATER CHINA\\n\\nYEAR ENDED MAY 31, 2023 ASIA PACIFIC & LATIN (1)\\n\\nGLOBAL BRAND DIVISIONS\\n\\nTOTAL NIKE\\n\\nAMERICA\\n\\nBRAND CONVERSE CORPORATE\\n\\nTOTAL NIKE, INC.\\n\\nRevenues by: Footwear\\n\\n$\\n\\n14,897 $\\n\\n8,260 $\\n\\n5,435 $\\n\\n4,543 $\\n\\n— $\\n\\n33,135 $\\n\\n2,155 $\\n\\n— $\\n\\n35,290\\n\\nApparel Equipment Other\\n\\n5,947 764 —\\n\\n4,566 592 —\\n\\n1,666 147 —\\n\\n1,664 224 —\\n\\n— — 58\\n\\n13,843 1,727 58\\n\\n90 28 154\\n\\n— — 27\\n\\n13,933 1,755 239\\n\\nTOTAL REVENUES\\n\\n$\\n\\n21,608 $\\n\\n13,418 $\\n\\n7,248 $\\n\\n6,431 $\\n\\n58 $\\n\\n48,763 $\\n\\n2,427 $\\n\\n27 $\\n\\n51,217\\n\\nRevenues by:\\n\\nSales to Wholesale Customers Sales through Direct to Consumer\\n\\n$\\n\\n11,273 $ 10,335\\n\\n8,522 $ 4,896\\n\\n3,866 $ 3,382\\n\\n3,736 $ 2,695\\n\\n— $ —\\n\\n27,397 $ 21,308\\n\\n1,299 $ 974\\n\\n— $ —\\n\\n28,696 22,282\\n\\nOther\\n\\nTOTAL REVENUES\\n\\n$\\n\\n—\\n\\n21,608 $\\n\\n—\\n\\n13,418 $\\n\\n— 7,248 $\\n\\n— 6,431 $\\n\\n58 58 $\\n\\n58\\n\\n48,763 $\\n\\n154 2,427 $\\n\\n27 27 $\\n\\n239 51,217\\n\\n(1) Refer to Note 18 — Acquisitions and Divestitures for additional information on the transition of the Company's NIKE Brand businesses in its CASA territory to third-party distributors.\\n\\nYEAR ENDED MAY 31, 2022\\n\\n(Dollars in millions)\\n\\nNORTH AMERICA\\n\\nEUROPE, MIDDLE EAST & AFRICA\\n\\nGREATER CHINA\\n\\nASIA PACIFIC & LATIN AMERICA\\n\\nGLOBAL BRAND DIVISIONS\\n\\nTOTAL NIKE\\n\\nBRAND CONVERSE CORPORATE\\n\\nTOTAL NIKE, INC.\\n\\nRevenues by: Footwear Apparel\\n\\n$\\n\\n12,228 $ 5,492\\n\\n7,388 $ 4,527\\n\\n5,416 $ 1,938\\n\\n4,111 $ 1,610\\n\\n— $ —\\n\\n29,143 $ 13,567\\n\\n2,094 $ 103\\n\\n— $ —\\n\\n31,237 13,670\\n\\nEquipment Other\\n\\n633 —\\n\\n564 —\\n\\n193 —\\n\\n234 —\\n\\n— 102\\n\\n1,624 102\\n\\n26 123\\n\\n— (72)\\n\\n1,650 153\\n\\nTOTAL REVENUES Revenues by:\\n\\n$\\n\\n18,353 $\\n\\n12,479 $\\n\\n7,547 $\\n\\n5,955 $\\n\\n102 $\\n\\n44,436 $\\n\\n2,346 $\\n\\n(72) $\\n\\n46,710\\n\\nSales to Wholesale Customers Sales through Direct to Consumer Other\\n\\n$\\n\\n9,621 $ 8,732 —\\n\\n8,377 $ 4,102 —\\n\\n4,081 $ 3,466 —\\n\\n3,529 $ 2,426 —\\n\\n— $ — 102\\n\\n25,608 $ 18,726 102\\n\\n1,292 $ 931 123\\n\\n— $ — (72)\\n\\n26,900 19,657 153\\n\\nTOTAL REVENUES\\n\\n$\\n\\n18,353 $\\n\\n12,479 $\\n\\n7,547 $\\n\\n5,955 $\\n\\n102 $\\n\\n44,436 $\\n\\n2,346 $\\n\\n(72) $\\n\\n46,710\\n\\n2023 FORM 10-K 83\\n\\nTable of Contents\\n\\nYEAR ENDED MAY 31, 2021\\n\\n(Dollars in millions)\\n\\nNORTH AMERICA\\n\\nEUROPE, MIDDLE EAST & AFRICA\\n\\nGREATER CHINA\"),\n",
-                            "  Document(metadata={'source': 'resources/nke-10k-2023.pdf'}, page_content=\"ASIA PACIFIC & LATIN AMERICA\\n\\n(1)\\n\\nGLOBAL BRAND DIVISIONS\\n\\nTOTAL NIKE BRAND\\n\\nCONVERSE CORPORATE\\n\\nTOTAL NIKE, INC.\\n\\nRevenues by:\\n\\nFootwear Apparel Equipment\\n\\n$\\n\\n11,644 $ 5,028 507\\n\\n6,970 $ 3,996 490\\n\\n5,748 $ 2,347 195\\n\\n3,659 $ 1,494 190\\n\\n— $ — —\\n\\n28,021 $ 12,865 1,382\\n\\n1,986 $ 104 29\\n\\n— $ — —\\n\\n30,007 12,969 1,411\\n\\nOther\\n\\nTOTAL REVENUES\\n\\n$\\n\\n—\\n\\n17,179 $\\n\\n—\\n\\n11,456 $\\n\\n— 8,290 $\\n\\n— 5,343 $\\n\\n25 25 $\\n\\n25\\n\\n42,293 $\\n\\n86 2,205 $\\n\\n40 40 $\\n\\n151 44,538\\n\\nRevenues by:\\n\\nSales to Wholesale Customers $\\n\\n10,186 $\\n\\n7,812 $\\n\\n4,513 $\\n\\n3,387 $\\n\\n— $\\n\\n25,898 $\\n\\n1,353 $\\n\\n— $\\n\\n27,251\\n\\nSales through Direct to Consumer Other\\n\\n6,993 —\\n\\n3,644 —\\n\\n3,777 —\\n\\n1,956 —\\n\\n— 25\\n\\n16,370 25\\n\\n766 86\\n\\n— 40\\n\\n17,136 151\\n\\nTOTAL REVENUES\\n\\n$\\n\\n17,179 $\\n\\n11,456 $\\n\\n8,290 $\\n\\n5,343 $\\n\\n25 $\\n\\n42,293 $\\n\\n2,205 $\\n\\n40 $\\n\\n44,538\\n\\n(1) Refer to Note 18 — Acquisitions and Divestitures for additional information on the transition of the Company's NIKE Brand business in Brazil to a third-party distributor.\\n\\nFor the fiscal years ended May 31, 2023, 2022 and 2021, Global Brand Divisions revenues include NIKE Brand licensing and other miscellaneous revenues that are not part of a geographic operating segment. Converse Other revenues were primarily attributable to licensing businesses. Corporate revenues primarily consisted of foreign currency hedge gains and losses related to revenues generated by entities within the NIKE Brand geographic operating segments and Converse but managed through the Company's central foreign exchange risk management program.\\n\\nAs of May 31, 2023 and 2022, the Company did not have any contract assets and had an immaterial amount of contract liabilities recorded in Accrued liabilities on the Consolidated Balance Sheets.\\n\\nSALES-RELATED RESERVES\\n\\nAs of May 31, 2023 and 2022, the Company's sales-related reserve balance, which includes returns, post-invoice sales discounts and miscellaneous claims, was $994 million and $1,015 million, respectively, recorded in Accrued liabilities on the Consolidated Balance Sheets. The estimated cost of inventory for expected product returns was $226 million and $194 million as of May 31, 2023 and 2022, respectively, and was recorded in Prepaid expenses and other current assets on the Consolidated Balance Sheets.\\n\\nNOTE 15 — OPERATING SEGMENTS AND RELATED INFORMATION\")],\n",
-                            " 'answer': \"Nike's revenue last year was $51,217 million.\"}"
-                        ]
-                    },
-                    "execution_count": 109,
-                    "metadata": {},
-                    "output_type": "execute_result"
-                }
-            ],
-            "source": [
-                "from langchain.chains import create_retrieval_chain\n",
-                "from langchain.chains.combine_documents import create_stuff_documents_chain\n",
-                "\n",
-                "question_answer_chain = create_stuff_documents_chain(llm, prompt)\n",
-                "rag_chain = create_retrieval_chain(rds.as_retriever(), question_answer_chain)\n",
-                "\n",
-                "rag_chain.invoke({\"input\": \"What was nike's revenue last year?\"})"
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "metadata": {},
-            "source": [
-                "## (Optional) Creating a test set\n",
-                "\n",
-                "Now that our setup is complete and we have our RAG app to evaluate we need a test set to evaluate against. The ragas library provides a helpful class for generating a synthetic test set given our data as input that we will use here. The output of this generation is a set of `questions`, `contexts`, and `ground_truth`. \n",
-                "\n",
-                "The questions are generated by an LLM based on slices of context from the provided doc and the ground_truth is determined via a critic LLM. Note there is nothing special about this data itself and you can provide your own `questions` and `ground_truth` for evaluation purposes. When starting a project however, there is often a lack of quality human labeled data to be used for evaluation and a synthetic dataset is a valuable place to start if pre live user/process data (which should be incorporated as an ultimate goal).\n",
-                "\n",
-                "For more detail see [the docs](https://docs.ragas.io/en/stable/concepts/testset_generation.html)"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": 15,
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "# NBVAL_SKIP\n",
-                "# source: https://docs.ragas.io/en/latest/getstarted/testset_generation.html\n",
-                "from ragas.testset.generator import TestsetGenerator\n",
-                "from ragas.testset.evolutions import simple, reasoning, multi_context\n",
-                "from ragas.run_config import RunConfig\n",
-                "from langchain_openai import ChatOpenAI, OpenAIEmbeddings\n",
-                "\n",
-                "run_config = RunConfig(\n",
-                "    timeout=200,\n",
-                "    max_wait=160,\n",
-                "    max_retries=3,\n",
-                ")\n",
-                "\n",
-                "# generator with openai models\n",
-                "generator_llm = ChatOpenAI(model=\"gpt-3.5-turbo-16k\")\n",
-                "critic_llm = ChatOpenAI(model=\"gpt-4o-mini\")\n",
-                "embeddings = OpenAIEmbeddings()\n",
-                "\n",
-                "generator = TestsetGenerator.from_langchain(\n",
-                "    generator_llm,\n",
-                "    critic_llm,\n",
-                "    embeddings,\n",
-                "    run_config=run_config,\n",
-                ")\n",
-                "\n",
-                "testset = generator.generate_with_langchain_docs(\n",
-                "    chunks,\n",
-                "    test_size=10,\n",
-                "    distributions={\n",
-                "        simple: 0.5,\n",
-                "        reasoning: 0.25,\n",
-                "        multi_context: 0.25\n",
-                "    },\n",
-                "    run_config=run_config\n",
-                ")\n",
-                "\n",
-                "# save to csv since this can be a time consuming process\n",
-                "testset.to_pandas().to_csv(\"resources/new_testset.csv\", index=False)"
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "metadata": {},
-            "source": [
-                "## Evaluation helper functions\n",
-                "\n",
-                "The following code takes a RetrievalQA chain, testset dataframe, and the metrics to be evaluated and returns a dataframe including the metrics calculated."
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": 110,
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "import pandas as pd\n",
-                "from datasets import Dataset\n",
-                "from ragas import evaluate\n",
-                "from ragas.run_config import RunConfig\n",
-                "\n",
-                "def parse_contexts(source_docs):\n",
-                "    return [doc.page_content for doc in source_docs]\n",
-                "\n",
-                "def create_evaluation_dataset(chain, testset):\n",
-                "    res_set = {\n",
-                "        \"question\": [],\n",
-                "        \"answer\": [],\n",
-                "        \"contexts\": [],\n",
-                "        \"ground_truth\": []\n",
-                "    }\n",
-                "\n",
-                "    for _, row in testset.iterrows():\n",
-                "        result = chain.invoke({\"input\": row[\"question\"]})\n",
-                "\n",
-                "        res_set[\"question\"].append(row[\"question\"])\n",
-                "        res_set[\"answer\"].append(result[\"answer\"])\n",
-                "\n",
-                "        contexts = parse_contexts(result[\"context\"])\n",
-                "\n",
-                "        if not len(contexts):\n",
-                "            print(f\"no contexts found for question: {row['question']}\")\n",
-                "        res_set[\"contexts\"].append(contexts)\n",
-                "        res_set[\"ground_truth\"].append(str(row[\"ground_truth\"]))\n",
-                "\n",
-                "    return Dataset.from_dict(res_set)\n",
-                "\n",
-                "def evaluate_dataset(eval_dataset, metrics, llm, embeddings):\n",
-                "\n",
-                "    run_config = RunConfig(max_retries=1) # see ragas docs for more run_config options\n",
-                "\n",
-                "    eval_result = evaluate(\n",
-                "        eval_dataset,\n",
-                "        metrics=metrics,\n",
-                "        run_config=run_config,\n",
-                "        llm=llm,\n",
-                "        embeddings=embeddings\n",
-                "    )\n",
-                "\n",
-                "    eval_df = eval_result.to_pandas()\n",
-                "    return eval_df"
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "metadata": {},
-            "source": [
-                "# Create the evaluation data\n",
-                "\n",
-                "Input: chain to be evaluated and a pregenerated test set<br>\n",
-                "Output: dataset formatted for use with ragas evaluation function"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": 111,
-            "metadata": {},
-            "outputs": [
-                {
-                    "data": {
-                        "text/html": [
-                            "<div>\n",
-                            "<style scoped>\n",
-                            "    .dataframe tbody tr th:only-of-type {\n",
-                            "        vertical-align: middle;\n",
-                            "    }\n",
-                            "\n",
-                            "    .dataframe tbody tr th {\n",
-                            "        vertical-align: top;\n",
-                            "    }\n",
-                            "\n",
-                            "    .dataframe thead th {\n",
-                            "        text-align: right;\n",
-                            "    }\n",
-                            "</style>\n",
-                            "<table border=\"1\" class=\"dataframe\">\n",
-                            "  <thead>\n",
-                            "    <tr style=\"text-align: right;\">\n",
-                            "      <th></th>\n",
-                            "      <th>question</th>\n",
-                            "      <th>contexts</th>\n",
-                            "      <th>ground_truth</th>\n",
-                            "      <th>evolution_type</th>\n",
-                            "      <th>metadata</th>\n",
-                            "      <th>episode_done</th>\n",
-                            "    </tr>\n",
-                            "  </thead>\n",
-                            "  <tbody>\n",
-                            "    <tr>\n",
-                            "      <th>0</th>\n",
-                            "      <td>What are short-term investments and how are th...</td>\n",
-                            "      <td>[\"CASH AND EQUIVALENTS Cash and equivalents re...</td>\n",
-                            "      <td>Short-term investments are highly liquid inves...</td>\n",
-                            "      <td>simple</td>\n",
-                            "      <td>[{'source': 'resources/nke-10k-2023.pdf'}]</td>\n",
-                            "      <td>True</td>\n",
-                            "    </tr>\n",
-                            "    <tr>\n",
-                            "      <th>1</th>\n",
-                            "      <td>What are some of the risks and uncertainties a...</td>\n",
-                            "      <td>['Our NIKE Direct operations, including our re...</td>\n",
-                            "      <td>Many factors unique to retail operations, some...</td>\n",
-                            "      <td>simple</td>\n",
-                            "      <td>[{'source': 'resources/nke-10k-2023.pdf'}]</td>\n",
-                            "      <td>True</td>\n",
-                            "    </tr>\n",
-                            "    <tr>\n",
-                            "      <th>2</th>\n",
-                            "      <td>What is NIKE's policy regarding securities ana...</td>\n",
-                            "      <td>[\"Investors should also be aware that while NI...</td>\n",
-                            "      <td>NIKE's policy is to not disclose any material ...</td>\n",
-                            "      <td>simple</td>\n",
-                            "      <td>[{'source': 'resources/nke-10k-2023.pdf'}]</td>\n",
-                            "      <td>True</td>\n",
-                            "    </tr>\n",
-                            "    <tr>\n",
-                            "      <th>3</th>\n",
-                            "      <td>What are the revenues for the Footwear and App...</td>\n",
-                            "      <td>['(Dollars in millions, except per share data)...</td>\n",
-                            "      <td>The revenues for the Footwear and Apparel cate...</td>\n",
-                            "      <td>simple</td>\n",
-                            "      <td>[{'source': 'resources/nke-10k-2023.pdf'}]</td>\n",
-                            "      <td>True</td>\n",
-                            "    </tr>\n",
-                            "    <tr>\n",
-                            "      <th>4</th>\n",
-                            "      <td>How do master netting arrangements impact the ...</td>\n",
-                            "      <td>[\"The Company records the assets and liabiliti...</td>\n",
-                            "      <td>The Company records the assets and liabilities...</td>\n",
-                            "      <td>simple</td>\n",
-                            "      <td>[{'source': 'resources/nke-10k-2023.pdf'}]</td>\n",
-                            "      <td>True</td>\n",
-                            "    </tr>\n",
-                            "  </tbody>\n",
-                            "</table>\n",
-                            "</div>"
-                        ],
-                        "text/plain": [
-                            "                                            question  \\\n",
-                            "0  What are short-term investments and how are th...   \n",
-                            "1  What are some of the risks and uncertainties a...   \n",
-                            "2  What is NIKE's policy regarding securities ana...   \n",
-                            "3  What are the revenues for the Footwear and App...   \n",
-                            "4  How do master netting arrangements impact the ...   \n",
-                            "\n",
-                            "                                            contexts  \\\n",
-                            "0  [\"CASH AND EQUIVALENTS Cash and equivalents re...   \n",
-                            "1  ['Our NIKE Direct operations, including our re...   \n",
-                            "2  [\"Investors should also be aware that while NI...   \n",
-                            "3  ['(Dollars in millions, except per share data)...   \n",
-                            "4  [\"The Company records the assets and liabiliti...   \n",
-                            "\n",
-                            "                                        ground_truth evolution_type  \\\n",
-                            "0  Short-term investments are highly liquid inves...         simple   \n",
-                            "1  Many factors unique to retail operations, some...         simple   \n",
-                            "2  NIKE's policy is to not disclose any material ...         simple   \n",
-                            "3  The revenues for the Footwear and Apparel cate...         simple   \n",
-                            "4  The Company records the assets and liabilities...         simple   \n",
-                            "\n",
-                            "                                     metadata  episode_done  \n",
-                            "0  [{'source': 'resources/nke-10k-2023.pdf'}]          True  \n",
-                            "1  [{'source': 'resources/nke-10k-2023.pdf'}]          True  \n",
-                            "2  [{'source': 'resources/nke-10k-2023.pdf'}]          True  \n",
-                            "3  [{'source': 'resources/nke-10k-2023.pdf'}]          True  \n",
-                            "4  [{'source': 'resources/nke-10k-2023.pdf'}]          True  "
-                        ]
-                    },
-                    "execution_count": 111,
-                    "metadata": {},
-                    "output_type": "execute_result"
-                }
-            ],
-            "source": [
-                "testset_df = pd.read_csv(\"resources/testset_15.csv\")\n",
-                "testset_df.head()"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": 112,
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "eval_dataset = create_evaluation_dataset(rag_chain, testset_df)\n",
-                "eval_dataset.to_pandas().shape"
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "metadata": {},
-            "source": [
-                "# Evaluate generation metrics\n",
-                "Generation metrics quantify how well the RAG app did creating answers to the provided questions (i.e. the G in **R**etrival **A**ugments **G**eneration). We will calculate the generation metrics **faithfulness** and **answer relevancy** for this example.\n",
-                "\n",
-                "The ragas libary conveniently abstracts the calculation of these metrics so we don't have to write redundant code but please review the following definitions in order to build intuition around what these metrics actually measure.\n",
-                "\n",
-                "Note: the following examples are paraphrased from the [ragas docs](https://docs.ragas.io/en/stable/concepts/metrics/index.html)\n",
-                "\n",
-                "------\n",
-                "\n",
-                "### Faithfulness\n",
-                "\n",
-                "An answer to a question can be said to be \"faithful\" if the **claims** that are made in the answer **can be inferred** from the **context**.\n",
-                "\n",
-                "#### Mathematically:\n",
-                "\n",
-                "$$\n",
-                "Faithfullness\\ score = \\frac{Number\\ of\\ claims\\ in\\ the\\ generated\\ answer\\ that\\ can\\ be\\ inferred\\ from\\ the\\ given\\ context}{Total\\ number\\ of\\ claim\\ in\\ the\\ generated\\ answer}\n",
-                "$$\n",
-                "\n",
-                "#### Example process:\n",
-                "\n",
-                "> Question: Where and when was Einstein born?\n",
-                "> \n",
-                "> Context: Albert Einstein (born 14 March 1879) was a German-born theoretical physicist, widely held to be one of the greatest and most influential scientists of all time\n",
-                ">\n",
-                "> answer: Einstein was born in Germany on 20th March 1879.\n",
-                "\n",
-                "Step 1: Use LLM to break generated answer into individual statements.\n",
-                "- “Einstein was born in Germany.”\n",
-                "- “Einstein was born on 20th March 1879.”\n",
-                "\n",
-                "Step 2: For each statement use LLM to verify if it can be inferred from the context.\n",
-                "- “Einstein was born in Germany.” => yes. \n",
-                "- “Einstein was born on 20th March 1879.” => no.\n",
-                "\n",
-                "Step 3: plug into formula\n",
-                "\n",
-                "Number of claims inferred from context = 1\n",
-                "Total number of claims = 2\n",
-                "Faithfulness = 1/2\n",
-                "\n",
-                "### Answer Relevance\n",
-                "\n",
-                "An answer can be said to be relevant if it directly addresses the question (intuitively).\n",
-                "\n",
-                "#### Example process:\n",
-                "\n",
-                "1. Use an LLM to generate \"hypothetical\" questions to a given answer with the following prompt:\n",
-                "\n",
-                "    > Generate a question for the given answer.\n",
-                "    > answer: [answer]\n",
-                "\n",
-                "2. Embed the generated \"hypothetical\" questions as vectors.\n",
-                "3. Calculate the cosine similarity of the hypothetical questions and the original question, sum those similarities, and divide by n.\n",
-                "\n",
-                "With data:\n",
-                "\n",
-                "> Question: Where is France and what is it’s capital?\n",
-                "> \n",
-                "> answer: France is in western Europe.\n",
-                "\n",
-                "Step 1 - use LLM to create 'n' variants of question from the generated answer.\n",
-                "\n",
-                "- “In which part of Europe is France located?”\n",
-                "- “What is the geographical location of France within Europe?”\n",
-                "- “Can you identify the region of Europe where France is situated?”\n",
-                "\n",
-                "Step 2 - Calculate the mean cosine similarity between the generated questions and the actual question.\n",
-                "\n",
-                "## Now let's implement using our helper functions\n",
-                "\n"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": 114,
-            "metadata": {},
-            "outputs": [
-                {
-                    "data": {
-                        "application/vnd.jupyter.widget-view+json": {
-                            "model_id": "dd9cabb4b0c448b08cad96d2ef3391a2",
-                            "version_major": 2,
-                            "version_minor": 0
-                        },
-                        "text/plain": [
-                            "Evaluating:   0%|          | 0/15 [00:00<?, ?it/s]"
-                        ]
-                    },
-                    "metadata": {},
-                    "output_type": "display_data"
-                }
-            ],
-            "source": [
-                "from ragas.metrics import faithfulness, answer_relevancy\n",
-                "\n",
-                "faithfulness_metrics = evaluate_dataset(eval_dataset, [faithfulness], llm, embeddings)"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": 115,
-            "metadata": {},
-            "outputs": [
-                {
-                    "data": {
-                        "application/vnd.jupyter.widget-view+json": {
-                            "model_id": "72432636d3a44519b57329c66ded9c8c",
-                            "version_major": 2,
-                            "version_minor": 0
-                        },
-                        "text/plain": [
-                            "Evaluating:   0%|          | 0/15 [00:00<?, ?it/s]"
-                        ]
-                    },
-                    "metadata": {},
-                    "output_type": "display_data"
-                }
-            ],
-            "source": [
-                "answer_relevancy_metrics = evaluate_dataset(eval_dataset, [answer_relevancy], llm, embeddings)"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": 116,
-            "metadata": {},
-            "outputs": [
-                {
-                    "data": {
-                        "text/html": [
-                            "<div>\n",
-                            "<style scoped>\n",
-                            "    .dataframe tbody tr th:only-of-type {\n",
-                            "        vertical-align: middle;\n",
-                            "    }\n",
-                            "\n",
-                            "    .dataframe tbody tr th {\n",
-                            "        vertical-align: top;\n",
-                            "    }\n",
-                            "\n",
-                            "    .dataframe thead th {\n",
-                            "        text-align: right;\n",
-                            "    }\n",
-                            "</style>\n",
-                            "<table border=\"1\" class=\"dataframe\">\n",
-                            "  <thead>\n",
-                            "    <tr style=\"text-align: right;\">\n",
-                            "      <th></th>\n",
-                            "      <th>faithfulness</th>\n",
-                            "      <th>answer_relevancy</th>\n",
-                            "    </tr>\n",
-                            "  </thead>\n",
-                            "  <tbody>\n",
-                            "    <tr>\n",
-                            "      <th>count</th>\n",
-                            "      <td>15.000000</td>\n",
-                            "      <td>15.000000</td>\n",
-                            "    </tr>\n",
-                            "    <tr>\n",
-                            "      <th>mean</th>\n",
-                            "      <td>0.781229</td>\n",
-                            "      <td>0.938581</td>\n",
-                            "    </tr>\n",
-                            "    <tr>\n",
-                            "      <th>std</th>\n",
-                            "      <td>0.362666</td>\n",
-                            "      <td>0.085342</td>\n",
-                            "    </tr>\n",
-                            "    <tr>\n",
-                            "      <th>min</th>\n",
-                            "      <td>0.000000</td>\n",
-                            "      <td>0.736997</td>\n",
-                            "    </tr>\n",
-                            "    <tr>\n",
-                            "      <th>25%</th>\n",
-                            "      <td>0.652778</td>\n",
-                            "      <td>0.926596</td>\n",
-                            "    </tr>\n",
-                            "    <tr>\n",
-                            "      <th>50%</th>\n",
-                            "      <td>1.000000</td>\n",
-                            "      <td>0.975230</td>\n",
-                            "    </tr>\n",
-                            "    <tr>\n",
-                            "      <th>75%</th>\n",
-                            "      <td>1.000000</td>\n",
-                            "      <td>0.994168</td>\n",
-                            "    </tr>\n",
-                            "    <tr>\n",
-                            "      <th>max</th>\n",
-                            "      <td>1.000000</td>\n",
-                            "      <td>1.000000</td>\n",
-                            "    </tr>\n",
-                            "  </tbody>\n",
-                            "</table>\n",
-                            "</div>"
-                        ],
-                        "text/plain": [
-                            "       faithfulness  answer_relevancy\n",
-                            "count     15.000000         15.000000\n",
-                            "mean       0.781229          0.938581\n",
-                            "std        0.362666          0.085342\n",
-                            "min        0.000000          0.736997\n",
-                            "25%        0.652778          0.926596\n",
-                            "50%        1.000000          0.975230\n",
-                            "75%        1.000000          0.994168\n",
-                            "max        1.000000          1.000000"
-                        ]
-                    },
-                    "execution_count": 116,
-                    "metadata": {},
-                    "output_type": "execute_result"
-                }
-            ],
-            "source": [
-                "gen_metrics_default = faithfulness_metrics\n",
-                "gen_metrics_default[\"answer_relevancy\"] = answer_relevancy_metrics[\"answer_relevancy\"]\n",
-                "\n",
-                "gen_metrics_default.describe()"
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "metadata": {},
-            "source": [
-                "# Evaluating retrieval metrics\n",
-                "\n",
-                "Retrieval metrics quantify how well the system performed at fetching the best possible context for generation. Like before please review the definitions below to understand what happens under-the-hood when we execute the evaluation code. \n",
-                "\n",
-                "-----\n",
-                "\n",
-                "### Context Relevance\n",
-                "\n",
-                "\"The context is considered relevant to the extent that it exclusively contains information that is needed to answer the question.\"\n",
-                "\n",
-                "#### Example process:\n",
-                "\n",
-                "1. Use the following LLM prompt to extract a subset of sentences necessary to answer the question. The context is defined as the formatted search result from the vector database.\n",
-                "\n",
-                "    > Please extract relevant sentences from\n",
-                "    > the provided context that can potentially\n",
-                "    > help answer the following `{question}`. If no\n",
-                "    > relevant sentences are found, or if you\n",
-                "    > believe the question cannot be answered\n",
-                "    > from the given context, return the phrase\n",
-                "    > \"Insufficient Information\". While extracting candidate sentences you’re not allowed to make any changes to sentences\n",
-                "    > from given `{context}`.\n",
-                "\n",
-                "2. Compute the context relevance score = (number of extracted sentences) / (total number of sentences in context)\n",
-                "\n",
-                "Moving from the initial paper to the active evaluation library ragas there are a few more insightful metrics to evaluate. From the library [source](https://docs.ragas.io/en/stable/concepts/metrics/index.html) let's introduce `context precision` and `context recall`. \n",
-                "\n",
-                "### Context recall\n",
-                "Context can be said to have high recall if retrieved context aligns with the ground truth answer.\n",
-                "\n",
-                "#### Mathematically:\n",
-                "\n",
-                "$$\n",
-                "Context\\ recall = \\frac{Ground\\ Truth\\ sentences\\ that\\ can\\ be\\ attributed\\ to\\ context}{Total\\ number\\ of\\ sentences\\ in\\ the\\ ground\\ truth}\n",
-                "$$\n",
-                "\n",
-                "#### Example process:\n",
-                "\n",
-                "Data:\n",
-                "> question: Where is France and what is it’s capital?\n",
-                "> ground truth answer: France is in Western Europe and its capital is Paris.\n",
-                "> context: France, in Western Europe, encompasses medieval cities, alpine villages and Mediterranean beaches. The country is also renowned for its wines and sophisticated cuisine. Lascaux’s ancient cave drawings, Lyon’s Roman theater and the vast Palace of Versailles attest to its rich history.\n",
-                ">\n",
-                "> Note: ground truth answer can be created by critic LLM or with own human labeled data set.\n",
-                "\n",
-                "Step 1 - use an LLM to break the ground truth down into individual statements:\n",
-                "- `France is in Western Europe`\n",
-                "- `Its capital is Paris`\n",
-                "\n",
-                "Step 2 - for each ground truth statement, use an LLM to determine if it can be attributed from the context.\n",
-                "- `France is in Western Europe` => yes\n",
-                "- `Its capital is Paris` => no\n",
-                "\n",
-                "\n",
-                "Step 3 - plug in to formula\n",
-                "\n",
-                "context recall = (1 + 0) / 2 = 0.5\n",
-                "\n",
-                "### Context precision\n",
-                "\n",
-                "This metrics relates to how chunks are ranked in a response. Ideally the most relevant chunks are at the top.\n",
-                "\n",
-                "#### Mathematically:\n",
-                "\n",
-                "$$\n",
-                "Context\\ Precision@k = \\frac{precision@k}{total\\ number\\ relevant\\ items\\ in\\ the\\ top\\ k\\ results}\n",
-                "$$\n",
-                "\n",
-                "$$\n",
-                "Precision@k = \\frac{true\\ positive@k}{true\\ positives@k + false\\ positives@k}\n",
-                "$$\n",
-                "\n",
-                "#### Example process:\n",
-                "\n",
-                "Data:\n",
-                "> Question: Where is France and what is it’s capital?\n",
-                "> \n",
-                "> Ground truth: France is in Western Europe and its capital is Paris.\n",
-                "> \n",
-                "> Context: [ “The country is also renowned for its wines and sophisticated cuisine. Lascaux’s ancient cave drawings, Lyon’s Roman theater and”, “France, in Western Europe, encompasses medieval cities, alpine villages and Mediterranean beaches. Paris, its capital, is famed for its fashion houses, classical art museums including the Louvre and monuments like the Eiffel Tower”]\n",
-                "\n",
-                "Step 1 - for each chunk use the LLM to check if it's relevant or not to the ground truth answer.\n",
-                "\n",
-                "Step 2 - for each chunk in the context calculate the precision defined as: ``\n",
-                "- `“The country is also renowned for its wines and sophisticated cuisine. Lascaux’s ancient cave drawings, Lyon’s Roman theater and”` => precision = 0/1 or 0.\n",
-                "- `“France, in Western Europe, encompasses medieval cities, alpine villages and Mediterranean beaches. Paris, its capital, is famed for its fashion houses, classical art museums including the Louvre and monuments like the Eiffel Tower”` => the precision would be (1) / (1 true positive + 1 false positive) = 0.5. \n",
-                "\n",
-                "\n",
-                "Step 3 - calculate the overall context precision = (0 + 0.5) / 1 = 0.5"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": 117,
-            "metadata": {},
-            "outputs": [
-                {
-                    "data": {
-                        "application/vnd.jupyter.widget-view+json": {
-                            "model_id": "c076c3dc42cf49cf8d768dec225727d5",
-                            "version_major": 2,
-                            "version_minor": 0
-                        },
-                        "text/plain": [
-                            "Evaluating:   0%|          | 0/15 [00:00<?, ?it/s]"
-                        ]
-                    },
-                    "metadata": {},
-                    "output_type": "display_data"
-                }
-            ],
-            "source": [
-                "from ragas.metrics import context_recall, context_precision\n",
-                "\n",
-                "context_recall_metrics = evaluate_dataset(eval_dataset, [context_recall], llm, embeddings)"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": 118,
-            "metadata": {},
-            "outputs": [
-                {
-                    "data": {
-                        "application/vnd.jupyter.widget-view+json": {
-                            "model_id": "1055dffc473846a3b5f43895485be9a0",
-                            "version_major": 2,
-                            "version_minor": 0
-                        },
-                        "text/plain": [
-                            "Evaluating:   0%|          | 0/15 [00:00<?, ?it/s]"
-                        ]
-                    },
-                    "metadata": {},
-                    "output_type": "display_data"
-                }
-            ],
-            "source": [
-                "context_precision_metrics = evaluate_dataset(eval_dataset, [context_precision], llm, embeddings)"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": 119,
-            "metadata": {},
-            "outputs": [
-                {
-                    "data": {
-                        "text/html": [
-                            "<div>\n",
-                            "<style scoped>\n",
-                            "    .dataframe tbody tr th:only-of-type {\n",
-                            "        vertical-align: middle;\n",
-                            "    }\n",
-                            "\n",
-                            "    .dataframe tbody tr th {\n",
-                            "        vertical-align: top;\n",
-                            "    }\n",
-                            "\n",
-                            "    .dataframe thead th {\n",
-                            "        text-align: right;\n",
-                            "    }\n",
-                            "</style>\n",
-                            "<table border=\"1\" class=\"dataframe\">\n",
-                            "  <thead>\n",
-                            "    <tr style=\"text-align: right;\">\n",
-                            "      <th></th>\n",
-                            "      <th>context_recall</th>\n",
-                            "      <th>context_precision</th>\n",
-                            "    </tr>\n",
-                            "  </thead>\n",
-                            "  <tbody>\n",
-                            "    <tr>\n",
-                            "      <th>count</th>\n",
-                            "      <td>15.000000</td>\n",
-                            "      <td>15.000000</td>\n",
-                            "    </tr>\n",
-                            "    <tr>\n",
-                            "      <th>mean</th>\n",
-                            "      <td>0.966667</td>\n",
-                            "      <td>0.925926</td>\n",
-                            "    </tr>\n",
-                            "    <tr>\n",
-                            "      <th>std</th>\n",
-                            "      <td>0.129099</td>\n",
-                            "      <td>0.145352</td>\n",
-                            "    </tr>\n",
-                            "    <tr>\n",
-                            "      <th>min</th>\n",
-                            "      <td>0.500000</td>\n",
-                            "      <td>0.500000</td>\n",
-                            "    </tr>\n",
-                            "    <tr>\n",
-                            "      <th>25%</th>\n",
-                            "      <td>1.000000</td>\n",
-                            "      <td>0.916667</td>\n",
-                            "    </tr>\n",
-                            "    <tr>\n",
-                            "      <th>50%</th>\n",
-                            "      <td>1.000000</td>\n",
-                            "      <td>1.000000</td>\n",
-                            "    </tr>\n",
-                            "    <tr>\n",
-                            "      <th>75%</th>\n",
-                            "      <td>1.000000</td>\n",
-                            "      <td>1.000000</td>\n",
-                            "    </tr>\n",
-                            "    <tr>\n",
-                            "      <th>max</th>\n",
-                            "      <td>1.000000</td>\n",
-                            "      <td>1.000000</td>\n",
-                            "    </tr>\n",
-                            "  </tbody>\n",
-                            "</table>\n",
-                            "</div>"
-                        ],
-                        "text/plain": [
-                            "       context_recall  context_precision\n",
-                            "count       15.000000          15.000000\n",
-                            "mean         0.966667           0.925926\n",
-                            "std          0.129099           0.145352\n",
-                            "min          0.500000           0.500000\n",
-                            "25%          1.000000           0.916667\n",
-                            "50%          1.000000           1.000000\n",
-                            "75%          1.000000           1.000000\n",
-                            "max          1.000000           1.000000"
-                        ]
-                    },
-                    "execution_count": 119,
-                    "metadata": {},
-                    "output_type": "execute_result"
-                }
-            ],
-            "source": [
-                "ret_metrics_default = context_recall_metrics\n",
-                "ret_metrics_default[\"context_precision\"] = context_precision_metrics[\"context_precision\"]\n",
-                "\n",
-                "ret_metrics_default.describe()"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": 120,
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "metrics = ret_metrics_default\n",
-                "metrics[\"faithfulness\"] = gen_metrics_default[\"faithfulness\"]\n",
-                "metrics[\"answer_relevancy\"] = gen_metrics_default[\"answer_relevancy\"]\n",
-                "\n",
-                "metrics.to_csv(f\"resources/metrics_{CHUNK_SIZE}_{CHUNK_OVERLAP}.csv\", index=False)"
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "metadata": {},
-            "source": [
-                "# All together"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": 121,
-            "metadata": {},
-            "outputs": [
-                {
-                    "data": {
-                        "text/html": [
-                            "<div>\n",
-                            "<style scoped>\n",
-                            "    .dataframe tbody tr th:only-of-type {\n",
-                            "        vertical-align: middle;\n",
-                            "    }\n",
-                            "\n",
-                            "    .dataframe tbody tr th {\n",
-                            "        vertical-align: top;\n",
-                            "    }\n",
-                            "\n",
-                            "    .dataframe thead th {\n",
-                            "        text-align: right;\n",
-                            "    }\n",
-                            "</style>\n",
-                            "<table border=\"1\" class=\"dataframe\">\n",
-                            "  <thead>\n",
-                            "    <tr style=\"text-align: right;\">\n",
-                            "      <th></th>\n",
-                            "      <th>context_recall</th>\n",
-                            "      <th>context_precision</th>\n",
-                            "      <th>faithfulness</th>\n",
-                            "      <th>answer_relevancy</th>\n",
-                            "    </tr>\n",
-                            "  </thead>\n",
-                            "  <tbody>\n",
-                            "    <tr>\n",
-                            "      <th>count</th>\n",
-                            "      <td>15.000000</td>\n",
-                            "      <td>15.000000</td>\n",
-                            "      <td>15.000000</td>\n",
-                            "      <td>15.000000</td>\n",
-                            "    </tr>\n",
-                            "    <tr>\n",
-                            "      <th>mean</th>\n",
-                            "      <td>0.966667</td>\n",
-                            "      <td>0.925926</td>\n",
-                            "      <td>0.781229</td>\n",
-                            "      <td>0.938581</td>\n",
-                            "    </tr>\n",
-                            "    <tr>\n",
-                            "      <th>std</th>\n",
-                            "      <td>0.129099</td>\n",
-                            "      <td>0.145352</td>\n",
-                            "      <td>0.362666</td>\n",
-                            "      <td>0.085342</td>\n",
-                            "    </tr>\n",
-                            "    <tr>\n",
-                            "      <th>min</th>\n",
-                            "      <td>0.500000</td>\n",
-                            "      <td>0.500000</td>\n",
-                            "      <td>0.000000</td>\n",
-                            "      <td>0.736997</td>\n",
-                            "    </tr>\n",
-                            "    <tr>\n",
-                            "      <th>25%</th>\n",
-                            "      <td>1.000000</td>\n",
-                            "      <td>0.916667</td>\n",
-                            "      <td>0.652778</td>\n",
-                            "      <td>0.926596</td>\n",
-                            "    </tr>\n",
-                            "    <tr>\n",
-                            "      <th>50%</th>\n",
-                            "      <td>1.000000</td>\n",
-                            "      <td>1.000000</td>\n",
-                            "      <td>1.000000</td>\n",
-                            "      <td>0.975230</td>\n",
-                            "    </tr>\n",
-                            "    <tr>\n",
-                            "      <th>75%</th>\n",
-                            "      <td>1.000000</td>\n",
-                            "      <td>1.000000</td>\n",
-                            "      <td>1.000000</td>\n",
-                            "      <td>0.994168</td>\n",
-                            "    </tr>\n",
-                            "    <tr>\n",
-                            "      <th>max</th>\n",
-                            "      <td>1.000000</td>\n",
-                            "      <td>1.000000</td>\n",
-                            "      <td>1.000000</td>\n",
-                            "      <td>1.000000</td>\n",
-                            "    </tr>\n",
-                            "  </tbody>\n",
-                            "</table>\n",
-                            "</div>"
-                        ],
-                        "text/plain": [
-                            "       context_recall  context_precision  faithfulness  answer_relevancy\n",
-                            "count       15.000000          15.000000     15.000000         15.000000\n",
-                            "mean         0.966667           0.925926      0.781229          0.938581\n",
-                            "std          0.129099           0.145352      0.362666          0.085342\n",
-                            "min          0.500000           0.500000      0.000000          0.736997\n",
-                            "25%          1.000000           0.916667      0.652778          0.926596\n",
-                            "50%          1.000000           1.000000      1.000000          0.975230\n",
-                            "75%          1.000000           1.000000      1.000000          0.994168\n",
-                            "max          1.000000           1.000000      1.000000          1.000000"
-                        ]
-                    },
-                    "execution_count": 121,
-                    "metadata": {},
-                    "output_type": "execute_result"
-                }
-            ],
-            "source": [
-                "metrics.describe()"
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "metadata": {},
-            "source": [
-                "## Analysis\n",
-                "Overall our RAG app showed pretty good performance. All values indicated above 0.6, which from anecdotal experience, is a reasonable lower-bound for performance however obviously higher values are more ideal. It is worth noting that generation metrics can be a bit more hazy in terms of ideal ranges since the LLM evaluation cannot yet capture the way a response feels to a user. For these metrics it's important to make sure they are not severely low however blind optimization to the top can result in a very uncreative chat experience which may or may not be ideal for the intended use case.\n",
-                "\n",
-                "## Review\n",
-                "\n",
-                "- we initialized our RAG app with data from a 10k document\n",
-                "- generated a testset to evaluate \n",
-                "- calculated both retrieval and generation metrics\n",
-                "\n",
-                "## Next steps\n",
-                "\n",
-                "Now that we know how to measure our system we can quickly and easily experiment with different techniques with a baseline in place to improve our systems.\n",
-                "\n",
-                "## Cleanup"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": 122,
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "from redisvl.index import SearchIndex\n",
-                "\n",
-                "idx = SearchIndex.from_existing(\n",
-                "    index_name,\n",
-                "    redis_url=REDIS_URL\n",
-                ")\n",
-                "\n",
-                "idx.delete()"
-            ]
-        }
-    ],
-    "metadata": {
-        "kernelspec": {
-            "display_name": "Python 3",
-            "language": "python",
-            "name": "python3"
-        },
-        "language_info": {
-            "codemirror_mode": {
-                "name": "ipython",
-                "version": 3
-            },
-            "file_extension": ".py",
-            "mimetype": "text/x-python",
-            "name": "python",
-            "nbconvert_exporter": "python",
-            "pygments_lexer": "ipython3",
-            "version": "3.11.9"
-        }
-    },
-    "nbformat": 4,
-    "nbformat_minor": 2
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "![Redis](https://redis.io/wp-content/uploads/2024/04/Logotype.svg?auto=webp&quality=85,75&width=120)\n",
+    "# Evaluating RAG\n",
+    "\n",
+    "This notebook uses the [ragas library](https://docs.ragas.io/en/stable/getstarted/index.html) and [Redis](https://redis.com) to evaluate the performance of sample RAG application. Also see the original [source paper](https://arxiv.org/pdf/2309.15217) to build a more detailed understanding.\n",
+    "\n",
+    "## Let's Begin!\n",
+    "<a href=\"https://colab.research.google.com/github/redis-developer/redis-ai-resources/blob/main/python-recipes/RAG/06_ragas_evaluation.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To start, we need a RAG app to evaluate. Let's create one using LangChain and connect it with Redis as the vector DB.\n",
+    "\n",
+    "## Init redis, data prep, and populating the vector DB"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "\u001B[1m[\u001B[0m\u001B[34;49mnotice\u001B[0m\u001B[1;39;49m]\u001B[0m\u001B[39;49m A new release of pip is available: \u001B[0m\u001B[31;49m24.0\u001B[0m\u001B[39;49m -> \u001B[0m\u001B[32;49m24.2\u001B[0m\n",
+      "\u001B[1m[\u001B[0m\u001B[34;49mnotice\u001B[0m\u001B[1;39;49m]\u001B[0m\u001B[39;49m To update, run: \u001B[0m\u001B[32;49mpip install --upgrade pip\u001B[0m\n",
+      "Note: you may need to restart the kernel to use updated packages.\n"
+     ]
+    }
+   ],
+   "source": "%pip install -q redis \"unstructured[pdf]\" sentence-transformers langchain \"langchain-redis>=0.2.0\" langchain-huggingface langchain-openai ragas datasets"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Running Redis in Colab\n",
+    "Use the shell script below to download, extract, and install [Redis Stack](https://redis.io/docs/getting-started/install-stack/) directly from the Redis package archive."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# NBVAL_SKIP\n",
+    "%%sh\n",
+    "curl -fsSL https://packages.redis.io/gpg | sudo gpg --dearmor -o /usr/share/keyrings/redis-archive-keyring.gpg\n",
+    "echo \"deb [signed-by=/usr/share/keyrings/redis-archive-keyring.gpg] https://packages.redis.io/deb $(lsb_release -cs) main\" | sudo tee /etc/apt/sources.list.d/redis.list\n",
+    "sudo apt-get update  > /dev/null 2>&1\n",
+    "sudo apt-get install redis-stack-server  > /dev/null 2>&1\n",
+    "redis-stack-server --daemonize yes"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### For Alternative Environments\n",
+    "There are many ways to get the necessary redis-stack instance running\n",
+    "1. On cloud, deploy a [FREE instance of Redis in the cloud](https://redis.com/try-free/). Or, if you have your\n",
+    "own version of Redis Enterprise running, that works too!\n",
+    "2. Per OS, [see the docs](https://redis.io/docs/latest/operate/oss_and_stack/install/install-stack/)\n",
+    "3. With docker: `docker run -d --name redis-stack-server -p 6379:6379 redis/redis-stack-server:latest`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import warnings\n",
+    "warnings.filterwarnings('ignore')\n",
+    "\n",
+    "# Replace values below with your own if using Redis Cloud instance\n",
+    "REDIS_HOST = os.getenv(\"REDIS_HOST\", \"localhost\") # ex: \"redis-18374.c253.us-central1-1.gce.cloud.redislabs.com\"\n",
+    "REDIS_PORT = os.getenv(\"REDIS_PORT\", \"6379\")      # ex: 18374\n",
+    "REDIS_PASSWORD = os.getenv(\"REDIS_PASSWORD\", \"\")  # ex: \"1TNxTEdYRDgIDKM2gDfasupCADXXXX\"\n",
+    "\n",
+    "# If SSL is enabled on the endpoint, use rediss:// as the URL prefix\n",
+    "REDIS_URL = f\"redis://:{REDIS_PASSWORD}@{REDIS_HOST}:{REDIS_PORT}\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langchain_text_splitters import RecursiveCharacterTextSplitter\n",
+    "from langchain_community.document_loaders import PyPDFLoader\n",
+    "\n",
+    "CHUNK_SIZE = 2500\n",
+    "CHUNK_OVERLAP = 0\n",
+    "\n",
+    "# pdf to load\n",
+    "path = 'resources/nke-10k-2023.pdf'\n",
+    "assert os.path.exists(path), f\"File not found: {path}\"\n",
+    "\n",
+    "# load and split\n",
+    "loader = PyPDFLoader(path)\n",
+    "pages = loader.load()\n",
+    "text_splitter = RecursiveCharacterTextSplitter(chunk_size=CHUNK_SIZE, chunk_overlap=CHUNK_OVERLAP)\n",
+    "chunks = text_splitter.split_documents(pages)\n",
+    "\n",
+    "print(\"Done preprocessing. Created\", len(chunks), \"chunks of the original pdf\", path)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 95,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Document(metadata={'source': 'resources/nke-10k-2023.pdf'}, page_content=\"Table of ContentsUNITED STATESSECURITIES AND EXCHANGE COMMISSIONWashington, D.C. 20549FORM 10-K(Mark One)☑ ANNUAL REPORT PURSUANT TO SECTION 13 OR 15(D) OF THE SECURITIES EXCHANGE ACT OF 1934FOR THE FISCAL YEAR ENDED MAY 31, 2023OR☐ TRANSITION REPORT PURSUANT TO SECTION 13 OR 15(D) OF THE SECURITIES EXCHANGE ACT OF 1934FOR THE TRANSITION PERIOD FROM TO .Commission File No. 1-10635\\n\\nAs of November 30, 2022, the aggregate market values of the Registrant's Common Stock held by non-affiliates were:Class A$7,831,564,572 Class B136,467,702,472 $144,299,267,044\\n\\nNIKE, Inc.(Exact name of Registrant as specified in its charter)Oregon93-0584541(State or other jurisdiction of incorporation)(IRS Employer Identification No.)One Bowerman Drive, Beaverton, Oregon 97005-6453(Address of principal executive offices and zip code)(503) 671-6453(Registrant's telephone number, including area code)SECURITIES REGISTERED PURSUANT TO SECTION 12(B) OF THE ACT:Class B Common StockNKENew York Stock Exchange(Title of each class)(Trading symbol)(Name of each exchange on which registered)SECURITIES REGISTERED PURSUANT TO SECTION 12(G) OF THE ACT:NONE\")"
+      ]
+     },
+     "execution_count": 95,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "chunks[0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 96,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langchain_huggingface import HuggingFaceEmbeddings\n",
+    "\n",
+    "embeddings = HuggingFaceEmbeddings(model_name=\"sentence-transformers/all-MiniLM-L6-v2\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 97,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langchain_redis import RedisVectorStore\n",
+    "\n",
+    "# set the index name for this example\n",
+    "index_name = \"ragas_ex\"\n",
+    "\n",
+    "# construct the vector store class from texts and metadata\n",
+    "rds = RedisVectorStore.from_documents(\n",
+    "    chunks,\n",
+    "    embeddings,\n",
+    "    index_name=index_name,\n",
+    "    redis_url=REDIS_URL,\n",
+    "    metadata_schema=[\n",
+    "        {\n",
+    "            \"name\": \"source\",\n",
+    "            \"type\": \"text\"\n",
+    "        },\n",
+    "    ]\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Test the vector store"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 98,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'As discussed in Note 15 — Operating Segments and Related Information in the accompanying Notes to the Consolidated Financial Statements, our operating segments are evidence of the structure of the Company\\'s internal organization. The NIKE Brand segments are defined by geographic regions for operations participating in NIKE Brand sales activity.\\n\\nThe breakdown of Revenues is as follows:\\n\\n(Dollars in millions)\\n\\nFISCAL 2023 FISCAL 2022\\n\\n% CHANGE\\n\\n% CHANGE EXCLUDING CURRENCY (1) CHANGES FISCAL 2021\\n\\n% CHANGE\\n\\nNorth America Europe, Middle East & Africa Greater China\\n\\n$\\n\\n21,608 $ 13,418 7,248\\n\\n18,353 12,479 7,547\\n\\n18 % 8 % -4 %\\n\\n18 % $ 21 % 4 %\\n\\n17,179 11,456 8,290\\n\\n7 % 9 % -9 %\\n\\nAsia Pacific & Latin America Global Brand Divisions\\n\\n(3)\\n\\n(2)\\n\\n6,431 58\\n\\n5,955 102\\n\\n8 % -43 %\\n\\n17 % -43 %\\n\\n5,343 25\\n\\n11 % 308 %\\n\\nTOTAL NIKE BRAND Converse\\n\\n$\\n\\n48,763 $ 2,427\\n\\n44,436 2,346\\n\\n10 % 3 %\\n\\n16 % $ 8 %\\n\\n42,293 2,205\\n\\n5 % 6 %\\n\\n(4)\\n\\nCorporate TOTAL NIKE, INC. REVENUES\\n\\n$\\n\\n27\\n\\n51,217 $\\n\\n(72) 46,710\\n\\n— 10 %\\n\\n— 16 % $\\n\\n40 44,538\\n\\n— 5 %\\n\\n(1) The percent change excluding currency changes represents a non-GAAP financial measure. For further information, see \"Use of Non-GAAP Financial Measures\".\\n\\n(2) For additional information on the transition of our NIKE Brand businesses within our CASA territory to a third-party distributor, see Note 18 — Acquisitions and Divestitures of the Notes to Consolidated\\n\\nFinancial Statements contained in Item 8 of this Annual Report.\\n\\n(3) Global Brand Divisions revenues include NIKE Brand licensing and other miscellaneous revenues that are not part of a geographic operating segment.\\n\\n(4) Corporate revenues primarily consist of foreign currency hedge gains and losses related to revenues generated by entities within the NIKE Brand geographic operating segments and Converse, but\\n\\nmanaged through our central foreign exchange risk management program.\\n\\nThe primary financial measure used by the Company to evaluate performance is Earnings Before Interest and Taxes (\"EBIT\"). As discussed in Note 15 — Operating Segments and Related Information in the accompanying Notes to the Consolidated Financial Statements, certain corporate costs are not included in EBIT.\\n\\nThe breakdown of EBIT is as follows:\\n\\n(Dollars in millions)\\n\\nFISCAL 2023\\n\\nFISCAL 2022\\n\\n% CHANGE\\n\\nFISCAL 2021\\n\\nNorth America Europe, Middle East & Africa Greater China\\n\\n$\\n\\n5,454 3,531 2,283\\n\\n$\\n\\n5,114 3,293 2,365\\n\\n7 % $ 7 % -3 %\\n\\n5,089 2,435 3,243\\n\\nAsia Pacific & Latin America Global Brand Divisions (1)'"
+      ]
+     },
+     "execution_count": 98,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "rds.similarity_search(\"What was nike's revenue last year?\")[0].page_content"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setup RAG\n",
+    "\n",
+    "Now that the vector db is populated let's initialize our RAG app."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 99,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import getpass\n",
+    "from langchain_openai import ChatOpenAI\n",
+    "\n",
+    "if \"OPENAI_API_KEY\" not in os.environ:\n",
+    "    os.environ[\"OPENAI_API_KEY\"] = getpass.getpass(\"OPENAI_API_KEY\")\n",
+    "\n",
+    "llm = ChatOpenAI(\n",
+    "    openai_api_key=os.environ[\"OPENAI_API_KEY\"],\n",
+    "    model=\"gpt-3.5-turbo-16k\",\n",
+    "    max_tokens=None\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 108,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langchain_core.prompts import ChatPromptTemplate\n",
+    "\n",
+    "system_prompt = \"\"\"\n",
+    "    Use the following pieces of context from financial 10k filings data to answer the user question at the end. \n",
+    "    If you don't know the answer, say that you don't know, don't try to make up an answer.\n",
+    "\n",
+    "    Context:\n",
+    "    ---------\n",
+    "    {context}\n",
+    "\"\"\"\n",
+    "\n",
+    "def format_docs(docs):\n",
+    "    return \"\\n\\n\".join(doc.page_content for doc in docs)\n",
+    "\n",
+    "prompt = ChatPromptTemplate.from_messages(\n",
+    "    [\n",
+    "        (\"system\", system_prompt),\n",
+    "        (\"human\", \"{input}\")\n",
+    "    ]\n",
+    ")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Test it out"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 109,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'input': \"What was nike's revenue last year?\",\n",
+       " 'context': [Document(metadata={'source': 'resources/nke-10k-2023.pdf'}, page_content='As discussed in Note 15 — Operating Segments and Related Information in the accompanying Notes to the Consolidated Financial Statements, our operating segments are evidence of the structure of the Company\\'s internal organization. The NIKE Brand segments are defined by geographic regions for operations participating in NIKE Brand sales activity.\\n\\nThe breakdown of Revenues is as follows:\\n\\n(Dollars in millions)\\n\\nFISCAL 2023 FISCAL 2022\\n\\n% CHANGE\\n\\n% CHANGE EXCLUDING CURRENCY (1) CHANGES FISCAL 2021\\n\\n% CHANGE\\n\\nNorth America Europe, Middle East & Africa Greater China\\n\\n$\\n\\n21,608 $ 13,418 7,248\\n\\n18,353 12,479 7,547\\n\\n18 % 8 % -4 %\\n\\n18 % $ 21 % 4 %\\n\\n17,179 11,456 8,290\\n\\n7 % 9 % -9 %\\n\\nAsia Pacific & Latin America Global Brand Divisions\\n\\n(3)\\n\\n(2)\\n\\n6,431 58\\n\\n5,955 102\\n\\n8 % -43 %\\n\\n17 % -43 %\\n\\n5,343 25\\n\\n11 % 308 %\\n\\nTOTAL NIKE BRAND Converse\\n\\n$\\n\\n48,763 $ 2,427\\n\\n44,436 2,346\\n\\n10 % 3 %\\n\\n16 % $ 8 %\\n\\n42,293 2,205\\n\\n5 % 6 %\\n\\n(4)\\n\\nCorporate TOTAL NIKE, INC. REVENUES\\n\\n$\\n\\n27\\n\\n51,217 $\\n\\n(72) 46,710\\n\\n— 10 %\\n\\n— 16 % $\\n\\n40 44,538\\n\\n— 5 %\\n\\n(1) The percent change excluding currency changes represents a non-GAAP financial measure. For further information, see \"Use of Non-GAAP Financial Measures\".\\n\\n(2) For additional information on the transition of our NIKE Brand businesses within our CASA territory to a third-party distributor, see Note 18 — Acquisitions and Divestitures of the Notes to Consolidated\\n\\nFinancial Statements contained in Item 8 of this Annual Report.\\n\\n(3) Global Brand Divisions revenues include NIKE Brand licensing and other miscellaneous revenues that are not part of a geographic operating segment.\\n\\n(4) Corporate revenues primarily consist of foreign currency hedge gains and losses related to revenues generated by entities within the NIKE Brand geographic operating segments and Converse, but\\n\\nmanaged through our central foreign exchange risk management program.\\n\\nThe primary financial measure used by the Company to evaluate performance is Earnings Before Interest and Taxes (\"EBIT\"). As discussed in Note 15 — Operating Segments and Related Information in the accompanying Notes to the Consolidated Financial Statements, certain corporate costs are not included in EBIT.\\n\\nThe breakdown of EBIT is as follows:\\n\\n(Dollars in millions)\\n\\nFISCAL 2023\\n\\nFISCAL 2022\\n\\n% CHANGE\\n\\nFISCAL 2021\\n\\nNorth America Europe, Middle East & Africa Greater China\\n\\n$\\n\\n5,454 3,531 2,283\\n\\n$\\n\\n5,114 3,293 2,365\\n\\n7 % $ 7 % -3 %\\n\\n5,089 2,435 3,243\\n\\nAsia Pacific & Latin America Global Brand Divisions (1)'),\n",
+       "  Document(metadata={'source': 'resources/nke-10k-2023.pdf'}, page_content=\"NIKE, INC. CONSOLIDATED STATEMENTS OF INCOME\\n\\n(In millions, except per share data)\\n\\nRevenues Cost of sales\\n\\nGross profit\\n\\nDemand creation expense Operating overhead expense\\n\\nTotal selling and administrative expense\\n\\nInterest expense (income), net\\n\\nOther (income) expense, net Income before income taxes\\n\\nIncome tax expense NET INCOME\\n\\nEarnings per common share:\\n\\nBasic Diluted\\n\\nWeighted average common shares outstanding:\\n\\nBasic Diluted\\n\\nThe accompanying Notes to the Consolidated Financial Statements are an integral part of this statement.\\n\\n$\\n\\n$\\n\\n$ $\\n\\nYEAR ENDED MAY 31,\\n\\n2023\\n\\n2022\\n\\n2021\\n\\n51,217 $ 28,925\\n\\n46,710 $ 25,231\\n\\n44,538 24,576\\n\\n22,292 4,060 12,317\\n\\n21,479 3,850 10,954\\n\\n19,962 3,114 9,911\\n\\n16,377 (6)\\n\\n14,804 205\\n\\n13,025 262\\n\\n(280) 6,201\\n\\n(181) 6,651\\n\\n14 6,661\\n\\n1,131 5,070 $\\n\\n605 6,046 $\\n\\n934 5,727\\n\\n3.27 $ 3.23 $\\n\\n3.83 $ 3.75 $\\n\\n3.64 3.56\\n\\n1,551.6 1,569.8\\n\\n1,578.8 1,610.8\\n\\n1,573.0 1,609.4\\n\\n2023 FORM 10-K 55\\n\\nTable of Contents\\n\\nNIKE, INC. CONSOLIDATED STATEMENTS OF COMPREHENSIVE INCOME\\n\\nYEAR ENDED MAY 31,\\n\\n(Dollars in millions)\\n\\n2023\\n\\n2022\\n\\nNet income Other comprehensive income (loss), net of tax:\\n\\n$\\n\\n5,070 $\\n\\n6,046 $\\n\\nChange in net foreign currency translation adjustment\\n\\n267\\n\\n(522)\\n\\nChange in net gains (losses) on cash flow hedges Change in net gains (losses) on other\\n\\n(348) (6)\\n\\n1,214 6\\n\\nTotal other comprehensive income (loss), net of tax TOTAL COMPREHENSIVE INCOME\\n\\n$\\n\\n(87) 4,983 $\\n\\n698 6,744 $\\n\\nThe accompanying Notes to the Consolidated Financial Statements are an integral part of this statement.\\n\\n2023 FORM 10-K 56\\n\\n2021\\n\\n5,727\\n\\n496\\n\\n(825) 5\\n\\n(324) 5,403\\n\\nTable of Contents\\n\\nNIKE, INC. CONSOLIDATED BALANCE SHEETS\\n\\n(In millions)\\n\\nASSETS\\n\\nCurrent assets:\\n\\nCash and equivalents Short-term investments\\n\\nAccounts receivable, net Inventories Prepaid expenses and other current assets\\n\\nTotal current assets\\n\\nProperty, plant and equipment, net\\n\\nOperating lease right-of-use assets, net Identifiable intangible assets, net Goodwill\\n\\nDeferred income taxes and other assets\\n\\nTOTAL ASSETS\\n\\nLIABILITIES AND SHAREHOLDERS' EQUITY Current liabilities:\\n\\nCurrent portion of long-term debt Notes payable Accounts payable\\n\\nCurrent portion of operating lease liabilities Accrued liabilities Income taxes payable\\n\\nTotal current liabilities\\n\\nLong-term debt\\n\\nOperating lease liabilities Deferred income taxes and other liabilities Commitments and contingencies (Note 16)\\n\\nRedeemable preferred stock Shareholders' equity: Common stock at stated value:\"),\n",
+       "  Document(metadata={'source': 'resources/nke-10k-2023.pdf'}, page_content=\"Tax (expense) benefit Gain (loss) net of tax\\n\\n5 (14)\\n\\n(9) 22\\n\\nTotal net gain (loss) reclassified for the period\\n\\n$\\n\\n463 $\\n\\n30\\n\\n2023 FORM 10-K 82\\n\\nTable of Contents\\n\\nNOTE 14 — REVENUES\\n\\nDISAGGREGATION OF REVENUES The following tables present the Company's Revenues disaggregated by reportable operating segment, major product line and distribution channel:\\n\\n(Dollars in millions)\\n\\nNORTH AMERICA\\n\\nEUROPE, MIDDLE EAST & AFRICA\\n\\nGREATER CHINA\\n\\nYEAR ENDED MAY 31, 2023 ASIA PACIFIC & LATIN (1)\\n\\nGLOBAL BRAND DIVISIONS\\n\\nTOTAL NIKE\\n\\nAMERICA\\n\\nBRAND CONVERSE CORPORATE\\n\\nTOTAL NIKE, INC.\\n\\nRevenues by: Footwear\\n\\n$\\n\\n14,897 $\\n\\n8,260 $\\n\\n5,435 $\\n\\n4,543 $\\n\\n— $\\n\\n33,135 $\\n\\n2,155 $\\n\\n— $\\n\\n35,290\\n\\nApparel Equipment Other\\n\\n5,947 764 —\\n\\n4,566 592 —\\n\\n1,666 147 —\\n\\n1,664 224 —\\n\\n— — 58\\n\\n13,843 1,727 58\\n\\n90 28 154\\n\\n— — 27\\n\\n13,933 1,755 239\\n\\nTOTAL REVENUES\\n\\n$\\n\\n21,608 $\\n\\n13,418 $\\n\\n7,248 $\\n\\n6,431 $\\n\\n58 $\\n\\n48,763 $\\n\\n2,427 $\\n\\n27 $\\n\\n51,217\\n\\nRevenues by:\\n\\nSales to Wholesale Customers Sales through Direct to Consumer\\n\\n$\\n\\n11,273 $ 10,335\\n\\n8,522 $ 4,896\\n\\n3,866 $ 3,382\\n\\n3,736 $ 2,695\\n\\n— $ —\\n\\n27,397 $ 21,308\\n\\n1,299 $ 974\\n\\n— $ —\\n\\n28,696 22,282\\n\\nOther\\n\\nTOTAL REVENUES\\n\\n$\\n\\n—\\n\\n21,608 $\\n\\n—\\n\\n13,418 $\\n\\n— 7,248 $\\n\\n— 6,431 $\\n\\n58 58 $\\n\\n58\\n\\n48,763 $\\n\\n154 2,427 $\\n\\n27 27 $\\n\\n239 51,217\\n\\n(1) Refer to Note 18 — Acquisitions and Divestitures for additional information on the transition of the Company's NIKE Brand businesses in its CASA territory to third-party distributors.\\n\\nYEAR ENDED MAY 31, 2022\\n\\n(Dollars in millions)\\n\\nNORTH AMERICA\\n\\nEUROPE, MIDDLE EAST & AFRICA\\n\\nGREATER CHINA\\n\\nASIA PACIFIC & LATIN AMERICA\\n\\nGLOBAL BRAND DIVISIONS\\n\\nTOTAL NIKE\\n\\nBRAND CONVERSE CORPORATE\\n\\nTOTAL NIKE, INC.\\n\\nRevenues by: Footwear Apparel\\n\\n$\\n\\n12,228 $ 5,492\\n\\n7,388 $ 4,527\\n\\n5,416 $ 1,938\\n\\n4,111 $ 1,610\\n\\n— $ —\\n\\n29,143 $ 13,567\\n\\n2,094 $ 103\\n\\n— $ —\\n\\n31,237 13,670\\n\\nEquipment Other\\n\\n633 —\\n\\n564 —\\n\\n193 —\\n\\n234 —\\n\\n— 102\\n\\n1,624 102\\n\\n26 123\\n\\n— (72)\\n\\n1,650 153\\n\\nTOTAL REVENUES Revenues by:\\n\\n$\\n\\n18,353 $\\n\\n12,479 $\\n\\n7,547 $\\n\\n5,955 $\\n\\n102 $\\n\\n44,436 $\\n\\n2,346 $\\n\\n(72) $\\n\\n46,710\\n\\nSales to Wholesale Customers Sales through Direct to Consumer Other\\n\\n$\\n\\n9,621 $ 8,732 —\\n\\n8,377 $ 4,102 —\\n\\n4,081 $ 3,466 —\\n\\n3,529 $ 2,426 —\\n\\n— $ — 102\\n\\n25,608 $ 18,726 102\\n\\n1,292 $ 931 123\\n\\n— $ — (72)\\n\\n26,900 19,657 153\\n\\nTOTAL REVENUES\\n\\n$\\n\\n18,353 $\\n\\n12,479 $\\n\\n7,547 $\\n\\n5,955 $\\n\\n102 $\\n\\n44,436 $\\n\\n2,346 $\\n\\n(72) $\\n\\n46,710\\n\\n2023 FORM 10-K 83\\n\\nTable of Contents\\n\\nYEAR ENDED MAY 31, 2021\\n\\n(Dollars in millions)\\n\\nNORTH AMERICA\\n\\nEUROPE, MIDDLE EAST & AFRICA\\n\\nGREATER CHINA\"),\n",
+       "  Document(metadata={'source': 'resources/nke-10k-2023.pdf'}, page_content=\"ASIA PACIFIC & LATIN AMERICA\\n\\n(1)\\n\\nGLOBAL BRAND DIVISIONS\\n\\nTOTAL NIKE BRAND\\n\\nCONVERSE CORPORATE\\n\\nTOTAL NIKE, INC.\\n\\nRevenues by:\\n\\nFootwear Apparel Equipment\\n\\n$\\n\\n11,644 $ 5,028 507\\n\\n6,970 $ 3,996 490\\n\\n5,748 $ 2,347 195\\n\\n3,659 $ 1,494 190\\n\\n— $ — —\\n\\n28,021 $ 12,865 1,382\\n\\n1,986 $ 104 29\\n\\n— $ — —\\n\\n30,007 12,969 1,411\\n\\nOther\\n\\nTOTAL REVENUES\\n\\n$\\n\\n—\\n\\n17,179 $\\n\\n—\\n\\n11,456 $\\n\\n— 8,290 $\\n\\n— 5,343 $\\n\\n25 25 $\\n\\n25\\n\\n42,293 $\\n\\n86 2,205 $\\n\\n40 40 $\\n\\n151 44,538\\n\\nRevenues by:\\n\\nSales to Wholesale Customers $\\n\\n10,186 $\\n\\n7,812 $\\n\\n4,513 $\\n\\n3,387 $\\n\\n— $\\n\\n25,898 $\\n\\n1,353 $\\n\\n— $\\n\\n27,251\\n\\nSales through Direct to Consumer Other\\n\\n6,993 —\\n\\n3,644 —\\n\\n3,777 —\\n\\n1,956 —\\n\\n— 25\\n\\n16,370 25\\n\\n766 86\\n\\n— 40\\n\\n17,136 151\\n\\nTOTAL REVENUES\\n\\n$\\n\\n17,179 $\\n\\n11,456 $\\n\\n8,290 $\\n\\n5,343 $\\n\\n25 $\\n\\n42,293 $\\n\\n2,205 $\\n\\n40 $\\n\\n44,538\\n\\n(1) Refer to Note 18 — Acquisitions and Divestitures for additional information on the transition of the Company's NIKE Brand business in Brazil to a third-party distributor.\\n\\nFor the fiscal years ended May 31, 2023, 2022 and 2021, Global Brand Divisions revenues include NIKE Brand licensing and other miscellaneous revenues that are not part of a geographic operating segment. Converse Other revenues were primarily attributable to licensing businesses. Corporate revenues primarily consisted of foreign currency hedge gains and losses related to revenues generated by entities within the NIKE Brand geographic operating segments and Converse but managed through the Company's central foreign exchange risk management program.\\n\\nAs of May 31, 2023 and 2022, the Company did not have any contract assets and had an immaterial amount of contract liabilities recorded in Accrued liabilities on the Consolidated Balance Sheets.\\n\\nSALES-RELATED RESERVES\\n\\nAs of May 31, 2023 and 2022, the Company's sales-related reserve balance, which includes returns, post-invoice sales discounts and miscellaneous claims, was $994 million and $1,015 million, respectively, recorded in Accrued liabilities on the Consolidated Balance Sheets. The estimated cost of inventory for expected product returns was $226 million and $194 million as of May 31, 2023 and 2022, respectively, and was recorded in Prepaid expenses and other current assets on the Consolidated Balance Sheets.\\n\\nNOTE 15 — OPERATING SEGMENTS AND RELATED INFORMATION\")],\n",
+       " 'answer': \"Nike's revenue last year was $51,217 million.\"}"
+      ]
+     },
+     "execution_count": 109,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from langchain.chains import create_retrieval_chain\n",
+    "from langchain.chains.combine_documents import create_stuff_documents_chain\n",
+    "\n",
+    "question_answer_chain = create_stuff_documents_chain(llm, prompt)\n",
+    "rag_chain = create_retrieval_chain(rds.as_retriever(), question_answer_chain)\n",
+    "\n",
+    "rag_chain.invoke({\"input\": \"What was nike's revenue last year?\"})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## (Optional) Creating a test set\n",
+    "\n",
+    "Now that our setup is complete and we have our RAG app to evaluate we need a test set to evaluate against. The ragas library provides a helpful class for generating a synthetic test set given our data as input that we will use here. The output of this generation is a set of `questions`, `contexts`, and `ground_truth`. \n",
+    "\n",
+    "The questions are generated by an LLM based on slices of context from the provided doc and the ground_truth is determined via a critic LLM. Note there is nothing special about this data itself and you can provide your own `questions` and `ground_truth` for evaluation purposes. When starting a project however, there is often a lack of quality human labeled data to be used for evaluation and a synthetic dataset is a valuable place to start if pre live user/process data (which should be incorporated as an ultimate goal).\n",
+    "\n",
+    "For more detail see [the docs](https://docs.ragas.io/en/stable/concepts/testset_generation.html)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# NBVAL_SKIP\n",
+    "# source: https://docs.ragas.io/en/latest/getstarted/testset_generation.html\n",
+    "from ragas.testset.generator import TestsetGenerator\n",
+    "from ragas.testset.evolutions import simple, reasoning, multi_context\n",
+    "from ragas.run_config import RunConfig\n",
+    "from langchain_openai import ChatOpenAI, OpenAIEmbeddings\n",
+    "\n",
+    "run_config = RunConfig(\n",
+    "    timeout=200,\n",
+    "    max_wait=160,\n",
+    "    max_retries=3,\n",
+    ")\n",
+    "\n",
+    "# generator with openai models\n",
+    "generator_llm = ChatOpenAI(model=\"gpt-3.5-turbo-16k\")\n",
+    "critic_llm = ChatOpenAI(model=\"gpt-4o-mini\")\n",
+    "embeddings = OpenAIEmbeddings()\n",
+    "\n",
+    "generator = TestsetGenerator.from_langchain(\n",
+    "    generator_llm,\n",
+    "    critic_llm,\n",
+    "    embeddings,\n",
+    "    run_config=run_config,\n",
+    ")\n",
+    "\n",
+    "testset = generator.generate_with_langchain_docs(\n",
+    "    chunks,\n",
+    "    test_size=10,\n",
+    "    distributions={\n",
+    "        simple: 0.5,\n",
+    "        reasoning: 0.25,\n",
+    "        multi_context: 0.25\n",
+    "    },\n",
+    "    run_config=run_config\n",
+    ")\n",
+    "\n",
+    "# save to csv since this can be a time consuming process\n",
+    "testset.to_pandas().to_csv(\"resources/new_testset.csv\", index=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Evaluation helper functions\n",
+    "\n",
+    "The following code takes a RetrievalQA chain, testset dataframe, and the metrics to be evaluated and returns a dataframe including the metrics calculated."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 110,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "from datasets import Dataset\n",
+    "from ragas import evaluate\n",
+    "from ragas.run_config import RunConfig\n",
+    "\n",
+    "def parse_contexts(source_docs):\n",
+    "    return [doc.page_content for doc in source_docs]\n",
+    "\n",
+    "def create_evaluation_dataset(chain, testset):\n",
+    "    res_set = {\n",
+    "        \"question\": [],\n",
+    "        \"answer\": [],\n",
+    "        \"contexts\": [],\n",
+    "        \"ground_truth\": []\n",
+    "    }\n",
+    "\n",
+    "    for _, row in testset.iterrows():\n",
+    "        result = chain.invoke({\"input\": row[\"question\"]})\n",
+    "\n",
+    "        res_set[\"question\"].append(row[\"question\"])\n",
+    "        res_set[\"answer\"].append(result[\"answer\"])\n",
+    "\n",
+    "        contexts = parse_contexts(result[\"context\"])\n",
+    "\n",
+    "        if not len(contexts):\n",
+    "            print(f\"no contexts found for question: {row['question']}\")\n",
+    "        res_set[\"contexts\"].append(contexts)\n",
+    "        res_set[\"ground_truth\"].append(str(row[\"ground_truth\"]))\n",
+    "\n",
+    "    return Dataset.from_dict(res_set)\n",
+    "\n",
+    "def evaluate_dataset(eval_dataset, metrics, llm, embeddings):\n",
+    "\n",
+    "    run_config = RunConfig(max_retries=1) # see ragas docs for more run_config options\n",
+    "\n",
+    "    eval_result = evaluate(\n",
+    "        eval_dataset,\n",
+    "        metrics=metrics,\n",
+    "        run_config=run_config,\n",
+    "        llm=llm,\n",
+    "        embeddings=embeddings\n",
+    "    )\n",
+    "\n",
+    "    eval_df = eval_result.to_pandas()\n",
+    "    return eval_df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Create the evaluation data\n",
+    "\n",
+    "Input: chain to be evaluated and a pregenerated test set<br>\n",
+    "Output: dataset formatted for use with ragas evaluation function"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 111,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>question</th>\n",
+       "      <th>contexts</th>\n",
+       "      <th>ground_truth</th>\n",
+       "      <th>evolution_type</th>\n",
+       "      <th>metadata</th>\n",
+       "      <th>episode_done</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>What are short-term investments and how are th...</td>\n",
+       "      <td>[\"CASH AND EQUIVALENTS Cash and equivalents re...</td>\n",
+       "      <td>Short-term investments are highly liquid inves...</td>\n",
+       "      <td>simple</td>\n",
+       "      <td>[{'source': 'resources/nke-10k-2023.pdf'}]</td>\n",
+       "      <td>True</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>What are some of the risks and uncertainties a...</td>\n",
+       "      <td>['Our NIKE Direct operations, including our re...</td>\n",
+       "      <td>Many factors unique to retail operations, some...</td>\n",
+       "      <td>simple</td>\n",
+       "      <td>[{'source': 'resources/nke-10k-2023.pdf'}]</td>\n",
+       "      <td>True</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>What is NIKE's policy regarding securities ana...</td>\n",
+       "      <td>[\"Investors should also be aware that while NI...</td>\n",
+       "      <td>NIKE's policy is to not disclose any material ...</td>\n",
+       "      <td>simple</td>\n",
+       "      <td>[{'source': 'resources/nke-10k-2023.pdf'}]</td>\n",
+       "      <td>True</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>What are the revenues for the Footwear and App...</td>\n",
+       "      <td>['(Dollars in millions, except per share data)...</td>\n",
+       "      <td>The revenues for the Footwear and Apparel cate...</td>\n",
+       "      <td>simple</td>\n",
+       "      <td>[{'source': 'resources/nke-10k-2023.pdf'}]</td>\n",
+       "      <td>True</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>How do master netting arrangements impact the ...</td>\n",
+       "      <td>[\"The Company records the assets and liabiliti...</td>\n",
+       "      <td>The Company records the assets and liabilities...</td>\n",
+       "      <td>simple</td>\n",
+       "      <td>[{'source': 'resources/nke-10k-2023.pdf'}]</td>\n",
+       "      <td>True</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                            question  \\\n",
+       "0  What are short-term investments and how are th...   \n",
+       "1  What are some of the risks and uncertainties a...   \n",
+       "2  What is NIKE's policy regarding securities ana...   \n",
+       "3  What are the revenues for the Footwear and App...   \n",
+       "4  How do master netting arrangements impact the ...   \n",
+       "\n",
+       "                                            contexts  \\\n",
+       "0  [\"CASH AND EQUIVALENTS Cash and equivalents re...   \n",
+       "1  ['Our NIKE Direct operations, including our re...   \n",
+       "2  [\"Investors should also be aware that while NI...   \n",
+       "3  ['(Dollars in millions, except per share data)...   \n",
+       "4  [\"The Company records the assets and liabiliti...   \n",
+       "\n",
+       "                                        ground_truth evolution_type  \\\n",
+       "0  Short-term investments are highly liquid inves...         simple   \n",
+       "1  Many factors unique to retail operations, some...         simple   \n",
+       "2  NIKE's policy is to not disclose any material ...         simple   \n",
+       "3  The revenues for the Footwear and Apparel cate...         simple   \n",
+       "4  The Company records the assets and liabilities...         simple   \n",
+       "\n",
+       "                                     metadata  episode_done  \n",
+       "0  [{'source': 'resources/nke-10k-2023.pdf'}]          True  \n",
+       "1  [{'source': 'resources/nke-10k-2023.pdf'}]          True  \n",
+       "2  [{'source': 'resources/nke-10k-2023.pdf'}]          True  \n",
+       "3  [{'source': 'resources/nke-10k-2023.pdf'}]          True  \n",
+       "4  [{'source': 'resources/nke-10k-2023.pdf'}]          True  "
+      ]
+     },
+     "execution_count": 111,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "testset_df = pd.read_csv(\"resources/testset_15.csv\")\n",
+    "testset_df.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 112,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "eval_dataset = create_evaluation_dataset(rag_chain, testset_df)\n",
+    "eval_dataset.to_pandas().shape"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Evaluate generation metrics\n",
+    "Generation metrics quantify how well the RAG app did creating answers to the provided questions (i.e. the G in **R**etrival **A**ugments **G**eneration). We will calculate the generation metrics **faithfulness** and **answer relevancy** for this example.\n",
+    "\n",
+    "The ragas libary conveniently abstracts the calculation of these metrics so we don't have to write redundant code but please review the following definitions in order to build intuition around what these metrics actually measure.\n",
+    "\n",
+    "Note: the following examples are paraphrased from the [ragas docs](https://docs.ragas.io/en/stable/concepts/metrics/index.html)\n",
+    "\n",
+    "------\n",
+    "\n",
+    "### Faithfulness\n",
+    "\n",
+    "An answer to a question can be said to be \"faithful\" if the **claims** that are made in the answer **can be inferred** from the **context**.\n",
+    "\n",
+    "#### Mathematically:\n",
+    "\n",
+    "$$\n",
+    "Faithfullness\\ score = \\frac{Number\\ of\\ claims\\ in\\ the\\ generated\\ answer\\ that\\ can\\ be\\ inferred\\ from\\ the\\ given\\ context}{Total\\ number\\ of\\ claim\\ in\\ the\\ generated\\ answer}\n",
+    "$$\n",
+    "\n",
+    "#### Example process:\n",
+    "\n",
+    "> Question: Where and when was Einstein born?\n",
+    "> \n",
+    "> Context: Albert Einstein (born 14 March 1879) was a German-born theoretical physicist, widely held to be one of the greatest and most influential scientists of all time\n",
+    ">\n",
+    "> answer: Einstein was born in Germany on 20th March 1879.\n",
+    "\n",
+    "Step 1: Use LLM to break generated answer into individual statements.\n",
+    "- “Einstein was born in Germany.”\n",
+    "- “Einstein was born on 20th March 1879.”\n",
+    "\n",
+    "Step 2: For each statement use LLM to verify if it can be inferred from the context.\n",
+    "- “Einstein was born in Germany.” => yes. \n",
+    "- “Einstein was born on 20th March 1879.” => no.\n",
+    "\n",
+    "Step 3: plug into formula\n",
+    "\n",
+    "Number of claims inferred from context = 1\n",
+    "Total number of claims = 2\n",
+    "Faithfulness = 1/2\n",
+    "\n",
+    "### Answer Relevance\n",
+    "\n",
+    "An answer can be said to be relevant if it directly addresses the question (intuitively).\n",
+    "\n",
+    "#### Example process:\n",
+    "\n",
+    "1. Use an LLM to generate \"hypothetical\" questions to a given answer with the following prompt:\n",
+    "\n",
+    "    > Generate a question for the given answer.\n",
+    "    > answer: [answer]\n",
+    "\n",
+    "2. Embed the generated \"hypothetical\" questions as vectors.\n",
+    "3. Calculate the cosine similarity of the hypothetical questions and the original question, sum those similarities, and divide by n.\n",
+    "\n",
+    "With data:\n",
+    "\n",
+    "> Question: Where is France and what is it’s capital?\n",
+    "> \n",
+    "> answer: France is in western Europe.\n",
+    "\n",
+    "Step 1 - use LLM to create 'n' variants of question from the generated answer.\n",
+    "\n",
+    "- “In which part of Europe is France located?”\n",
+    "- “What is the geographical location of France within Europe?”\n",
+    "- “Can you identify the region of Europe where France is situated?”\n",
+    "\n",
+    "Step 2 - Calculate the mean cosine similarity between the generated questions and the actual question.\n",
+    "\n",
+    "## Now let's implement using our helper functions\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 114,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "dd9cabb4b0c448b08cad96d2ef3391a2",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Evaluating:   0%|          | 0/15 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "from ragas.metrics import faithfulness, answer_relevancy\n",
+    "\n",
+    "faithfulness_metrics = evaluate_dataset(eval_dataset, [faithfulness], llm, embeddings)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 115,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "72432636d3a44519b57329c66ded9c8c",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Evaluating:   0%|          | 0/15 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "answer_relevancy_metrics = evaluate_dataset(eval_dataset, [answer_relevancy], llm, embeddings)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 116,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>faithfulness</th>\n",
+       "      <th>answer_relevancy</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>count</th>\n",
+       "      <td>15.000000</td>\n",
+       "      <td>15.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>mean</th>\n",
+       "      <td>0.781229</td>\n",
+       "      <td>0.938581</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>std</th>\n",
+       "      <td>0.362666</td>\n",
+       "      <td>0.085342</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>min</th>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.736997</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>25%</th>\n",
+       "      <td>0.652778</td>\n",
+       "      <td>0.926596</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>50%</th>\n",
+       "      <td>1.000000</td>\n",
+       "      <td>0.975230</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>75%</th>\n",
+       "      <td>1.000000</td>\n",
+       "      <td>0.994168</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>max</th>\n",
+       "      <td>1.000000</td>\n",
+       "      <td>1.000000</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "       faithfulness  answer_relevancy\n",
+       "count     15.000000         15.000000\n",
+       "mean       0.781229          0.938581\n",
+       "std        0.362666          0.085342\n",
+       "min        0.000000          0.736997\n",
+       "25%        0.652778          0.926596\n",
+       "50%        1.000000          0.975230\n",
+       "75%        1.000000          0.994168\n",
+       "max        1.000000          1.000000"
+      ]
+     },
+     "execution_count": 116,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "gen_metrics_default = faithfulness_metrics\n",
+    "gen_metrics_default[\"answer_relevancy\"] = answer_relevancy_metrics[\"answer_relevancy\"]\n",
+    "\n",
+    "gen_metrics_default.describe()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Evaluating retrieval metrics\n",
+    "\n",
+    "Retrieval metrics quantify how well the system performed at fetching the best possible context for generation. Like before please review the definitions below to understand what happens under-the-hood when we execute the evaluation code. \n",
+    "\n",
+    "-----\n",
+    "\n",
+    "### Context Relevance\n",
+    "\n",
+    "\"The context is considered relevant to the extent that it exclusively contains information that is needed to answer the question.\"\n",
+    "\n",
+    "#### Example process:\n",
+    "\n",
+    "1. Use the following LLM prompt to extract a subset of sentences necessary to answer the question. The context is defined as the formatted search result from the vector database.\n",
+    "\n",
+    "    > Please extract relevant sentences from\n",
+    "    > the provided context that can potentially\n",
+    "    > help answer the following `{question}`. If no\n",
+    "    > relevant sentences are found, or if you\n",
+    "    > believe the question cannot be answered\n",
+    "    > from the given context, return the phrase\n",
+    "    > \"Insufficient Information\". While extracting candidate sentences you’re not allowed to make any changes to sentences\n",
+    "    > from given `{context}`.\n",
+    "\n",
+    "2. Compute the context relevance score = (number of extracted sentences) / (total number of sentences in context)\n",
+    "\n",
+    "Moving from the initial paper to the active evaluation library ragas there are a few more insightful metrics to evaluate. From the library [source](https://docs.ragas.io/en/stable/concepts/metrics/index.html) let's introduce `context precision` and `context recall`. \n",
+    "\n",
+    "### Context recall\n",
+    "Context can be said to have high recall if retrieved context aligns with the ground truth answer.\n",
+    "\n",
+    "#### Mathematically:\n",
+    "\n",
+    "$$\n",
+    "Context\\ recall = \\frac{Ground\\ Truth\\ sentences\\ that\\ can\\ be\\ attributed\\ to\\ context}{Total\\ number\\ of\\ sentences\\ in\\ the\\ ground\\ truth}\n",
+    "$$\n",
+    "\n",
+    "#### Example process:\n",
+    "\n",
+    "Data:\n",
+    "> question: Where is France and what is it’s capital?\n",
+    "> ground truth answer: France is in Western Europe and its capital is Paris.\n",
+    "> context: France, in Western Europe, encompasses medieval cities, alpine villages and Mediterranean beaches. The country is also renowned for its wines and sophisticated cuisine. Lascaux’s ancient cave drawings, Lyon’s Roman theater and the vast Palace of Versailles attest to its rich history.\n",
+    ">\n",
+    "> Note: ground truth answer can be created by critic LLM or with own human labeled data set.\n",
+    "\n",
+    "Step 1 - use an LLM to break the ground truth down into individual statements:\n",
+    "- `France is in Western Europe`\n",
+    "- `Its capital is Paris`\n",
+    "\n",
+    "Step 2 - for each ground truth statement, use an LLM to determine if it can be attributed from the context.\n",
+    "- `France is in Western Europe` => yes\n",
+    "- `Its capital is Paris` => no\n",
+    "\n",
+    "\n",
+    "Step 3 - plug in to formula\n",
+    "\n",
+    "context recall = (1 + 0) / 2 = 0.5\n",
+    "\n",
+    "### Context precision\n",
+    "\n",
+    "This metrics relates to how chunks are ranked in a response. Ideally the most relevant chunks are at the top.\n",
+    "\n",
+    "#### Mathematically:\n",
+    "\n",
+    "$$\n",
+    "Context\\ Precision@k = \\frac{precision@k}{total\\ number\\ relevant\\ items\\ in\\ the\\ top\\ k\\ results}\n",
+    "$$\n",
+    "\n",
+    "$$\n",
+    "Precision@k = \\frac{true\\ positive@k}{true\\ positives@k + false\\ positives@k}\n",
+    "$$\n",
+    "\n",
+    "#### Example process:\n",
+    "\n",
+    "Data:\n",
+    "> Question: Where is France and what is it’s capital?\n",
+    "> \n",
+    "> Ground truth: France is in Western Europe and its capital is Paris.\n",
+    "> \n",
+    "> Context: [ “The country is also renowned for its wines and sophisticated cuisine. Lascaux’s ancient cave drawings, Lyon’s Roman theater and”, “France, in Western Europe, encompasses medieval cities, alpine villages and Mediterranean beaches. Paris, its capital, is famed for its fashion houses, classical art museums including the Louvre and monuments like the Eiffel Tower”]\n",
+    "\n",
+    "Step 1 - for each chunk use the LLM to check if it's relevant or not to the ground truth answer.\n",
+    "\n",
+    "Step 2 - for each chunk in the context calculate the precision defined as: ``\n",
+    "- `“The country is also renowned for its wines and sophisticated cuisine. Lascaux’s ancient cave drawings, Lyon’s Roman theater and”` => precision = 0/1 or 0.\n",
+    "- `“France, in Western Europe, encompasses medieval cities, alpine villages and Mediterranean beaches. Paris, its capital, is famed for its fashion houses, classical art museums including the Louvre and monuments like the Eiffel Tower”` => the precision would be (1) / (1 true positive + 1 false positive) = 0.5. \n",
+    "\n",
+    "\n",
+    "Step 3 - calculate the overall context precision = (0 + 0.5) / 1 = 0.5"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 117,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "c076c3dc42cf49cf8d768dec225727d5",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Evaluating:   0%|          | 0/15 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "from ragas.metrics import context_recall, context_precision\n",
+    "\n",
+    "context_recall_metrics = evaluate_dataset(eval_dataset, [context_recall], llm, embeddings)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 118,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "1055dffc473846a3b5f43895485be9a0",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Evaluating:   0%|          | 0/15 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "context_precision_metrics = evaluate_dataset(eval_dataset, [context_precision], llm, embeddings)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 119,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>context_recall</th>\n",
+       "      <th>context_precision</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>count</th>\n",
+       "      <td>15.000000</td>\n",
+       "      <td>15.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>mean</th>\n",
+       "      <td>0.966667</td>\n",
+       "      <td>0.925926</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>std</th>\n",
+       "      <td>0.129099</td>\n",
+       "      <td>0.145352</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>min</th>\n",
+       "      <td>0.500000</td>\n",
+       "      <td>0.500000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>25%</th>\n",
+       "      <td>1.000000</td>\n",
+       "      <td>0.916667</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>50%</th>\n",
+       "      <td>1.000000</td>\n",
+       "      <td>1.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>75%</th>\n",
+       "      <td>1.000000</td>\n",
+       "      <td>1.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>max</th>\n",
+       "      <td>1.000000</td>\n",
+       "      <td>1.000000</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "       context_recall  context_precision\n",
+       "count       15.000000          15.000000\n",
+       "mean         0.966667           0.925926\n",
+       "std          0.129099           0.145352\n",
+       "min          0.500000           0.500000\n",
+       "25%          1.000000           0.916667\n",
+       "50%          1.000000           1.000000\n",
+       "75%          1.000000           1.000000\n",
+       "max          1.000000           1.000000"
+      ]
+     },
+     "execution_count": 119,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ret_metrics_default = context_recall_metrics\n",
+    "ret_metrics_default[\"context_precision\"] = context_precision_metrics[\"context_precision\"]\n",
+    "\n",
+    "ret_metrics_default.describe()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 120,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "metrics = ret_metrics_default\n",
+    "metrics[\"faithfulness\"] = gen_metrics_default[\"faithfulness\"]\n",
+    "metrics[\"answer_relevancy\"] = gen_metrics_default[\"answer_relevancy\"]\n",
+    "\n",
+    "metrics.to_csv(f\"resources/metrics_{CHUNK_SIZE}_{CHUNK_OVERLAP}.csv\", index=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# All together"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 121,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>context_recall</th>\n",
+       "      <th>context_precision</th>\n",
+       "      <th>faithfulness</th>\n",
+       "      <th>answer_relevancy</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>count</th>\n",
+       "      <td>15.000000</td>\n",
+       "      <td>15.000000</td>\n",
+       "      <td>15.000000</td>\n",
+       "      <td>15.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>mean</th>\n",
+       "      <td>0.966667</td>\n",
+       "      <td>0.925926</td>\n",
+       "      <td>0.781229</td>\n",
+       "      <td>0.938581</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>std</th>\n",
+       "      <td>0.129099</td>\n",
+       "      <td>0.145352</td>\n",
+       "      <td>0.362666</td>\n",
+       "      <td>0.085342</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>min</th>\n",
+       "      <td>0.500000</td>\n",
+       "      <td>0.500000</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.736997</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>25%</th>\n",
+       "      <td>1.000000</td>\n",
+       "      <td>0.916667</td>\n",
+       "      <td>0.652778</td>\n",
+       "      <td>0.926596</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>50%</th>\n",
+       "      <td>1.000000</td>\n",
+       "      <td>1.000000</td>\n",
+       "      <td>1.000000</td>\n",
+       "      <td>0.975230</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>75%</th>\n",
+       "      <td>1.000000</td>\n",
+       "      <td>1.000000</td>\n",
+       "      <td>1.000000</td>\n",
+       "      <td>0.994168</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>max</th>\n",
+       "      <td>1.000000</td>\n",
+       "      <td>1.000000</td>\n",
+       "      <td>1.000000</td>\n",
+       "      <td>1.000000</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "       context_recall  context_precision  faithfulness  answer_relevancy\n",
+       "count       15.000000          15.000000     15.000000         15.000000\n",
+       "mean         0.966667           0.925926      0.781229          0.938581\n",
+       "std          0.129099           0.145352      0.362666          0.085342\n",
+       "min          0.500000           0.500000      0.000000          0.736997\n",
+       "25%          1.000000           0.916667      0.652778          0.926596\n",
+       "50%          1.000000           1.000000      1.000000          0.975230\n",
+       "75%          1.000000           1.000000      1.000000          0.994168\n",
+       "max          1.000000           1.000000      1.000000          1.000000"
+      ]
+     },
+     "execution_count": 121,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "metrics.describe()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Analysis\n",
+    "Overall our RAG app showed pretty good performance. All values indicated above 0.6, which from anecdotal experience, is a reasonable lower-bound for performance however obviously higher values are more ideal. It is worth noting that generation metrics can be a bit more hazy in terms of ideal ranges since the LLM evaluation cannot yet capture the way a response feels to a user. For these metrics it's important to make sure they are not severely low however blind optimization to the top can result in a very uncreative chat experience which may or may not be ideal for the intended use case.\n",
+    "\n",
+    "## Review\n",
+    "\n",
+    "- we initialized our RAG app with data from a 10k document\n",
+    "- generated a testset to evaluate \n",
+    "- calculated both retrieval and generation metrics\n",
+    "\n",
+    "## Next steps\n",
+    "\n",
+    "Now that we know how to measure our system we can quickly and easily experiment with different techniques with a baseline in place to improve our systems.\n",
+    "\n",
+    "## Cleanup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 122,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from redisvl.index import SearchIndex\n",
+    "\n",
+    "idx = SearchIndex.from_existing(\n",
+    "    index_name,\n",
+    "    redis_url=REDIS_URL\n",
+    ")\n",
+    "\n",
+    "idx.delete()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
 }

--- a/python-recipes/RAG/07_user_role_based_rag.ipynb
+++ b/python-recipes/RAG/07_user_role_based_rag.ipynb
@@ -1,1788 +1,1786 @@
 {
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "id": "XwR-PYCFu0Nd",
-      "metadata": {
-        "id": "XwR-PYCFu0Nd"
-      },
-      "source": [
-        "# Building a Role-Based RAG Pipeline with Redis\n",
-        "\n",
-        "This notebook demonstrates a simplified setup for a **Role-Based Retrieval Augmented Generation (RAG)** pipeline, where:\n",
-        "\n",
-        "1. Each **User** has one or more **roles**.\n",
-        "2. Knowledge base **Documents** in Redis are tagged with the official roles that can access them (`allowed_roles`).\n",
-        "3. A unified **query flow** ensures a user only sees documents that match at least one of their roles.\n",
-        "\n",
-        "![Role Based RAG](https://raw.githubusercontent.com/redis-developer/redis-ai-resources/main/assets/role-based-rag.png)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "58823e66",
-      "metadata": {
-        "id": "58823e66"
-      },
-      "source": [
-        "\n",
-        "## Let's Begin!\n",
-        "<a href=\"https://colab.research.google.com/github/redis-developer/redis-ai-resources/blob/main/python-recipes/RAG/07_user_role_based_rag.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 1,
-      "id": "4e0aa177",
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "4e0aa177",
-        "outputId": "0ba61596-b3e4-442f-cd9c-8b480f1c52d1"
-      },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "\u001b[?25l   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/99.3 kB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m\r\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m99.3/99.3 kB\u001b[0m \u001b[31m7.1 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-            "\u001b[?25h\u001b[?25l   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/2.5 MB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m\r\u001b[2K   \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m2.5/2.5 MB\u001b[0m \u001b[31m91.5 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m2.5/2.5 MB\u001b[0m \u001b[31m55.0 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-            "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m298.0/298.0 kB\u001b[0m \u001b[31m25.9 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-            "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m1.0/1.0 MB\u001b[0m \u001b[31m60.2 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-            "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m412.2/412.2 kB\u001b[0m \u001b[31m34.2 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-            "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m261.5/261.5 kB\u001b[0m \u001b[31m19.1 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-            "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m46.0/46.0 kB\u001b[0m \u001b[31m4.3 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-            "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m86.8/86.8 kB\u001b[0m \u001b[31m8.6 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-            "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m50.8/50.8 kB\u001b[0m \u001b[31m4.6 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-            "\u001b[?25h"
-          ]
-        }
-      ],
-      "source": [
-        "%pip install -q \"redisvl>=0.6.0\" openai langchain-community pypdf"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "fXsGCsLQu0Ne",
-      "metadata": {
-        "id": "fXsGCsLQu0Ne"
-      },
-      "source": [
-        "## 1. High-Level Data Flow & Setup\n",
-        "\n",
-        "1. **User Creation & Role Management**\n",
-        "   - A user is stored at `user:{user_id}` in Redis with a JSON structure containing the user’s roles.\n",
-        "   - We can create, update, or delete users as needed.\n",
-        "   - **This serves as a simple look up layer and should NOT replace your production-ready auth API flow**\n",
-        "\n",
-        "2. **Document Storage**\n",
-        "   - Documents chunks are stored at `doc:{doc_id}:{chunk_id}` in Redis as JSON.\n",
-        "   - Each document chunk includes fields such as `doc_id`, `chunk_id`, `content`, `allowed_roles`, and an `embedding` (for vector similarity).\n",
-        "\n",
-        "3. **Querying / Search**\n",
-        "   - User roles are retrieved from Redis.\n",
-        "   - We perform a vector similarity search (or any other type of retrieval) on the documents.\n",
-        "   - We filter the results so that only documents whose `allowed_roles` intersect with the user’s roles are returned.\n",
-        "\n",
-        "4. **RAG Integration**\n",
-        "   - The returned documents can be fed into a Large Language Model (LLM) to provide context and generate an answer.\n",
-        "\n",
-        "First, we’ll set up our Python environment and Redis connection.\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "73c33af6",
-      "metadata": {
-        "id": "73c33af6"
-      },
-      "source": [
-        "### Download Documents\n",
-        "Running remotely or in collab? Run this cell to download the necessary datasets."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "48971c52",
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "48971c52",
-        "outputId": "e17d146a-43be-41fb-b029-f330d79f1a65"
-      },
-      "outputs": [],
-      "source": [
-        "# NBVAL_SKIP\n",
-        "!git clone https://github.com/redis-developer/redis-ai-resources.git temp_repo\n",
-        "!mkdir -p resources\n",
-        "!mv temp_repo/python-recipes/RAG/resources/aapl-10k-2023.pdf resources/\n",
-        "!mv temp_repo/python-recipes/RAG/resources/2022-chevy-colorado-ebrochure.pdf resources/\n",
-        "!rm -rf temp_repo"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "993371a2",
-      "metadata": {
-        "id": "993371a2"
-      },
-      "source": [
-        "### Run Redis Stack\n",
-        "\n",
-        "For this tutorial you will need a running instance of Redis if you don't already have one.\n",
-        "\n",
-        "#### For Colab\n",
-        "Use the shell script below to download, extract, and install [Redis Stack](https://redis.io/docs/getting-started/install-stack/) directly from the Redis package archive."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 4,
-      "id": "8edc5862",
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "8edc5862",
-        "outputId": "df2643ed-2422-4ee5-bd42-bec17b405eec"
-      },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "deb [signed-by=/usr/share/keyrings/redis-archive-keyring.gpg] https://packages.redis.io/deb jammy main\n",
-            "Starting redis-stack-server, database path /var/lib/redis-stack\n"
-          ]
-        }
-      ],
-      "source": [
-        "# NBVAL_SKIP\n",
-        "%%sh\n",
-        "curl -fsSL https://packages.redis.io/gpg | sudo gpg --dearmor -o /usr/share/keyrings/redis-archive-keyring.gpg\n",
-        "echo \"deb [signed-by=/usr/share/keyrings/redis-archive-keyring.gpg] https://packages.redis.io/deb $(lsb_release -cs) main\" | sudo tee /etc/apt/sources.list.d/redis.list\n",
-        "sudo apt-get update  > /dev/null 2>&1\n",
-        "sudo apt-get install redis-stack-server  > /dev/null 2>&1\n",
-        "redis-stack-server --daemonize yes"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "bc571319",
-      "metadata": {
-        "id": "bc571319"
-      },
-      "source": [
-        "#### For Alternative Environments\n",
-        "There are many ways to get the necessary redis-stack instance running\n",
-        "1. On cloud, deploy a [FREE instance of Redis in the cloud](https://redis.com/try-free/). Or, if you have your\n",
-        "own version of Redis Enterprise running, that works too!\n",
-        "2. Per OS, [see the docs](https://redis.io/docs/latest/operate/oss_and_stack/install/install-stack/)\n",
-        "3. With docker: `docker run -d --name redis-stack-server -p 6379:6379 redis/redis-stack-server:latest`"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 5,
-      "id": "qU49fNVnu0Nf",
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "qU49fNVnu0Nf",
-        "outputId": "4d2f34c3-6179-4f1d-eff7-5e8e9d8fd58b"
-      },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Successfully connected to Redis\n"
-          ]
-        }
-      ],
-      "source": [
-        "import os\n",
-        "\n",
-        "from redis import Redis\n",
-        "\n",
-        "# Replace values below with your own if using Redis Cloud instance\n",
-        "REDIS_HOST = os.getenv(\"REDIS_HOST\", \"localhost\") # ex: \"redis-18374.c253.us-central1-1.gce.cloud.redislabs.com\"\n",
-        "REDIS_PORT = os.getenv(\"REDIS_PORT\", \"6379\")      # ex: 18374\n",
-        "REDIS_PASSWORD = os.getenv(\"REDIS_PASSWORD\", \"\")  # ex: \"1TNxTEdYRDgIDKM2gDfasupCADXXXX\"\n",
-        "\n",
-        "# If SSL is enabled on the endpoint, use rediss:// as the URL prefix\n",
-        "REDIS_URL = f\"redis://:{REDIS_PASSWORD}@{REDIS_HOST}:{REDIS_PORT}\"\n",
-        "\n",
-        "# Connect to Redis (adjust host/port if needed)\n",
-        "redis_client = Redis.from_url(REDIS_URL)\n",
-        "redis_client.ping()\n",
-        "\n",
-        "print(\"Successfully connected to Redis\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "aqzMteQsu0Nf",
-      "metadata": {
-        "id": "aqzMteQsu0Nf"
-      },
-      "source": [
-        "## 2. User Management\n",
-        "\n",
-        "Below is a simple `User` class that stores a user in Redis as JSON. We:\n",
-        "\n",
-        "- Use a Redis key of the form `user:{user_id}`.\n",
-        "- Store fields like `user_id`, `roles`, etc.\n",
-        "- Provide CRUD methods (Create, Read, Update, Delete) for user objects.\n",
-        "\n",
-        "**Data Structure Example**\n",
-        "```json\n",
-        "{\n",
-        "  \"user_id\": \"alice\",\n",
-        "  \"roles\": [\"finance\", \"manager\"]\n",
-        "}\n",
-        "```\n",
-        "\n",
-        "We'll also include some basic checks to ensure we don't add duplicate roles, handle empty role lists, etc.\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 6,
-      "id": "38pdjXJvu0Nf",
-      "metadata": {
-        "id": "38pdjXJvu0Nf"
-      },
-      "outputs": [],
-      "source": [
-        "from typing import List, Optional\n",
-        "from enum import Enum\n",
-        "\n",
-        "\n",
-        "class UserRoles(str, Enum):\n",
-        "    FINANCE = \"finance\"\n",
-        "    MANAGER = \"manager\"\n",
-        "    EXECUTIVE = \"executive\"\n",
-        "    HR = \"hr\"\n",
-        "    SALES = \"sales\"\n",
-        "    PRODUCT = \"product\"\n",
-        "\n",
-        "\n",
-        "class User:\n",
-        "    \"\"\"\n",
-        "    User class for storing user data in Redis.\n",
-        "\n",
-        "    Each user has:\n",
-        "    - user_id (string)\n",
-        "    - roles (list of UserRoles)\n",
-        "\n",
-        "    Key in Redis: user:{user_id}\n",
-        "    \"\"\"\n",
-        "    def __init__(\n",
-        "        self,\n",
-        "        redis_client: Redis,\n",
-        "        user_id: str,\n",
-        "        roles: Optional[List[UserRoles]] = None\n",
-        "    ):\n",
-        "        self.redis_client = redis_client\n",
-        "        self.user_id = user_id\n",
-        "        self.roles = roles or []\n",
-        "\n",
-        "    @property\n",
-        "    def key(self) -> str:\n",
-        "        return f\"user:{self.user_id}\"\n",
-        "\n",
-        "    def exists(self) -> bool:\n",
-        "        \"\"\"Check if the user key exists in Redis.\"\"\"\n",
-        "        return self.redis_client.exists(self.key) == 1\n",
-        "\n",
-        "    def create(self):\n",
-        "        \"\"\"\n",
-        "        Create a new user in Redis. Fails if user already exists.\n",
-        "        \"\"\"\n",
-        "        if self.exists():\n",
-        "            raise ValueError(f\"User {self.user_id} already exists.\")\n",
-        "\n",
-        "        self.save()\n",
-        "\n",
-        "    def save(self):\n",
-        "        \"\"\"\n",
-        "        Save (create or update) the user data in Redis.\n",
-        "        If user does not exist, it will be created.\n",
-        "        \"\"\"\n",
-        "        data = {\n",
-        "            \"user_id\": self.user_id,\n",
-        "            \"roles\": [UserRoles(role).value for role in set(self.roles)] # ensure roles are unique and convert to strings\n",
-        "        }\n",
-        "        self.redis_client.json().set(self.key, \".\", data)\n",
-        "\n",
-        "    @classmethod\n",
-        "    def get(cls, redis_client: Redis, user_id):\n",
-        "        \"\"\"\n",
-        "        Retrieve a user from Redis.\n",
-        "        \"\"\"\n",
-        "        key = f\"user:{user_id}\"\n",
-        "        data = redis_client.json().get(key)\n",
-        "        if not data:\n",
-        "            return None\n",
-        "        # Convert string roles back to UserRoles enum\n",
-        "        roles = [UserRoles(role) for role in data.get(\"roles\", [])]\n",
-        "        return cls(redis_client, data[\"user_id\"], roles)\n",
-        "\n",
-        "    def update_roles(self, roles: List[UserRoles]):\n",
-        "        \"\"\"\n",
-        "        Overwrite the user's roles in Redis.\n",
-        "        \"\"\"\n",
-        "        self.roles = roles\n",
-        "        self.save()\n",
-        "\n",
-        "    def add_role(self, role: UserRoles):\n",
-        "        \"\"\"Add a single role to the user.\"\"\"\n",
-        "        if role not in self.roles:\n",
-        "            self.roles.append(role)\n",
-        "            self.save()\n",
-        "\n",
-        "    def remove_role(self, role: UserRoles):\n",
-        "        \"\"\"Remove a single role from the user.\"\"\"\n",
-        "        if role in self.roles:\n",
-        "            self.roles.remove(role)\n",
-        "            self.save()\n",
-        "\n",
-        "    def delete(self):\n",
-        "        \"\"\"Delete this user from Redis.\"\"\"\n",
-        "        self.redis_client.delete(self.key)\n",
-        "\n",
-        "    def __repr__(self):\n",
-        "        return f\"<User user_id={self.user_id}, roles={[UserRoles(role).value for role in self.roles]}>\"\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "FNQxAaoCxPN7",
-      "metadata": {
-        "id": "FNQxAaoCxPN7"
-      },
-      "source": [
-        "### Example usage of User class"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 7,
-      "id": "_WcOlgVyu0Ng",
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "_WcOlgVyu0Ng",
-        "outputId": "0776fa25-513b-445b-d46d-35d9333b3a75"
-      },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "User 'alice' created.\n",
-            "Retrieved: <User user_id=alice, roles=['finance', 'manager']>\n",
-            "After adding 'executive': <User user_id=alice, roles=['finance', 'manager', 'executive']>\n",
-            "After removing 'manager': <User user_id=alice, roles=['finance', 'executive']>\n"
-          ]
-        }
-      ],
-      "source": [
-        "# Example usage of the User class\n",
-        "\n",
-        "# Let's create a new user\n",
-        "alice = User(redis_client, \"alice\", roles=[\"finance\", \"manager\"])\n",
-        "\n",
-        "# We'll save the user in Redis\n",
-        "try:\n",
-        "    alice.create()\n",
-        "    print(\"User 'alice' created.\")\n",
-        "except ValueError as e:\n",
-        "    print(e)\n",
-        "\n",
-        "# Retrieve the user\n",
-        "alice_obj = User.get(redis_client, \"alice\")\n",
-        "print(\"Retrieved:\", alice_obj)\n",
-        "\n",
-        "# Add another role\n",
-        "alice_obj.add_role(\"executive\")\n",
-        "print(\"After adding 'executive':\", alice_obj)\n",
-        "\n",
-        "# Remove a role\n",
-        "alice_obj.remove_role(\"manager\")\n",
-        "print(\"After removing 'manager':\", alice_obj)\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 8,
-      "id": "c911e892",
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "c911e892",
-        "outputId": "df4666ff-97ce-4e75-d70c-75fe5d9e6703"
-      },
-      "outputs": [
-        {
-          "data": {
-            "text/plain": [
-              "<User user_id=alice, roles=['finance', 'manager']>"
-            ]
-          },
-          "execution_count": 8,
-          "metadata": {},
-          "output_type": "execute_result"
-        }
-      ],
-      "source": [
-        "# Take a peek at the user object itself\n",
-        "alice"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 9,
-      "id": "P3j6yu8l87j3",
-      "metadata": {
-        "id": "P3j6yu8l87j3"
-      },
-      "outputs": [],
-      "source": [
-        "# Create one more user\n",
-        "larry = User(redis_client, \"larry\", roles=[\"product\"])\n",
-        "larry.create()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "Y7B4l7XVx5md",
-      "metadata": {
-        "id": "Y7B4l7XVx5md"
-      },
-      "source": [
-        ">💡 Using a cloud DB? Take a peek at your instance using [RedisInsight](https://redis.io/insight) to see what user data is in place."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "aCXYFXu0u0Ng",
-      "metadata": {
-        "id": "aCXYFXu0u0Ng"
-      },
-      "source": [
-        "## 3. Document Management (Using LangChain)\n",
-        "\n",
-        "Here, we'll use **LangChain** for document loading, chunking, and vectorizing. Then, we’ll **store documents** in Redis as JSON. Each document will look like:\n",
-        "\n",
-        "```json\n",
-        "{\n",
-        "  \"doc_id\": \"123\",\n",
-        "  \"chunk_id\": \"123\",\n",
-        "  \"path\": \"resources/doc.pdf\",\n",
-        "  \"title\": \"Quarterly Finance Report\",\n",
-        "  \"content\": \"Some text...\",\n",
-        "  \"allowed_roles\": [\"finance\", \"executive\"],\n",
-        "  \"embedding\": [0.12, 0.98, ...]  \n",
-        "}\n",
-        "```"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "d3cJ5DSP5vXt",
-      "metadata": {
-        "id": "d3cJ5DSP5vXt"
-      },
-      "source": [
-        "### Building a document knowledge base\n",
-        "We will create a `KnowledgeBase` class to encapsulate document processing logic and search. The class will handle:\n",
-        "1. Document ingest and chunking\n",
-        "2. Role tagging with a simple str-based rule (likely custom depending on use case)\n",
-        "3. Retrieval over the entire document corpus adhering to provided user roles\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 23,
-      "id": "67d38524",
-      "metadata": {
-        "id": "67d38524"
-      },
-      "outputs": [],
-      "source": [
-        "from typing import List, Optional, Dict, Any, Set\n",
-        "from pathlib import Path\n",
-        "import uuid\n",
-        "\n",
-        "from langchain_community.document_loaders import PyPDFLoader\n",
-        "from langchain.text_splitter import RecursiveCharacterTextSplitter\n",
-        "from redisvl.index import SearchIndex\n",
-        "from redisvl.query import VectorQuery\n",
-        "from redisvl.query.filter import FilterExpression, Tag\n",
-        "from redisvl.utils.vectorize import OpenAITextVectorizer\n",
-        "\n",
-        "\n",
-        "class KnowledgeBase:\n",
-        "    \"\"\"Manages document processing, embedding, and storage in Redis.\"\"\"\n",
-        "\n",
-        "    def __init__(\n",
-        "        self,\n",
-        "        redis_client,\n",
-        "        embeddings_model: str = \"text-embedding-3-small\",\n",
-        "        chunk_size: int = 2500,\n",
-        "        chunk_overlap: int = 100\n",
-        "    ):\n",
-        "        self.redis_client = redis_client\n",
-        "        self.embeddings = OpenAITextVectorizer(model=embeddings_model)\n",
-        "        self.text_splitter = RecursiveCharacterTextSplitter(\n",
-        "            chunk_size=chunk_size,\n",
-        "            chunk_overlap=chunk_overlap,\n",
-        "        )\n",
-        "\n",
-        "        # Initialize document search index\n",
-        "        self.index = self._create_search_index()\n",
-        "\n",
-        "    def _create_search_index(self) -> SearchIndex:\n",
-        "        \"\"\"Create the Redis search index for documents.\"\"\"\n",
-        "        schema = {\n",
-        "            \"index\": {\n",
-        "                \"name\": \"docs\",\n",
-        "                \"prefix\": \"doc\",\n",
-        "                \"storage_type\": \"json\"\n",
-        "            },\n",
-        "            \"fields\": [\n",
-        "                {\n",
-        "                    \"name\": \"doc_id\",\n",
-        "                    \"type\": \"tag\",\n",
-        "                },\n",
-        "                {\n",
-        "                    \"name\": \"chunk_id\",\n",
-        "                    \"type\": \"tag\",\n",
-        "                },\n",
-        "                {\n",
-        "                    \"name\": \"allowed_roles\",\n",
-        "                    \"path\": \"$.allowed_roles[*]\",\n",
-        "                    \"type\": \"tag\",\n",
-        "                },\n",
-        "                {\n",
-        "                    \"name\": \"content\",\n",
-        "                    \"type\": \"text\",\n",
-        "                },\n",
-        "                {\n",
-        "                    \"name\": \"embedding\",\n",
-        "                    \"type\": \"vector\",\n",
-        "                    \"attrs\": {\n",
-        "                        \"dims\": self.embeddings.dims,\n",
-        "                        \"distance_metric\": \"cosine\",\n",
-        "                        \"algorithm\": \"flat\",\n",
-        "                        \"datatype\": \"float32\"\n",
-        "                    }\n",
-        "                }\n",
-        "            ]\n",
-        "        }\n",
-        "        index = SearchIndex.from_dict(schema, redis_client=self.redis_client)\n",
-        "        index.create()\n",
-        "        return index\n",
-        "\n",
-        "    def ingest(self, doc_path: str, allowed_roles: Optional[List[str]] = None) -> str:\n",
-        "        \"\"\"\n",
-        "        Load a document, chunk it, create embeddings, and store in Redis.\n",
-        "        Returns the document ID.\n",
-        "        \"\"\"\n",
-        "        # Generate document ID\n",
-        "        doc_id = str(uuid.uuid4())\n",
-        "        path = Path(doc_path)\n",
-        "\n",
-        "        if not path.exists():\n",
-        "            raise FileNotFoundError(f\"Document not found: {doc_path}\")\n",
-        "\n",
-        "        # Load and chunk document\n",
-        "        loader = PyPDFLoader(str(path))\n",
-        "        pages = loader.load()\n",
-        "        chunks = self.text_splitter.split_documents(pages)\n",
-        "        print(f\"Extracted {len(chunks)} for doc {doc_id} from file {str(path)}\", flush=True)\n",
-        "\n",
-        "        # If roles not provided, determine from filename\n",
-        "        if allowed_roles is None:\n",
-        "            allowed_roles = self._determine_roles(path)\n",
-        "\n",
-        "        # Prepare chunks for Redis\n",
-        "        data, keys = [], []\n",
-        "        for i, chunk in enumerate(chunks):\n",
-        "            # Create embedding w/ openai\n",
-        "            embedding = self.embeddings.embed(chunk.page_content)\n",
-        "\n",
-        "            # Prepare chunk payload\n",
-        "            chunk_id = f\"chunk_{i}\"\n",
-        "            key = f\"doc:{doc_id}:{chunk_id}\"\n",
-        "            data.append({\n",
-        "                \"doc_id\": doc_id,\n",
-        "                \"chunk_id\": chunk_id,\n",
-        "                \"path\": str(path),\n",
-        "                \"content\": chunk.page_content,\n",
-        "                \"allowed_roles\": list(allowed_roles),\n",
-        "                \"embedding\": embedding,\n",
-        "            })\n",
-        "            keys.append(key)\n",
-        "\n",
-        "        # Store in Redis\n",
-        "        _ = self.index.load(data=data, keys=keys)\n",
-        "        print(f\"Loaded {len(chunks)} chunks for document {doc_id}\")\n",
-        "        return doc_id\n",
-        "\n",
-        "    def _determine_roles(self, file_path: Path) -> Set[str]:\n",
-        "        \"\"\"Determine allowed roles based on file path and name patterns.\"\"\"\n",
-        "        # Customize based on use case and business logic\n",
-        "        ROLE_PATTERNS = {\n",
-        "            ('10k', 'financial', 'earnings', 'revenue'):\n",
-        "                {'finance', 'executive'},\n",
-        "            ('brochure', 'spec', 'product', 'manual'):\n",
-        "                {'product', 'sales'},\n",
-        "            ('hr', 'handbook', 'policy', 'employee'):\n",
-        "                {'hr', 'manager'},\n",
-        "            ('sales', 'pricing', 'customer'):\n",
-        "                {'sales', 'manager'}\n",
-        "        }\n",
-        "\n",
-        "        filename = file_path.name.lower()\n",
-        "        roles = {\n",
-        "            role for terms, roles in ROLE_PATTERNS.items()\n",
-        "            for role in roles\n",
-        "            if any(term in filename for term in terms)\n",
-        "        }\n",
-        "        return roles or {'executive'}\n",
-        "\n",
-        "    @staticmethod\n",
-        "    def role_filter(user_roles: List[str]) -> FilterExpression:\n",
-        "        \"\"\"Generate a Redis filter based on provided user roles.\"\"\"\n",
-        "        return Tag(\"allowed_roles\") == user_roles\n",
-        "\n",
-        "    def search(self, query: str, user_roles: List[str], top_k: int = 5) -> List[Dict[str, Any]]:\n",
-        "        \"\"\"\n",
-        "        Search for documents matching the query and user roles.\n",
-        "        Returns list of matching documents.\n",
-        "        \"\"\"\n",
-        "        # Create query vector\n",
-        "        query_vector = self.embeddings.embed(query)\n",
-        "\n",
-        "        # Build role filter\n",
-        "        roles_filter = self.role_filter(user_roles)\n",
-        "\n",
-        "        # Execute search\n",
-        "        return self.index.query(\n",
-        "            VectorQuery(\n",
-        "                vector=query_vector,\n",
-        "                vector_field_name=\"embedding\",\n",
-        "                filter_expression=roles_filter,\n",
-        "                return_fields=[\"doc_id\", \"chunk_id\", \"allowed_roles\", \"content\"],\n",
-        "                num_results=top_k,\n",
-        "                dialect=4\n",
-        "            )\n",
-        "        )\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "YsBuAa_q9QU_",
-      "metadata": {
-        "id": "YsBuAa_q9QU_"
-      },
-      "source": [
-        "Load a document into the knowledge base."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 12,
-      "id": "s1LDdWhKu0Nh",
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "s1LDdWhKu0Nh",
-        "outputId": "66e1105e-78ba-425a-8156-c810c7c9054a"
-      },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "21:09:47 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "Extracted 34 for doc f2c7171a-16cc-4aad-a777-ed7202bd7212 from file resources/2022-chevy-colorado-ebrochure.pdf\n",
-            "21:09:49 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:09:49 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:09:50 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:09:50 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:09:51 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:09:51 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:09:52 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:09:52 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:09:53 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:09:53 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:09:53 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:09:53 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:09:54 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:09:54 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:09:55 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:09:55 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:09:55 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:09:56 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:09:56 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:09:56 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:09:57 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:09:57 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:09:57 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:09:58 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:10:01 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:10:02 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:10:02 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:10:05 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:10:05 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:10:05 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:10:06 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:10:06 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:10:06 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:10:07 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "Loaded 34 chunks for document f2c7171a-16cc-4aad-a777-ed7202bd7212\n",
-            "Loaded all chunks for f2c7171a-16cc-4aad-a777-ed7202bd7212\n"
-          ]
-        }
-      ],
-      "source": [
-        "kb = KnowledgeBase(redis_client)\n",
-        "\n",
-        "doc_id = kb.ingest(\"resources/2022-chevy-colorado-ebrochure.pdf\")\n",
-        "print(f\"Loaded all chunks for {doc_id}\", flush=True)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "-Ekqkf1fu0Nh",
-      "metadata": {
-        "id": "-Ekqkf1fu0Nh"
-      },
-      "source": [
-        "## 4. User Query Flow\n",
-        "\n",
-        "Now that we have our User DB and our Vector DB loaded in Redis. We will perform:\n",
-        "\n",
-        "1. **Vector Similarity Search** on `embedding`.\n",
-        "2. A metadata **Filter** based on `allowed_roles`.\n",
-        "3. Return top-k matching document chunks.\n",
-        "\n",
-        "This is implemented below.\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 13,
-      "id": "WpvrXmluu0Nh",
-      "metadata": {
-        "id": "WpvrXmluu0Nh"
-      },
-      "outputs": [],
-      "source": [
-        "def user_query(user_id: str, query: str):\n",
-        "    \"\"\"\n",
-        "    Placeholder for a search function.\n",
-        "    1. Load the user's roles.\n",
-        "    2. Perform a vector search for docs.\n",
-        "    3. Filter docs that match at least one of the user's roles.\n",
-        "    4. Return top-K results.\n",
-        "    \"\"\"\n",
-        "    # 1. Load & validate user roles\n",
-        "    user_obj = User.get(redis_client, user_id)\n",
-        "    if not user_obj:\n",
-        "        raise ValueError(f\"User {user_id} not found.\")\n",
-        "\n",
-        "    roles = set([role.value for role in user_obj.roles])\n",
-        "    if not roles:\n",
-        "        raise ValueError(f\"User {user_id} does not have any roles.\")\n",
-        "\n",
-        "    # 2. Retrieve document chunks\n",
-        "    results = kb.search(query, roles)\n",
-        "\n",
-        "    if not results:\n",
-        "      raise ValueError(f\"No available documents found for {user_id}\")\n",
-        "\n",
-        "    return results"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "qQS1BLwGBVDA",
-      "metadata": {
-        "id": "qQS1BLwGBVDA"
-      },
-      "source": [
-        "### Search examples\n",
-        "\n",
-        "Search with a non-existent user."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 14,
-      "id": "wYishsNy6lty",
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 287
-        },
-        "id": "wYishsNy6lty",
-        "outputId": "dfa5a8b5-d926-4e94-e8a1-ecceb51ccff5"
-      },
-      "outputs": [
-        {
-          "ename": "ValueError",
-          "evalue": "User tyler not found.",
-          "output_type": "error",
-          "traceback": [
-            "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-            "\u001b[0;31mValueError\u001b[0m                                Traceback (most recent call last)",
-            "\u001b[0;32m<ipython-input-14-e5a00ef91be5>\u001b[0m in \u001b[0;36m<cell line: 0>\u001b[0;34m()\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0;31m# Search with a non-existent user\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 2\u001b[0;31m \u001b[0mresults\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0muser_query\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m\"tyler\"\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mquery\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m\"What is the make and model of the vehicle here?\"\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
-            "\u001b[0;32m<ipython-input-13-1890afcb160d>\u001b[0m in \u001b[0;36muser_query\u001b[0;34m(user_id, query)\u001b[0m\n\u001b[1;32m     10\u001b[0m     \u001b[0muser_obj\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mUser\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mget\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mredis_client\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0muser_id\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     11\u001b[0m     \u001b[0;32mif\u001b[0m \u001b[0;32mnot\u001b[0m \u001b[0muser_obj\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 12\u001b[0;31m         \u001b[0;32mraise\u001b[0m \u001b[0mValueError\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34mf\"User {user_id} not found.\"\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     13\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     14\u001b[0m     \u001b[0mroles\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mset\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mrole\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mvalue\u001b[0m \u001b[0;32mfor\u001b[0m \u001b[0mrole\u001b[0m \u001b[0;32min\u001b[0m \u001b[0muser_obj\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mroles\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-            "\u001b[0;31mValueError\u001b[0m: User tyler not found."
-          ]
-        }
-      ],
-      "source": [
-        "# NBVAL_SKIP\n",
-        "results = user_query(\"tyler\", query=\"What is the make and model of the vehicle here?\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "0af59693",
-      "metadata": {},
-      "source": [
-        "Create user for Tyler."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 15,
-      "id": "ZNgxlQSvChx7",
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 329
-        },
-        "id": "ZNgxlQSvChx7",
-        "outputId": "d59aad34-2d24-4c87-dd42-b9a44ccaf26b"
-      },
-      "outputs": [
-        {
-          "ename": "ValueError",
-          "evalue": "'engineering' is not a valid UserRoles",
-          "output_type": "error",
-          "traceback": [
-            "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-            "\u001b[0;31mValueError\u001b[0m                                Traceback (most recent call last)",
-            "\u001b[0;32m<ipython-input-15-c95bc0bd8411>\u001b[0m in \u001b[0;36m<cell line: 0>\u001b[0;34m()\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0;31m# Create user for Tyler\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      2\u001b[0m \u001b[0mtyler\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mUser\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mredis_client\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m\"tyler\"\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mroles\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m\"sales\"\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m\"engineering\"\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 3\u001b[0;31m \u001b[0mtyler\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mcreate\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
-            "\u001b[0;32m<ipython-input-6-9f5e400ee42b>\u001b[0m in \u001b[0;36mcreate\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m     47\u001b[0m             \u001b[0;32mraise\u001b[0m \u001b[0mValueError\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34mf\"User {self.user_id} already exists.\"\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     48\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 49\u001b[0;31m         \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0msave\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     50\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     51\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0msave\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-            "\u001b[0;32m<ipython-input-6-9f5e400ee42b>\u001b[0m in \u001b[0;36msave\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m     56\u001b[0m         data = {\n\u001b[1;32m     57\u001b[0m             \u001b[0;34m\"user_id\"\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0muser_id\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 58\u001b[0;31m             \u001b[0;34m\"roles\"\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0;34m[\u001b[0m\u001b[0mUserRoles\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mrole\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mvalue\u001b[0m \u001b[0;32mfor\u001b[0m \u001b[0mrole\u001b[0m \u001b[0;32min\u001b[0m \u001b[0mset\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mroles\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m]\u001b[0m \u001b[0;31m# ensure roles are unique and convert to strings\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     59\u001b[0m         }\n\u001b[1;32m     60\u001b[0m         \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mredis_client\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mjson\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mset\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mkey\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m\".\"\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mdata\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-            "\u001b[0;32m<ipython-input-6-9f5e400ee42b>\u001b[0m in \u001b[0;36m<listcomp>\u001b[0;34m(.0)\u001b[0m\n\u001b[1;32m     56\u001b[0m         data = {\n\u001b[1;32m     57\u001b[0m             \u001b[0;34m\"user_id\"\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0muser_id\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 58\u001b[0;31m             \u001b[0;34m\"roles\"\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0;34m[\u001b[0m\u001b[0mUserRoles\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mrole\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mvalue\u001b[0m \u001b[0;32mfor\u001b[0m \u001b[0mrole\u001b[0m \u001b[0;32min\u001b[0m \u001b[0mset\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mroles\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m]\u001b[0m \u001b[0;31m# ensure roles are unique and convert to strings\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     59\u001b[0m         }\n\u001b[1;32m     60\u001b[0m         \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mredis_client\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mjson\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mset\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mkey\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m\".\"\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mdata\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-            "\u001b[0;32m/usr/lib/python3.11/enum.py\u001b[0m in \u001b[0;36m__call__\u001b[0;34m(cls, value, names, module, qualname, type, start, boundary)\u001b[0m\n\u001b[1;32m    712\u001b[0m         \"\"\"\n\u001b[1;32m    713\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0mnames\u001b[0m \u001b[0;32mis\u001b[0m \u001b[0;32mNone\u001b[0m\u001b[0;34m:\u001b[0m  \u001b[0;31m# simple value lookup\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 714\u001b[0;31m             \u001b[0;32mreturn\u001b[0m \u001b[0mcls\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m__new__\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mcls\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mvalue\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    715\u001b[0m         \u001b[0;31m# otherwise, functional API: we're creating a new Enum type\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    716\u001b[0m         return cls._create_(\n",
-            "\u001b[0;32m/usr/lib/python3.11/enum.py\u001b[0m in \u001b[0;36m__new__\u001b[0;34m(cls, value)\u001b[0m\n\u001b[1;32m   1135\u001b[0m                 \u001b[0mve_exc\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mValueError\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m\"%r is not a valid %s\"\u001b[0m \u001b[0;34m%\u001b[0m \u001b[0;34m(\u001b[0m\u001b[0mvalue\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mcls\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m__qualname__\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   1136\u001b[0m                 \u001b[0;32mif\u001b[0m \u001b[0mresult\u001b[0m \u001b[0;32mis\u001b[0m \u001b[0;32mNone\u001b[0m \u001b[0;32mand\u001b[0m \u001b[0mexc\u001b[0m \u001b[0;32mis\u001b[0m \u001b[0;32mNone\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m-> 1137\u001b[0;31m                     \u001b[0;32mraise\u001b[0m \u001b[0mve_exc\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m   1138\u001b[0m                 \u001b[0;32melif\u001b[0m \u001b[0mexc\u001b[0m \u001b[0;32mis\u001b[0m \u001b[0;32mNone\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   1139\u001b[0m                     exc = TypeError(\n",
-            "\u001b[0;31mValueError\u001b[0m: 'engineering' is not a valid UserRoles"
-          ]
-        }
-      ],
-      "source": [
-        "# NBVAL_SKIP\n",
-        "tyler = User(redis_client, \"tyler\", roles=[\"sales\", \"engineering\"])\n",
-        "tyler.create()"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 16,
-      "id": "WWVJF0UVCt4d",
-      "metadata": {
-        "collapsed": true,
-        "id": "WWVJF0UVCt4d"
-      },
-      "outputs": [],
-      "source": [
-        "# Try again but this time with valid roles\n",
-        "tyler = User(redis_client, \"tyler\", roles=[\"sales\"])\n",
-        "tyler.create()"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 17,
-      "id": "DXEyktWLC1cC",
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "DXEyktWLC1cC",
-        "outputId": "dbb6e93f-3b81-4c14-f329-daf97a613c89"
-      },
-      "outputs": [
-        {
-          "data": {
-            "text/plain": [
-              "<User user_id=tyler, roles=['sales']>"
-            ]
-          },
-          "execution_count": 17,
-          "metadata": {},
-          "output_type": "execute_result"
-        }
-      ],
-      "source": [
-        "tyler"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 18,
-      "id": "O0K_rdC7C6OH",
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "O0K_rdC7C6OH",
-        "outputId": "f823f253-cf42-4975-f711-6391b36f83bd"
-      },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "21:10:21 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n"
-          ]
-        },
-        {
-          "data": {
-            "text/plain": [
-              "[{'id': 'doc:f2c7171a-16cc-4aad-a777-ed7202bd7212:chunk_13',\n",
-              "  'vector_distance': '0.60664498806',\n",
-              "  'doc_id': '[\"f2c7171a-16cc-4aad-a777-ed7202bd7212\"]',\n",
-              "  'chunk_id': '[\"chunk_13\"]',\n",
-              "  'allowed_roles': '[\"sales\",\"product\"]'},\n",
-              " {'id': 'doc:f2c7171a-16cc-4aad-a777-ed7202bd7212:chunk_11',\n",
-              "  'vector_distance': '0.613630235195',\n",
-              "  'doc_id': '[\"f2c7171a-16cc-4aad-a777-ed7202bd7212\"]',\n",
-              "  'chunk_id': '[\"chunk_11\"]',\n",
-              "  'allowed_roles': '[\"sales\",\"product\"]'},\n",
-              " {'id': 'doc:f2c7171a-16cc-4aad-a777-ed7202bd7212:chunk_19',\n",
-              "  'vector_distance': '0.62441521883',\n",
-              "  'doc_id': '[\"f2c7171a-16cc-4aad-a777-ed7202bd7212\"]',\n",
-              "  'chunk_id': '[\"chunk_19\"]',\n",
-              "  'allowed_roles': '[\"sales\",\"product\"]'}]"
-            ]
-          },
-          "execution_count": 18,
-          "metadata": {},
-          "output_type": "execute_result"
-        }
-      ],
-      "source": [
-        "# Query with valid user\n",
-        "results = user_query(\n",
-        "    tyler.user_id,\n",
-        "    query=\"What is the make and model of the vehicle here?\"\n",
-        ")\n",
-        "results[:3]"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "454ce79b",
-      "metadata": {},
-      "source": [
-        "Search with a valid user, but incorrect roles."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 19,
-      "id": "irqwMseYDSS_",
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 394
-        },
-        "id": "irqwMseYDSS_",
-        "outputId": "acb3fe4b-c451-464f-c214-8a90d835f9ef"
-      },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "<User user_id=alice, roles=['finance', 'manager']> \n",
-            "\n",
-            "21:10:24 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n"
-          ]
-        },
-        {
-          "ename": "ValueError",
-          "evalue": "No available documents found for alice",
-          "output_type": "error",
-          "traceback": [
-            "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-            "\u001b[0;31mValueError\u001b[0m                                Traceback (most recent call last)",
-            "\u001b[0;32m<ipython-input-19-45d2e7b2400d>\u001b[0m in \u001b[0;36m<cell line: 0>\u001b[0;34m()\u001b[0m\n\u001b[1;32m      3\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      4\u001b[0m \u001b[0;31m# Query with valid user\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 5\u001b[0;31m results = user_query(\n\u001b[0m\u001b[1;32m      6\u001b[0m     \u001b[0malice\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0muser_id\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mquery\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m\"What is the make and model of the vehicle here?\"\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      7\u001b[0m )\n",
-            "\u001b[0;32m<ipython-input-13-1890afcb160d>\u001b[0m in \u001b[0;36muser_query\u001b[0;34m(user_id, query)\u001b[0m\n\u001b[1;32m     20\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     21\u001b[0m     \u001b[0;32mif\u001b[0m \u001b[0;32mnot\u001b[0m \u001b[0mresults\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 22\u001b[0;31m       \u001b[0;32mraise\u001b[0m \u001b[0mValueError\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34mf\"No available documents found for {user_id}\"\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     23\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     24\u001b[0m     \u001b[0;32mreturn\u001b[0m \u001b[0mresults\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-            "\u001b[0;31mValueError\u001b[0m: No available documents found for alice"
-          ]
-        }
-      ],
-      "source": [
-        "# NBVAL_SKIP\n",
-        "print(alice, \"\\n\")\n",
-        "\n",
-        "# Query with valid user\n",
-        "results = user_query(\n",
-        "    alice.user_id, query=\"What is the make and model of the vehicle here?\"\n",
-        ")\n",
-        "results"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "c309b53d",
-      "metadata": {
-        "id": "c309b53d"
-      },
-      "source": [
-        "Empty results because there are no documents available for Alice to view. Add some."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 20,
-      "id": "0e5e990b",
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 1000
-        },
-        "id": "0e5e990b",
-        "outputId": "b0b1bc64-6b01-47d3-feb4-3d6d1cc8e38d"
-      },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Extracted 155 for doc 42b58f50-d689-4a36-8977-e8ca1a183446 from file resources/aapl-10k-2023.pdf\n",
-            "21:10:32 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:10:32 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:10:32 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:10:32 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:10:32 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:10:33 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:10:33 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:10:33 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:10:34 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:10:34 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:10:34 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:10:34 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:10:35 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:10:35 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:10:36 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:10:36 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:10:36 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:10:36 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:10:36 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:10:37 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:10:37 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:10:37 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:10:37 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:10:37 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:10:38 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:10:38 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:10:38 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:10:39 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:10:39 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:10:39 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:10:39 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:10:40 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:10:40 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:10:40 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:10:40 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:10:40 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:10:41 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:10:41 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:10:41 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:10:41 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:10:41 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:10:42 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:10:42 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:10:42 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:10:42 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:10:43 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:10:43 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:10:43 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:10:43 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:10:44 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:10:44 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:10:44 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:10:44 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:10:45 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:10:45 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:10:45 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:10:45 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:10:46 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:10:46 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:10:46 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:10:46 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:10:47 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:10:47 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:10:47 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:10:47 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:10:48 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:10:48 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:10:51 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:10:52 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:10:52 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:10:52 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:10:52 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:10:52 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:10:53 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:10:53 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:10:53 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:10:53 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:10:53 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:10:54 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:10:54 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:10:54 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:10:54 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:10:55 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:10:55 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:10:55 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:10:55 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:10:56 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:10:56 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:10:56 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:10:56 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:10:56 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:10:57 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:10:57 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:10:57 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:10:58 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:10:58 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:10:58 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:10:58 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:10:58 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:10:59 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:10:59 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:10:59 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:10:59 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:11:00 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:11:00 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:11:00 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:11:00 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:11:01 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:11:01 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:11:01 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:11:02 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:11:02 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:11:02 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:11:02 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:11:03 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:11:03 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:11:03 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:11:03 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:11:03 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:11:03 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:11:04 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:11:04 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:11:04 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:11:04 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:11:05 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:11:05 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:11:05 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:11:06 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:11:06 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:11:06 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:11:06 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:11:06 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:11:07 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:11:07 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:11:07 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:11:08 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:11:08 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:11:08 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:11:08 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:11:09 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:11:09 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:11:09 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:11:09 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:11:10 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:11:10 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:11:10 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:11:10 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:11:11 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:11:11 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:11:11 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:11:11 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:11:11 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:11:12 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:11:12 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:11:12 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "Loaded 155 chunks for document 42b58f50-d689-4a36-8977-e8ca1a183446\n"
-          ]
-        },
-        {
-          "data": {
-            "application/vnd.google.colaboratory.intrinsic+json": {
-              "type": "string"
-            },
-            "text/plain": [
-              "'42b58f50-d689-4a36-8977-e8ca1a183446'"
-            ]
-          },
-          "execution_count": 20,
-          "metadata": {},
-          "output_type": "execute_result"
-        }
-      ],
-      "source": [
-        "# Add a document that Alice will have access to\n",
-        "kb.ingest(\"resources/aapl-10k-2023.pdf\")"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 22,
-      "id": "9fcf8cc0",
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "9fcf8cc0",
-        "outputId": "bce13955-7d37-472b-f820-5588cd3986b4"
-      },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "21:11:30 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n"
-          ]
-        },
-        {
-          "data": {
-            "text/plain": [
-              "[{'id': 'doc:42b58f50-d689-4a36-8977-e8ca1a183446:chunk_81',\n",
-              "  'vector_distance': '0.343286693096',\n",
-              "  'doc_id': '[\"42b58f50-d689-4a36-8977-e8ca1a183446\"]',\n",
-              "  'chunk_id': '[\"chunk_81\"]',\n",
-              "  'allowed_roles': '[\"finance\",\"executive\"]'},\n",
-              " {'id': 'doc:42b58f50-d689-4a36-8977-e8ca1a183446:chunk_68',\n",
-              "  'vector_distance': '0.353579521179',\n",
-              "  'doc_id': '[\"42b58f50-d689-4a36-8977-e8ca1a183446\"]',\n",
-              "  'chunk_id': '[\"chunk_68\"]',\n",
-              "  'allowed_roles': '[\"finance\",\"executive\"]'},\n",
-              " {'id': 'doc:42b58f50-d689-4a36-8977-e8ca1a183446:chunk_72',\n",
-              "  'vector_distance': '0.354550600052',\n",
-              "  'doc_id': '[\"42b58f50-d689-4a36-8977-e8ca1a183446\"]',\n",
-              "  'chunk_id': '[\"chunk_72\"]',\n",
-              "  'allowed_roles': '[\"finance\",\"executive\"]'}]"
-            ]
-          },
-          "execution_count": 22,
-          "metadata": {},
-          "output_type": "execute_result"
-        }
-      ],
-      "source": [
-        "# Query with valid user\n",
-        "results = user_query(\n",
-        "    alice.user_id,\n",
-        "    query=\"What was the total revenue amount for Apple according to their 10k?\"\n",
-        ")\n",
-        "results[:3]"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "b3b432e6",
-      "metadata": {
-        "id": "b3b432e6"
-      },
-      "source": [
-        "## 5. Implementing Role-Based RAG from scratch\n",
-        "*with OpenAI and Redis*"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 39,
-      "id": "794b3c41",
-      "metadata": {
-        "id": "794b3c41"
-      },
-      "outputs": [],
-      "source": [
-        "from openai import OpenAI\n",
-        "from typing import List, Optional\n",
-        "import os\n",
-        "\n",
-        "from redisvl.extensions.message_history import MessageHistory\n",
-        "\n",
-        "\n",
-        "class RAGChatManager:\n",
-        "    \"\"\"\n",
-        "    Manages RAG-enhanced chat interactions with role-based access control and chat history.\n",
-        "\n",
-        "    Attributes:\n",
-        "        kb: A KnowledgeBase instance for searching documents\n",
-        "        client: An OpenAI client for chat completions\n",
-        "        model: Name of OpenAI model to use\n",
-        "        sessions: Dict to store active chat sessions\n",
-        "        system_prompt: The default system prompt\n",
-        "    \"\"\"\n",
-        "\n",
-        "    def __init__(\n",
-        "        self,\n",
-        "        knowledge_base: \"KnowledgeBase\",\n",
-        "        openai_api_key: Optional[str] = None,\n",
-        "        openai_model: str = \"gpt-4\",\n",
-        "        system_prompt: str = \"You are a helpful chatbot assistant with access to knowledge base documents\"\n",
-        "    ):\n",
-        "        \"\"\"Initialize the RAG chat manager.\"\"\"\n",
-        "        self.kb = knowledge_base\n",
-        "        self.client = OpenAI(api_key=openai_api_key or os.getenv(\"OPENAI_API_KEY\"))\n",
-        "        self.model = openai_model\n",
-        "        self.sessions = {}\n",
-        "        self.system_prompt = system_prompt\n",
-        "\n",
-        "    def user_roles(self, user_id: str) -> set:\n",
-        "        \"\"\"\n",
-        "        Get and validate user roles.\n",
-        "\n",
-        "        Args:\n",
-        "            user_id: User identifier\n",
-        "\n",
-        "        Returns:\n",
-        "            Set of user roles\n",
-        "\n",
-        "        Raises:\n",
-        "            ValueError: If user not found or has no roles\n",
-        "        \"\"\"\n",
-        "        user_obj = User.get(self.kb.redis_client, user_id)\n",
-        "        if not user_obj:\n",
-        "            raise ValueError(f\"User {user_id} not found.\")\n",
-        "\n",
-        "        roles = set([role.value for role in user_obj.roles])\n",
-        "        if not roles:\n",
-        "            raise ValueError(f\"User {user_id} does not have any roles.\")\n",
-        "\n",
-        "        return roles\n",
-        "\n",
-        "    def start_session(self, user_id: str) -> None:\n",
-        "        \"\"\"\n",
-        "        Start a new chat session for a user.\n",
-        "\n",
-        "        Args:\n",
-        "            user_id: User identifier\n",
-        "        \"\"\"\n",
-        "        if user_id not in self.sessions:\n",
-        "            self.sessions[user_id] = MessageHistory(\n",
-        "                name=f\"session:{user_id}\",\n",
-        "                redis_client=self.kb.redis_client\n",
-        "              )\n",
-        "\n",
-        "    def prep_msgs(\n",
-        "        self,\n",
-        "        user_id: str,\n",
-        "        system_prompt: str,\n",
-        "        context: str,\n",
-        "        query: str\n",
-        "    ) -> List[dict]:\n",
-        "        \"\"\"\n",
-        "        Get chat history messages including system prompt.\n",
-        "\n",
-        "        Args:\n",
-        "            user_id: User identifier for the session\n",
-        "            system_prompt: Optional system prompt to prepend\n",
-        "            context: Relevant context fetched from the knowledge base\n",
-        "            query: Original user question\n",
-        "\n",
-        "        Returns:\n",
-        "            List of message dictionaries\n",
-        "        \"\"\"\n",
-        "        messages = [{\"role\": \"system\", \"content\": system_prompt}]\n",
-        "\n",
-        "        if user_id in self.sessions:\n",
-        "            messages.extend(self.sessions[user_id].get_recent())\n",
-        "\n",
-        "        messages.append({\n",
-        "            \"role\": \"user\",\n",
-        "            \"content\": f\"\"\"Context information is below.\n",
-        "            ---------------------\n",
-        "            {context}\n",
-        "            ---------------------\n",
-        "            Given the context information above and the chat conversation history, please answer the question faithfully: {query}\"\"\"\n",
-        "        })\n",
-        "\n",
-        "        for msg in messages:\n",
-        "            if msg[\"role\"] == \"llm\":\n",
-        "                msg[\"role\"] = \"assistant\"\n",
-        "\n",
-        "        return messages\n",
-        "\n",
-        "    def chat(self, user_id: str, system_prompt: Optional[str] = None) -> None:\n",
-        "        \"\"\"\n",
-        "        Start an interactive chat loop with the user.\n",
-        "\n",
-        "        Args:\n",
-        "            user_id: User identifier\n",
-        "            system_prompt: Optional system prompt\n",
-        "\n",
-        "        The loop continues until user types 'exit' or 'quit'\n",
-        "        \"\"\"\n",
-        "        self.start_session(user_id)\n",
-        "\n",
-        "        print(\"Starting chat session with GPT4. Type 'exit' or 'quit' to end the session.\")\n",
-        "        while True:\n",
-        "            query = input(\"\\nYou: \").strip()\n",
-        "\n",
-        "            if query.lower() in ['exit', 'quit']:\n",
-        "                print(\"\\nEnding chat session...\")\n",
-        "                break\n",
-        "\n",
-        "            response = self.answer(query, user_id, system_prompt)\n",
-        "            print(f\"\\nAssistant: {response}\")\n",
-        "\n",
-        "    def answer(\n",
-        "        self,\n",
-        "        query: str,\n",
-        "        user_id: str,\n",
-        "        system_prompt: Optional[str] = None\n",
-        "    ) -> str:\n",
-        "        \"\"\"\n",
-        "        Process a chat message with RAG enhancement and role-based access.\n",
-        "\n",
-        "        If any exception occurs at any stage (roles, document search, LLM call),\n",
-        "        we do NOT store anything in the session and simply return the error.\n",
-        "        Otherwise, we store the query and the response (including 'no docs found' case).\n",
-        "\n",
-        "        Args:\n",
-        "            query: User's question\n",
-        "            user_id: User identifier\n",
-        "            system_prompt: Optional system prompt\n",
-        "\n",
-        "        Returns:\n",
-        "            AI response string or error message\n",
-        "        \"\"\"\n",
-        "\n",
-        "        # Start or retrieve an existing session for user\n",
-        "        self.start_session(user_id)\n",
-        "\n",
-        "        try:\n",
-        "            # 1. Validate user roles\n",
-        "            roles = self.user_roles(user_id)\n",
-        "\n",
-        "            # 2. Use provided system prompt or default\n",
-        "            system_prompt = system_prompt or self.system_prompt\n",
-        "\n",
-        "            # 3. Search for relevant documents\n",
-        "            docs = self.kb.search(query, roles)\n",
-        "\n",
-        "            # 4. If no documents, store & return early\n",
-        "            if not docs:\n",
-        "                no_docs_msg = (\n",
-        "                    \"I couldn't find any relevant documents you have permission to access. \"\n",
-        "                    \"Please try rephrasing your question or contact an administrator if you believe this is an error.\"\n",
-        "                )\n",
-        "                self.sessions[user_id].store(query, no_docs_msg)\n",
-        "                return no_docs_msg\n",
-        "\n",
-        "            # 5. Prepare context and messages for the LLM\n",
-        "            context = \"\\n\\n\".join([doc.get(\"content\", \"\") for doc in docs])\n",
-        "            messages = self.prep_msgs(\n",
-        "                user_id=user_id,\n",
-        "                system_prompt=system_prompt,\n",
-        "                context=context,\n",
-        "                query=query\n",
-        "            )\n",
-        "\n",
-        "            # 6. Generate response from the model\n",
-        "            response = self.client.chat.completions.create(\n",
-        "                model=self.model,\n",
-        "                messages=messages\n",
-        "            )\n",
-        "            ai_response = response.choices[0].message.content\n",
-        "\n",
-        "            # 7. Store query and LLM response\n",
-        "            self.sessions[user_id].store(query, ai_response)\n",
-        "\n",
-        "            return ai_response\n",
-        "\n",
-        "        except Exception as e:\n",
-        "            # Catch any exception; do not store anything, just return the error.\n",
-        "            return f\"I encountered an error: {str(e)}\"\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "zJdHMGdUCl_S",
-      "metadata": {
-        "id": "zJdHMGdUCl_S"
-      },
-      "source": [
-        "### Session-aware, role-based RAG"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 40,
-      "id": "1HDy2Ltr12I1",
-      "metadata": {
-        "id": "1HDy2Ltr12I1"
-      },
-      "outputs": [],
-      "source": [
-        "bot = RAGChatManager(kb)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 41,
-      "id": "sM6BQ-ZL2LUf",
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 89
-        },
-        "id": "sM6BQ-ZL2LUf",
-        "outputId": "b678b1ac-e177-4d16-9af8-2cd2cf2e48c1"
-      },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "21:20:45 redisvl.index.index INFO   Index already exists, not overwriting.\n",
-            "21:20:45 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:20:47 httpx INFO   HTTP Request: POST https://api.openai.com/v1/chat/completions \"HTTP/1.1 200 OK\"\n"
-          ]
-        },
-        {
-          "data": {
-            "application/vnd.google.colaboratory.intrinsic+json": {
-              "type": "string"
-            },
-            "text/plain": [
-              "\"The context information provided does not contain any details about a vehicle's make and model.\""
-            ]
-          },
-          "execution_count": 41,
-          "metadata": {},
-          "output_type": "execute_result"
-        }
-      ],
-      "source": [
-        "bot.answer(\"What is the make and model of the vehicle?\", user_id=\"alice\")"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 42,
-      "id": "3iJdgsaAjsaA",
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 89
-        },
-        "id": "3iJdgsaAjsaA",
-        "outputId": "545b9621-e04e-4d96-ade7-5ad1e1311d3c"
-      },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "21:20:50 redisvl.index.index INFO   Index already exists, not overwriting.\n",
-            "21:20:50 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:20:51 httpx INFO   HTTP Request: POST https://api.openai.com/v1/chat/completions \"HTTP/1.1 200 OK\"\n"
-          ]
-        },
-        {
-          "data": {
-            "application/vnd.google.colaboratory.intrinsic+json": {
-              "type": "string"
-            },
-            "text/plain": [
-              "'The make and model of the vehicle is Chevrolet Colorado.'"
-            ]
-          },
-          "execution_count": 42,
-          "metadata": {},
-          "output_type": "execute_result"
-        }
-      ],
-      "source": [
-        "bot.answer(\"What is the make and model of the vehicle?\", user_id=\"tyler\")"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 43,
-      "id": "17CUi5TXBFSB",
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 71
-        },
-        "id": "17CUi5TXBFSB",
-        "outputId": "852635cc-01a4-4a02-d07d-4a48eabafbba"
-      },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "21:20:54 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:20:55 httpx INFO   HTTP Request: POST https://api.openai.com/v1/chat/completions \"HTTP/1.1 200 OK\"\n"
-          ]
-        },
-        {
-          "data": {
-            "application/vnd.google.colaboratory.intrinsic+json": {
-              "type": "string"
-            },
-            "text/plain": [
-              "'The vehicle is from the year 2022.'"
-            ]
-          },
-          "execution_count": 43,
-          "metadata": {},
-          "output_type": "execute_result"
-        }
-      ],
-      "source": [
-        "bot.answer(\"What year is it?\", user_id=\"tyler\")"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 44,
-      "id": "N4IV1bLTCj1N",
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "N4IV1bLTCj1N",
-        "outputId": "e456deb7-c15d-4a88-ad31-27782be58f72"
-      },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Starting chat session with GPT4. Type 'exit' or 'quit' to end the session.\n",
-            "\n",
-            "You: What is the towing capacity of the truck?\n",
-            "21:22:10 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:22:14 httpx INFO   HTTP Request: POST https://api.openai.com/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
-            "\n",
-            "Assistant: The towing capacity of the truck varies depending on the specific model and engine. The 2.5L DOHC I-4 engine has a maximum towing weight rating of 3,500 lbs, the 3.6L DOHC V6 engine can tow up to 7,000 lbs, and the Duramax 2.8L Turbo-Diesel I-4 engine has a maximum towing weight rating of 7,700 lbs. You should always check the specific towing capacity of your vehicle and never exceed it, as this can lead to vehicle damage or unsafe driving conditions.\n",
-            "\n",
-            "You: Is it generally safe to drive? What safety features are available?\n",
-            "21:22:28 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:22:39 httpx INFO   HTTP Request: POST https://api.openai.com/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
-            "\n",
-            "Assistant: Yes, it's generally safe to drive the 2022 Chevrolet Colorado, but keep in mind that safety also depends on the driver's attentiveness and other factors like road conditions. This particular model comes with various safety features such as:\n",
-            "\n",
-            "1. Electronic Stability Control System and Traction Control - this system helps the driver maintain control of the vehicle during tricky driving conditions such as rainy or icy roads.\n",
-            "2. Hill Start Assist - this feature ensures the vehicle doesn't roll backward when you're on a hill and switching your foot from the brake pedal to the gas pedal.\n",
-            "3. Hitch Guidance - this feature assists with dynamic trailering and towing tasks.\n",
-            "4. An integrated trailer brake controller (with available Duramax 2.8L Turbo-Diesel I-4 engine or with available Trailering Package with 3.6L V6 engine).\n",
-            "5. Teen Driver technology - this feature allows parents to set speed and volume limits for their young drivers.\n",
-            "6. Tire Pressure Monitoring System with Tire Fill Alert.\n",
-            "7. The Recovery Hooks on 4x4 models.\n",
-            "8. The vehicle also includes various airbags: dual-stage frontal airbags for both driver and front passenger seat. Seat-mounted side-impact airbags for driver and front passenger; head-curtain airbags for front and rear outboard seating positions.\n",
-            "\n",
-            "However, it's essential to remember that safety features are not a substitute for the driver's responsibility to operate the vehicle safely. It's also crucial always to use seat belts and the correct child restraints for a child’s age and size.\n",
-            "\n",
-            "You: Do you know if it's better than the 2021 version of the truck?\n",
-            "21:22:57 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:23:03 httpx INFO   HTTP Request: POST https://api.openai.com/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
-            "\n",
-            "Assistant: As a chatbot, I don't have personal opinions, but I can share that the 2022 Chevrolet Colorado continues to offer the same strong performance, versatility, and wide range of configurations that made the 2021 model popular. However, specific improvements or changes may vary based on the trim level or optional packages. It's also important to note that 'better' can depend on your personal needs and preferences. If you are comparing the 2021 and 2022 models, consider factors such as performance, fuel economy, safety features, technology, and price to determine which is better for your needs.\n",
-            "\n",
-            "You: Got it. Thank you. That's all for today.\n",
-            "21:25:32 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-            "21:25:34 httpx INFO   HTTP Request: POST https://api.openai.com/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
-            "\n",
-            "Assistant: You're welcome! If you have any more questions in the future, don't hesitate to ask. Have a great day!\n",
-            "\n",
-            "You: quit\n",
-            "\n",
-            "Ending chat session...\n"
-          ]
-        }
-      ],
-      "source": [
-        "# NBVAL_SKIP\n",
-        "bot.chat(user_id=\"tyler\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "SHg3tFa2u0Nh",
-      "metadata": {
-        "id": "SHg3tFa2u0Nh"
-      },
-      "source": [
-        "## 6. Summary & Next Steps\n",
-        "\n",
-        "In this notebook, we set up a **basic** for a Role-Based RAG system:\n",
-        "\n",
-        "1. **Users** (with `roles`) stored in Redis via JSON.\n",
-        "2. **Documents** (with `allowed_roles`) loaded, parsed, embedded and also stored in Redis.\n",
-        "3. A user search pipeline that honors user roles when retrieving documents.\n",
-        "\n",
-        "\n",
-        "This approach ensures that **only documents** whose roles match the user’s roles are returned.\n",
-        "\n",
-        "\n",
-        "With these building blocks in place, you can integrate an LLM to supply a context from the returned docs, producing a robust retrieval-augmented generation pipeline with role-based access controls.\n"
-      ]
-    }
-  ],
-  "metadata": {
-    "accelerator": "GPU",
-    "colab": {
-      "gpuType": "T4",
-      "provenance": []
-    },
-    "kernelspec": {
-      "display_name": "Python 3",
-      "name": "python3"
-    },
-    "language_info": {
-      "codemirror_mode": {
-        "name": "ipython",
-        "version": 3
-      },
-      "file_extension": ".py",
-      "mimetype": "text/x-python",
-      "name": "python",
-      "nbconvert_exporter": "python",
-      "pygments_lexer": "ipython3",
-      "version": "3.11.9"
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "XwR-PYCFu0Nd",
+   "metadata": {
+    "id": "XwR-PYCFu0Nd"
+   },
+   "source": [
+    "# Building a Role-Based RAG Pipeline with Redis\n",
+    "\n",
+    "This notebook demonstrates a simplified setup for a **Role-Based Retrieval Augmented Generation (RAG)** pipeline, where:\n",
+    "\n",
+    "1. Each **User** has one or more **roles**.\n",
+    "2. Knowledge base **Documents** in Redis are tagged with the official roles that can access them (`allowed_roles`).\n",
+    "3. A unified **query flow** ensures a user only sees documents that match at least one of their roles.\n",
+    "\n",
+    "![Role Based RAG](https://raw.githubusercontent.com/redis-developer/redis-ai-resources/main/assets/role-based-rag.png)"
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 5
+  {
+   "cell_type": "markdown",
+   "id": "58823e66",
+   "metadata": {
+    "id": "58823e66"
+   },
+   "source": [
+    "\n",
+    "## Let's Begin!\n",
+    "<a href=\"https://colab.research.google.com/github/redis-developer/redis-ai-resources/blob/main/python-recipes/RAG/07_user_role_based_rag.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "4e0aa177",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "4e0aa177",
+    "outputId": "0ba61596-b3e4-442f-cd9c-8b480f1c52d1"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001B[?25l   \u001B[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001B[0m \u001B[32m0.0/99.3 kB\u001B[0m \u001B[31m?\u001B[0m eta \u001B[36m-:--:--\u001B[0m\r\u001B[2K   \u001B[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001B[0m \u001B[32m99.3/99.3 kB\u001B[0m \u001B[31m7.1 MB/s\u001B[0m eta \u001B[36m0:00:00\u001B[0m\n",
+      "\u001B[?25h\u001B[?25l   \u001B[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001B[0m \u001B[32m0.0/2.5 MB\u001B[0m \u001B[31m?\u001B[0m eta \u001B[36m-:--:--\u001B[0m\r\u001B[2K   \u001B[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001B[0m\u001B[91m╸\u001B[0m \u001B[32m2.5/2.5 MB\u001B[0m \u001B[31m91.5 MB/s\u001B[0m eta \u001B[36m0:00:01\u001B[0m\r\u001B[2K   \u001B[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001B[0m \u001B[32m2.5/2.5 MB\u001B[0m \u001B[31m55.0 MB/s\u001B[0m eta \u001B[36m0:00:00\u001B[0m\n",
+      "\u001B[2K   \u001B[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001B[0m \u001B[32m298.0/298.0 kB\u001B[0m \u001B[31m25.9 MB/s\u001B[0m eta \u001B[36m0:00:00\u001B[0m\n",
+      "\u001B[2K   \u001B[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001B[0m \u001B[32m1.0/1.0 MB\u001B[0m \u001B[31m60.2 MB/s\u001B[0m eta \u001B[36m0:00:00\u001B[0m\n",
+      "\u001B[2K   \u001B[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001B[0m \u001B[32m412.2/412.2 kB\u001B[0m \u001B[31m34.2 MB/s\u001B[0m eta \u001B[36m0:00:00\u001B[0m\n",
+      "\u001B[2K   \u001B[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001B[0m \u001B[32m261.5/261.5 kB\u001B[0m \u001B[31m19.1 MB/s\u001B[0m eta \u001B[36m0:00:00\u001B[0m\n",
+      "\u001B[2K   \u001B[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001B[0m \u001B[32m46.0/46.0 kB\u001B[0m \u001B[31m4.3 MB/s\u001B[0m eta \u001B[36m0:00:00\u001B[0m\n",
+      "\u001B[2K   \u001B[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001B[0m \u001B[32m86.8/86.8 kB\u001B[0m \u001B[31m8.6 MB/s\u001B[0m eta \u001B[36m0:00:00\u001B[0m\n",
+      "\u001B[2K   \u001B[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001B[0m \u001B[32m50.8/50.8 kB\u001B[0m \u001B[31m4.6 MB/s\u001B[0m eta \u001B[36m0:00:00\u001B[0m\n",
+      "\u001B[?25h"
+     ]
+    }
+   ],
+   "source": "%pip install -q \"redisvl>=0.6.0\" openai langchain-community pypdf"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fXsGCsLQu0Ne",
+   "metadata": {
+    "id": "fXsGCsLQu0Ne"
+   },
+   "source": [
+    "## 1. High-Level Data Flow & Setup\n",
+    "\n",
+    "1. **User Creation & Role Management**\n",
+    "   - A user is stored at `user:{user_id}` in Redis with a JSON structure containing the user’s roles.\n",
+    "   - We can create, update, or delete users as needed.\n",
+    "   - **This serves as a simple look up layer and should NOT replace your production-ready auth API flow**\n",
+    "\n",
+    "2. **Document Storage**\n",
+    "   - Documents chunks are stored at `doc:{doc_id}:{chunk_id}` in Redis as JSON.\n",
+    "   - Each document chunk includes fields such as `doc_id`, `chunk_id`, `content`, `allowed_roles`, and an `embedding` (for vector similarity).\n",
+    "\n",
+    "3. **Querying / Search**\n",
+    "   - User roles are retrieved from Redis.\n",
+    "   - We perform a vector similarity search (or any other type of retrieval) on the documents.\n",
+    "   - We filter the results so that only documents whose `allowed_roles` intersect with the user’s roles are returned.\n",
+    "\n",
+    "4. **RAG Integration**\n",
+    "   - The returned documents can be fed into a Large Language Model (LLM) to provide context and generate an answer.\n",
+    "\n",
+    "First, we’ll set up our Python environment and Redis connection.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "73c33af6",
+   "metadata": {
+    "id": "73c33af6"
+   },
+   "source": [
+    "### Download Documents\n",
+    "Running remotely or in collab? Run this cell to download the necessary datasets."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "48971c52",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "48971c52",
+    "outputId": "e17d146a-43be-41fb-b029-f330d79f1a65"
+   },
+   "outputs": [],
+   "source": [
+    "# NBVAL_SKIP\n",
+    "!git clone https://github.com/redis-developer/redis-ai-resources.git temp_repo\n",
+    "!mkdir -p resources\n",
+    "!mv temp_repo/python-recipes/RAG/resources/aapl-10k-2023.pdf resources/\n",
+    "!mv temp_repo/python-recipes/RAG/resources/2022-chevy-colorado-ebrochure.pdf resources/\n",
+    "!rm -rf temp_repo"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "993371a2",
+   "metadata": {
+    "id": "993371a2"
+   },
+   "source": [
+    "### Run Redis Stack\n",
+    "\n",
+    "For this tutorial you will need a running instance of Redis if you don't already have one.\n",
+    "\n",
+    "#### For Colab\n",
+    "Use the shell script below to download, extract, and install [Redis Stack](https://redis.io/docs/getting-started/install-stack/) directly from the Redis package archive."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "8edc5862",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "8edc5862",
+    "outputId": "df2643ed-2422-4ee5-bd42-bec17b405eec"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "deb [signed-by=/usr/share/keyrings/redis-archive-keyring.gpg] https://packages.redis.io/deb jammy main\n",
+      "Starting redis-stack-server, database path /var/lib/redis-stack\n"
+     ]
+    }
+   ],
+   "source": [
+    "# NBVAL_SKIP\n",
+    "%%sh\n",
+    "curl -fsSL https://packages.redis.io/gpg | sudo gpg --dearmor -o /usr/share/keyrings/redis-archive-keyring.gpg\n",
+    "echo \"deb [signed-by=/usr/share/keyrings/redis-archive-keyring.gpg] https://packages.redis.io/deb $(lsb_release -cs) main\" | sudo tee /etc/apt/sources.list.d/redis.list\n",
+    "sudo apt-get update  > /dev/null 2>&1\n",
+    "sudo apt-get install redis-stack-server  > /dev/null 2>&1\n",
+    "redis-stack-server --daemonize yes"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bc571319",
+   "metadata": {
+    "id": "bc571319"
+   },
+   "source": [
+    "#### For Alternative Environments\n",
+    "There are many ways to get the necessary redis-stack instance running\n",
+    "1. On cloud, deploy a [FREE instance of Redis in the cloud](https://redis.com/try-free/). Or, if you have your\n",
+    "own version of Redis Enterprise running, that works too!\n",
+    "2. Per OS, [see the docs](https://redis.io/docs/latest/operate/oss_and_stack/install/install-stack/)\n",
+    "3. With docker: `docker run -d --name redis-stack-server -p 6379:6379 redis/redis-stack-server:latest`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "qU49fNVnu0Nf",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "qU49fNVnu0Nf",
+    "outputId": "4d2f34c3-6179-4f1d-eff7-5e8e9d8fd58b"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Successfully connected to Redis\n"
+     ]
+    }
+   ],
+   "source": [
+    "import os\n",
+    "\n",
+    "from redis import Redis\n",
+    "\n",
+    "# Replace values below with your own if using Redis Cloud instance\n",
+    "REDIS_HOST = os.getenv(\"REDIS_HOST\", \"localhost\") # ex: \"redis-18374.c253.us-central1-1.gce.cloud.redislabs.com\"\n",
+    "REDIS_PORT = os.getenv(\"REDIS_PORT\", \"6379\")      # ex: 18374\n",
+    "REDIS_PASSWORD = os.getenv(\"REDIS_PASSWORD\", \"\")  # ex: \"1TNxTEdYRDgIDKM2gDfasupCADXXXX\"\n",
+    "\n",
+    "# If SSL is enabled on the endpoint, use rediss:// as the URL prefix\n",
+    "REDIS_URL = f\"redis://:{REDIS_PASSWORD}@{REDIS_HOST}:{REDIS_PORT}\"\n",
+    "\n",
+    "# Connect to Redis (adjust host/port if needed)\n",
+    "redis_client = Redis.from_url(REDIS_URL)\n",
+    "redis_client.ping()\n",
+    "\n",
+    "print(\"Successfully connected to Redis\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "aqzMteQsu0Nf",
+   "metadata": {
+    "id": "aqzMteQsu0Nf"
+   },
+   "source": [
+    "## 2. User Management\n",
+    "\n",
+    "Below is a simple `User` class that stores a user in Redis as JSON. We:\n",
+    "\n",
+    "- Use a Redis key of the form `user:{user_id}`.\n",
+    "- Store fields like `user_id`, `roles`, etc.\n",
+    "- Provide CRUD methods (Create, Read, Update, Delete) for user objects.\n",
+    "\n",
+    "**Data Structure Example**\n",
+    "```json\n",
+    "{\n",
+    "  \"user_id\": \"alice\",\n",
+    "  \"roles\": [\"finance\", \"manager\"]\n",
+    "}\n",
+    "```\n",
+    "\n",
+    "We'll also include some basic checks to ensure we don't add duplicate roles, handle empty role lists, etc.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "38pdjXJvu0Nf",
+   "metadata": {
+    "id": "38pdjXJvu0Nf"
+   },
+   "outputs": [],
+   "source": [
+    "from typing import List, Optional\n",
+    "from enum import Enum\n",
+    "\n",
+    "\n",
+    "class UserRoles(str, Enum):\n",
+    "    FINANCE = \"finance\"\n",
+    "    MANAGER = \"manager\"\n",
+    "    EXECUTIVE = \"executive\"\n",
+    "    HR = \"hr\"\n",
+    "    SALES = \"sales\"\n",
+    "    PRODUCT = \"product\"\n",
+    "\n",
+    "\n",
+    "class User:\n",
+    "    \"\"\"\n",
+    "    User class for storing user data in Redis.\n",
+    "\n",
+    "    Each user has:\n",
+    "    - user_id (string)\n",
+    "    - roles (list of UserRoles)\n",
+    "\n",
+    "    Key in Redis: user:{user_id}\n",
+    "    \"\"\"\n",
+    "    def __init__(\n",
+    "        self,\n",
+    "        redis_client: Redis,\n",
+    "        user_id: str,\n",
+    "        roles: Optional[List[UserRoles]] = None\n",
+    "    ):\n",
+    "        self.redis_client = redis_client\n",
+    "        self.user_id = user_id\n",
+    "        self.roles = roles or []\n",
+    "\n",
+    "    @property\n",
+    "    def key(self) -> str:\n",
+    "        return f\"user:{self.user_id}\"\n",
+    "\n",
+    "    def exists(self) -> bool:\n",
+    "        \"\"\"Check if the user key exists in Redis.\"\"\"\n",
+    "        return self.redis_client.exists(self.key) == 1\n",
+    "\n",
+    "    def create(self):\n",
+    "        \"\"\"\n",
+    "        Create a new user in Redis. Fails if user already exists.\n",
+    "        \"\"\"\n",
+    "        if self.exists():\n",
+    "            raise ValueError(f\"User {self.user_id} already exists.\")\n",
+    "\n",
+    "        self.save()\n",
+    "\n",
+    "    def save(self):\n",
+    "        \"\"\"\n",
+    "        Save (create or update) the user data in Redis.\n",
+    "        If user does not exist, it will be created.\n",
+    "        \"\"\"\n",
+    "        data = {\n",
+    "            \"user_id\": self.user_id,\n",
+    "            \"roles\": [UserRoles(role).value for role in set(self.roles)] # ensure roles are unique and convert to strings\n",
+    "        }\n",
+    "        self.redis_client.json().set(self.key, \".\", data)\n",
+    "\n",
+    "    @classmethod\n",
+    "    def get(cls, redis_client: Redis, user_id):\n",
+    "        \"\"\"\n",
+    "        Retrieve a user from Redis.\n",
+    "        \"\"\"\n",
+    "        key = f\"user:{user_id}\"\n",
+    "        data = redis_client.json().get(key)\n",
+    "        if not data:\n",
+    "            return None\n",
+    "        # Convert string roles back to UserRoles enum\n",
+    "        roles = [UserRoles(role) for role in data.get(\"roles\", [])]\n",
+    "        return cls(redis_client, data[\"user_id\"], roles)\n",
+    "\n",
+    "    def update_roles(self, roles: List[UserRoles]):\n",
+    "        \"\"\"\n",
+    "        Overwrite the user's roles in Redis.\n",
+    "        \"\"\"\n",
+    "        self.roles = roles\n",
+    "        self.save()\n",
+    "\n",
+    "    def add_role(self, role: UserRoles):\n",
+    "        \"\"\"Add a single role to the user.\"\"\"\n",
+    "        if role not in self.roles:\n",
+    "            self.roles.append(role)\n",
+    "            self.save()\n",
+    "\n",
+    "    def remove_role(self, role: UserRoles):\n",
+    "        \"\"\"Remove a single role from the user.\"\"\"\n",
+    "        if role in self.roles:\n",
+    "            self.roles.remove(role)\n",
+    "            self.save()\n",
+    "\n",
+    "    def delete(self):\n",
+    "        \"\"\"Delete this user from Redis.\"\"\"\n",
+    "        self.redis_client.delete(self.key)\n",
+    "\n",
+    "    def __repr__(self):\n",
+    "        return f\"<User user_id={self.user_id}, roles={[UserRoles(role).value for role in self.roles]}>\"\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "FNQxAaoCxPN7",
+   "metadata": {
+    "id": "FNQxAaoCxPN7"
+   },
+   "source": [
+    "### Example usage of User class"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "_WcOlgVyu0Ng",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "_WcOlgVyu0Ng",
+    "outputId": "0776fa25-513b-445b-d46d-35d9333b3a75"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "User 'alice' created.\n",
+      "Retrieved: <User user_id=alice, roles=['finance', 'manager']>\n",
+      "After adding 'executive': <User user_id=alice, roles=['finance', 'manager', 'executive']>\n",
+      "After removing 'manager': <User user_id=alice, roles=['finance', 'executive']>\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Example usage of the User class\n",
+    "\n",
+    "# Let's create a new user\n",
+    "alice = User(redis_client, \"alice\", roles=[\"finance\", \"manager\"])\n",
+    "\n",
+    "# We'll save the user in Redis\n",
+    "try:\n",
+    "    alice.create()\n",
+    "    print(\"User 'alice' created.\")\n",
+    "except ValueError as e:\n",
+    "    print(e)\n",
+    "\n",
+    "# Retrieve the user\n",
+    "alice_obj = User.get(redis_client, \"alice\")\n",
+    "print(\"Retrieved:\", alice_obj)\n",
+    "\n",
+    "# Add another role\n",
+    "alice_obj.add_role(\"executive\")\n",
+    "print(\"After adding 'executive':\", alice_obj)\n",
+    "\n",
+    "# Remove a role\n",
+    "alice_obj.remove_role(\"manager\")\n",
+    "print(\"After removing 'manager':\", alice_obj)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "c911e892",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "c911e892",
+    "outputId": "df4666ff-97ce-4e75-d70c-75fe5d9e6703"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<User user_id=alice, roles=['finance', 'manager']>"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Take a peek at the user object itself\n",
+    "alice"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "P3j6yu8l87j3",
+   "metadata": {
+    "id": "P3j6yu8l87j3"
+   },
+   "outputs": [],
+   "source": [
+    "# Create one more user\n",
+    "larry = User(redis_client, \"larry\", roles=[\"product\"])\n",
+    "larry.create()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "Y7B4l7XVx5md",
+   "metadata": {
+    "id": "Y7B4l7XVx5md"
+   },
+   "source": [
+    ">💡 Using a cloud DB? Take a peek at your instance using [RedisInsight](https://redis.io/insight) to see what user data is in place."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "aCXYFXu0u0Ng",
+   "metadata": {
+    "id": "aCXYFXu0u0Ng"
+   },
+   "source": [
+    "## 3. Document Management (Using LangChain)\n",
+    "\n",
+    "Here, we'll use **LangChain** for document loading, chunking, and vectorizing. Then, we’ll **store documents** in Redis as JSON. Each document will look like:\n",
+    "\n",
+    "```json\n",
+    "{\n",
+    "  \"doc_id\": \"123\",\n",
+    "  \"chunk_id\": \"123\",\n",
+    "  \"path\": \"resources/doc.pdf\",\n",
+    "  \"title\": \"Quarterly Finance Report\",\n",
+    "  \"content\": \"Some text...\",\n",
+    "  \"allowed_roles\": [\"finance\", \"executive\"],\n",
+    "  \"embedding\": [0.12, 0.98, ...]  \n",
+    "}\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d3cJ5DSP5vXt",
+   "metadata": {
+    "id": "d3cJ5DSP5vXt"
+   },
+   "source": [
+    "### Building a document knowledge base\n",
+    "We will create a `KnowledgeBase` class to encapsulate document processing logic and search. The class will handle:\n",
+    "1. Document ingest and chunking\n",
+    "2. Role tagging with a simple str-based rule (likely custom depending on use case)\n",
+    "3. Retrieval over the entire document corpus adhering to provided user roles\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "id": "67d38524",
+   "metadata": {
+    "id": "67d38524"
+   },
+   "outputs": [],
+   "source": [
+    "from typing import List, Optional, Dict, Any, Set\n",
+    "from pathlib import Path\n",
+    "import uuid\n",
+    "\n",
+    "from langchain_community.document_loaders import PyPDFLoader\n",
+    "from langchain_text_splitters import RecursiveCharacterTextSplitter\n",
+    "from redisvl.index import SearchIndex\n",
+    "from redisvl.query import VectorQuery\n",
+    "from redisvl.query.filter import FilterExpression, Tag\n",
+    "from redisvl.utils.vectorize import OpenAITextVectorizer\n",
+    "\n",
+    "\n",
+    "class KnowledgeBase:\n",
+    "    \"\"\"Manages document processing, embedding, and storage in Redis.\"\"\"\n",
+    "\n",
+    "    def __init__(\n",
+    "        self,\n",
+    "        redis_client,\n",
+    "        embeddings_model: str = \"text-embedding-3-small\",\n",
+    "        chunk_size: int = 2500,\n",
+    "        chunk_overlap: int = 100\n",
+    "    ):\n",
+    "        self.redis_client = redis_client\n",
+    "        self.embeddings = OpenAITextVectorizer(model=embeddings_model)\n",
+    "        self.text_splitter = RecursiveCharacterTextSplitter(\n",
+    "            chunk_size=chunk_size,\n",
+    "            chunk_overlap=chunk_overlap,\n",
+    "        )\n",
+    "\n",
+    "        # Initialize document search index\n",
+    "        self.index = self._create_search_index()\n",
+    "\n",
+    "    def _create_search_index(self) -> SearchIndex:\n",
+    "        \"\"\"Create the Redis search index for documents.\"\"\"\n",
+    "        schema = {\n",
+    "            \"index\": {\n",
+    "                \"name\": \"docs\",\n",
+    "                \"prefix\": \"doc\",\n",
+    "                \"storage_type\": \"json\"\n",
+    "            },\n",
+    "            \"fields\": [\n",
+    "                {\n",
+    "                    \"name\": \"doc_id\",\n",
+    "                    \"type\": \"tag\",\n",
+    "                },\n",
+    "                {\n",
+    "                    \"name\": \"chunk_id\",\n",
+    "                    \"type\": \"tag\",\n",
+    "                },\n",
+    "                {\n",
+    "                    \"name\": \"allowed_roles\",\n",
+    "                    \"path\": \"$.allowed_roles[*]\",\n",
+    "                    \"type\": \"tag\",\n",
+    "                },\n",
+    "                {\n",
+    "                    \"name\": \"content\",\n",
+    "                    \"type\": \"text\",\n",
+    "                },\n",
+    "                {\n",
+    "                    \"name\": \"embedding\",\n",
+    "                    \"type\": \"vector\",\n",
+    "                    \"attrs\": {\n",
+    "                        \"dims\": self.embeddings.dims,\n",
+    "                        \"distance_metric\": \"cosine\",\n",
+    "                        \"algorithm\": \"flat\",\n",
+    "                        \"datatype\": \"float32\"\n",
+    "                    }\n",
+    "                }\n",
+    "            ]\n",
+    "        }\n",
+    "        index = SearchIndex.from_dict(schema, redis_client=self.redis_client)\n",
+    "        index.create()\n",
+    "        return index\n",
+    "\n",
+    "    def ingest(self, doc_path: str, allowed_roles: Optional[List[str]] = None) -> str:\n",
+    "        \"\"\"\n",
+    "        Load a document, chunk it, create embeddings, and store in Redis.\n",
+    "        Returns the document ID.\n",
+    "        \"\"\"\n",
+    "        # Generate document ID\n",
+    "        doc_id = str(uuid.uuid4())\n",
+    "        path = Path(doc_path)\n",
+    "\n",
+    "        if not path.exists():\n",
+    "            raise FileNotFoundError(f\"Document not found: {doc_path}\")\n",
+    "\n",
+    "        # Load and chunk document\n",
+    "        loader = PyPDFLoader(str(path))\n",
+    "        pages = loader.load()\n",
+    "        chunks = self.text_splitter.split_documents(pages)\n",
+    "        print(f\"Extracted {len(chunks)} for doc {doc_id} from file {str(path)}\", flush=True)\n",
+    "\n",
+    "        # If roles not provided, determine from filename\n",
+    "        if allowed_roles is None:\n",
+    "            allowed_roles = self._determine_roles(path)\n",
+    "\n",
+    "        # Prepare chunks for Redis\n",
+    "        data, keys = [], []\n",
+    "        for i, chunk in enumerate(chunks):\n",
+    "            # Create embedding w/ openai\n",
+    "            embedding = self.embeddings.embed(chunk.page_content)\n",
+    "\n",
+    "            # Prepare chunk payload\n",
+    "            chunk_id = f\"chunk_{i}\"\n",
+    "            key = f\"doc:{doc_id}:{chunk_id}\"\n",
+    "            data.append({\n",
+    "                \"doc_id\": doc_id,\n",
+    "                \"chunk_id\": chunk_id,\n",
+    "                \"path\": str(path),\n",
+    "                \"content\": chunk.page_content,\n",
+    "                \"allowed_roles\": list(allowed_roles),\n",
+    "                \"embedding\": embedding,\n",
+    "            })\n",
+    "            keys.append(key)\n",
+    "\n",
+    "        # Store in Redis\n",
+    "        _ = self.index.load(data=data, keys=keys)\n",
+    "        print(f\"Loaded {len(chunks)} chunks for document {doc_id}\")\n",
+    "        return doc_id\n",
+    "\n",
+    "    def _determine_roles(self, file_path: Path) -> Set[str]:\n",
+    "        \"\"\"Determine allowed roles based on file path and name patterns.\"\"\"\n",
+    "        # Customize based on use case and business logic\n",
+    "        ROLE_PATTERNS = {\n",
+    "            ('10k', 'financial', 'earnings', 'revenue'):\n",
+    "                {'finance', 'executive'},\n",
+    "            ('brochure', 'spec', 'product', 'manual'):\n",
+    "                {'product', 'sales'},\n",
+    "            ('hr', 'handbook', 'policy', 'employee'):\n",
+    "                {'hr', 'manager'},\n",
+    "            ('sales', 'pricing', 'customer'):\n",
+    "                {'sales', 'manager'}\n",
+    "        }\n",
+    "\n",
+    "        filename = file_path.name.lower()\n",
+    "        roles = {\n",
+    "            role for terms, roles in ROLE_PATTERNS.items()\n",
+    "            for role in roles\n",
+    "            if any(term in filename for term in terms)\n",
+    "        }\n",
+    "        return roles or {'executive'}\n",
+    "\n",
+    "    @staticmethod\n",
+    "    def role_filter(user_roles: List[str]) -> FilterExpression:\n",
+    "        \"\"\"Generate a Redis filter based on provided user roles.\"\"\"\n",
+    "        return Tag(\"allowed_roles\") == user_roles\n",
+    "\n",
+    "    def search(self, query: str, user_roles: List[str], top_k: int = 5) -> List[Dict[str, Any]]:\n",
+    "        \"\"\"\n",
+    "        Search for documents matching the query and user roles.\n",
+    "        Returns list of matching documents.\n",
+    "        \"\"\"\n",
+    "        # Create query vector\n",
+    "        query_vector = self.embeddings.embed(query)\n",
+    "\n",
+    "        # Build role filter\n",
+    "        roles_filter = self.role_filter(user_roles)\n",
+    "\n",
+    "        # Execute search\n",
+    "        return self.index.query(\n",
+    "            VectorQuery(\n",
+    "                vector=query_vector,\n",
+    "                vector_field_name=\"embedding\",\n",
+    "                filter_expression=roles_filter,\n",
+    "                return_fields=[\"doc_id\", \"chunk_id\", \"allowed_roles\", \"content\"],\n",
+    "                num_results=top_k,\n",
+    "                dialect=4\n",
+    "            )\n",
+    "        )\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "YsBuAa_q9QU_",
+   "metadata": {
+    "id": "YsBuAa_q9QU_"
+   },
+   "source": [
+    "Load a document into the knowledge base."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "s1LDdWhKu0Nh",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "s1LDdWhKu0Nh",
+    "outputId": "66e1105e-78ba-425a-8156-c810c7c9054a"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "21:09:47 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "Extracted 34 for doc f2c7171a-16cc-4aad-a777-ed7202bd7212 from file resources/2022-chevy-colorado-ebrochure.pdf\n",
+      "21:09:49 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:09:49 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:09:50 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:09:50 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:09:51 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:09:51 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:09:52 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:09:52 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:09:53 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:09:53 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:09:53 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:09:53 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:09:54 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:09:54 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:09:55 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:09:55 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:09:55 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:09:56 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:09:56 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:09:56 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:09:57 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:09:57 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:09:57 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:09:58 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:10:01 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:10:02 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:10:02 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:10:05 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:10:05 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:10:05 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:10:06 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:10:06 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:10:06 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:10:07 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "Loaded 34 chunks for document f2c7171a-16cc-4aad-a777-ed7202bd7212\n",
+      "Loaded all chunks for f2c7171a-16cc-4aad-a777-ed7202bd7212\n"
+     ]
+    }
+   ],
+   "source": [
+    "kb = KnowledgeBase(redis_client)\n",
+    "\n",
+    "doc_id = kb.ingest(\"resources/2022-chevy-colorado-ebrochure.pdf\")\n",
+    "print(f\"Loaded all chunks for {doc_id}\", flush=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "-Ekqkf1fu0Nh",
+   "metadata": {
+    "id": "-Ekqkf1fu0Nh"
+   },
+   "source": [
+    "## 4. User Query Flow\n",
+    "\n",
+    "Now that we have our User DB and our Vector DB loaded in Redis. We will perform:\n",
+    "\n",
+    "1. **Vector Similarity Search** on `embedding`.\n",
+    "2. A metadata **Filter** based on `allowed_roles`.\n",
+    "3. Return top-k matching document chunks.\n",
+    "\n",
+    "This is implemented below.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "WpvrXmluu0Nh",
+   "metadata": {
+    "id": "WpvrXmluu0Nh"
+   },
+   "outputs": [],
+   "source": [
+    "def user_query(user_id: str, query: str):\n",
+    "    \"\"\"\n",
+    "    Placeholder for a search function.\n",
+    "    1. Load the user's roles.\n",
+    "    2. Perform a vector search for docs.\n",
+    "    3. Filter docs that match at least one of the user's roles.\n",
+    "    4. Return top-K results.\n",
+    "    \"\"\"\n",
+    "    # 1. Load & validate user roles\n",
+    "    user_obj = User.get(redis_client, user_id)\n",
+    "    if not user_obj:\n",
+    "        raise ValueError(f\"User {user_id} not found.\")\n",
+    "\n",
+    "    roles = set([role.value for role in user_obj.roles])\n",
+    "    if not roles:\n",
+    "        raise ValueError(f\"User {user_id} does not have any roles.\")\n",
+    "\n",
+    "    # 2. Retrieve document chunks\n",
+    "    results = kb.search(query, roles)\n",
+    "\n",
+    "    if not results:\n",
+    "      raise ValueError(f\"No available documents found for {user_id}\")\n",
+    "\n",
+    "    return results"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "qQS1BLwGBVDA",
+   "metadata": {
+    "id": "qQS1BLwGBVDA"
+   },
+   "source": [
+    "### Search examples\n",
+    "\n",
+    "Search with a non-existent user."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "wYishsNy6lty",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 287
+    },
+    "id": "wYishsNy6lty",
+    "outputId": "dfa5a8b5-d926-4e94-e8a1-ecceb51ccff5"
+   },
+   "outputs": [
+    {
+     "ename": "ValueError",
+     "evalue": "User tyler not found.",
+     "output_type": "error",
+     "traceback": [
+      "\u001B[0;31m---------------------------------------------------------------------------\u001B[0m",
+      "\u001B[0;31mValueError\u001B[0m                                Traceback (most recent call last)",
+      "\u001B[0;32m<ipython-input-14-e5a00ef91be5>\u001B[0m in \u001B[0;36m<cell line: 0>\u001B[0;34m()\u001B[0m\n\u001B[1;32m      1\u001B[0m \u001B[0;31m# Search with a non-existent user\u001B[0m\u001B[0;34m\u001B[0m\u001B[0;34m\u001B[0m\u001B[0m\n\u001B[0;32m----> 2\u001B[0;31m \u001B[0mresults\u001B[0m \u001B[0;34m=\u001B[0m \u001B[0muser_query\u001B[0m\u001B[0;34m(\u001B[0m\u001B[0;34m\"tyler\"\u001B[0m\u001B[0;34m,\u001B[0m \u001B[0mquery\u001B[0m\u001B[0;34m=\u001B[0m\u001B[0;34m\"What is the make and model of the vehicle here?\"\u001B[0m\u001B[0;34m)\u001B[0m\u001B[0;34m\u001B[0m\u001B[0;34m\u001B[0m\u001B[0m\n\u001B[0m",
+      "\u001B[0;32m<ipython-input-13-1890afcb160d>\u001B[0m in \u001B[0;36muser_query\u001B[0;34m(user_id, query)\u001B[0m\n\u001B[1;32m     10\u001B[0m     \u001B[0muser_obj\u001B[0m \u001B[0;34m=\u001B[0m \u001B[0mUser\u001B[0m\u001B[0;34m.\u001B[0m\u001B[0mget\u001B[0m\u001B[0;34m(\u001B[0m\u001B[0mredis_client\u001B[0m\u001B[0;34m,\u001B[0m \u001B[0muser_id\u001B[0m\u001B[0;34m)\u001B[0m\u001B[0;34m\u001B[0m\u001B[0;34m\u001B[0m\u001B[0m\n\u001B[1;32m     11\u001B[0m     \u001B[0;32mif\u001B[0m \u001B[0;32mnot\u001B[0m \u001B[0muser_obj\u001B[0m\u001B[0;34m:\u001B[0m\u001B[0;34m\u001B[0m\u001B[0;34m\u001B[0m\u001B[0m\n\u001B[0;32m---> 12\u001B[0;31m         \u001B[0;32mraise\u001B[0m \u001B[0mValueError\u001B[0m\u001B[0;34m(\u001B[0m\u001B[0;34mf\"User {user_id} not found.\"\u001B[0m\u001B[0;34m)\u001B[0m\u001B[0;34m\u001B[0m\u001B[0;34m\u001B[0m\u001B[0m\n\u001B[0m\u001B[1;32m     13\u001B[0m \u001B[0;34m\u001B[0m\u001B[0m\n\u001B[1;32m     14\u001B[0m     \u001B[0mroles\u001B[0m \u001B[0;34m=\u001B[0m \u001B[0mset\u001B[0m\u001B[0;34m(\u001B[0m\u001B[0;34m[\u001B[0m\u001B[0mrole\u001B[0m\u001B[0;34m.\u001B[0m\u001B[0mvalue\u001B[0m \u001B[0;32mfor\u001B[0m \u001B[0mrole\u001B[0m \u001B[0;32min\u001B[0m \u001B[0muser_obj\u001B[0m\u001B[0;34m.\u001B[0m\u001B[0mroles\u001B[0m\u001B[0;34m]\u001B[0m\u001B[0;34m)\u001B[0m\u001B[0;34m\u001B[0m\u001B[0;34m\u001B[0m\u001B[0m\n",
+      "\u001B[0;31mValueError\u001B[0m: User tyler not found."
+     ]
+    }
+   ],
+   "source": [
+    "# NBVAL_SKIP\n",
+    "results = user_query(\"tyler\", query=\"What is the make and model of the vehicle here?\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0af59693",
+   "metadata": {},
+   "source": [
+    "Create user for Tyler."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "ZNgxlQSvChx7",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 329
+    },
+    "id": "ZNgxlQSvChx7",
+    "outputId": "d59aad34-2d24-4c87-dd42-b9a44ccaf26b"
+   },
+   "outputs": [
+    {
+     "ename": "ValueError",
+     "evalue": "'engineering' is not a valid UserRoles",
+     "output_type": "error",
+     "traceback": [
+      "\u001B[0;31m---------------------------------------------------------------------------\u001B[0m",
+      "\u001B[0;31mValueError\u001B[0m                                Traceback (most recent call last)",
+      "\u001B[0;32m<ipython-input-15-c95bc0bd8411>\u001B[0m in \u001B[0;36m<cell line: 0>\u001B[0;34m()\u001B[0m\n\u001B[1;32m      1\u001B[0m \u001B[0;31m# Create user for Tyler\u001B[0m\u001B[0;34m\u001B[0m\u001B[0;34m\u001B[0m\u001B[0m\n\u001B[1;32m      2\u001B[0m \u001B[0mtyler\u001B[0m \u001B[0;34m=\u001B[0m \u001B[0mUser\u001B[0m\u001B[0;34m(\u001B[0m\u001B[0mredis_client\u001B[0m\u001B[0;34m,\u001B[0m \u001B[0;34m\"tyler\"\u001B[0m\u001B[0;34m,\u001B[0m \u001B[0mroles\u001B[0m\u001B[0;34m=\u001B[0m\u001B[0;34m[\u001B[0m\u001B[0;34m\"sales\"\u001B[0m\u001B[0;34m,\u001B[0m \u001B[0;34m\"engineering\"\u001B[0m\u001B[0;34m]\u001B[0m\u001B[0;34m)\u001B[0m\u001B[0;34m\u001B[0m\u001B[0;34m\u001B[0m\u001B[0m\n\u001B[0;32m----> 3\u001B[0;31m \u001B[0mtyler\u001B[0m\u001B[0;34m.\u001B[0m\u001B[0mcreate\u001B[0m\u001B[0;34m(\u001B[0m\u001B[0;34m)\u001B[0m\u001B[0;34m\u001B[0m\u001B[0;34m\u001B[0m\u001B[0m\n\u001B[0m",
+      "\u001B[0;32m<ipython-input-6-9f5e400ee42b>\u001B[0m in \u001B[0;36mcreate\u001B[0;34m(self)\u001B[0m\n\u001B[1;32m     47\u001B[0m             \u001B[0;32mraise\u001B[0m \u001B[0mValueError\u001B[0m\u001B[0;34m(\u001B[0m\u001B[0;34mf\"User {self.user_id} already exists.\"\u001B[0m\u001B[0;34m)\u001B[0m\u001B[0;34m\u001B[0m\u001B[0;34m\u001B[0m\u001B[0m\n\u001B[1;32m     48\u001B[0m \u001B[0;34m\u001B[0m\u001B[0m\n\u001B[0;32m---> 49\u001B[0;31m         \u001B[0mself\u001B[0m\u001B[0;34m.\u001B[0m\u001B[0msave\u001B[0m\u001B[0;34m(\u001B[0m\u001B[0;34m)\u001B[0m\u001B[0;34m\u001B[0m\u001B[0;34m\u001B[0m\u001B[0m\n\u001B[0m\u001B[1;32m     50\u001B[0m \u001B[0;34m\u001B[0m\u001B[0m\n\u001B[1;32m     51\u001B[0m     \u001B[0;32mdef\u001B[0m \u001B[0msave\u001B[0m\u001B[0;34m(\u001B[0m\u001B[0mself\u001B[0m\u001B[0;34m)\u001B[0m\u001B[0;34m:\u001B[0m\u001B[0;34m\u001B[0m\u001B[0;34m\u001B[0m\u001B[0m\n",
+      "\u001B[0;32m<ipython-input-6-9f5e400ee42b>\u001B[0m in \u001B[0;36msave\u001B[0;34m(self)\u001B[0m\n\u001B[1;32m     56\u001B[0m         data = {\n\u001B[1;32m     57\u001B[0m             \u001B[0;34m\"user_id\"\u001B[0m\u001B[0;34m:\u001B[0m \u001B[0mself\u001B[0m\u001B[0;34m.\u001B[0m\u001B[0muser_id\u001B[0m\u001B[0;34m,\u001B[0m\u001B[0;34m\u001B[0m\u001B[0;34m\u001B[0m\u001B[0m\n\u001B[0;32m---> 58\u001B[0;31m             \u001B[0;34m\"roles\"\u001B[0m\u001B[0;34m:\u001B[0m \u001B[0;34m[\u001B[0m\u001B[0mUserRoles\u001B[0m\u001B[0;34m(\u001B[0m\u001B[0mrole\u001B[0m\u001B[0;34m)\u001B[0m\u001B[0;34m.\u001B[0m\u001B[0mvalue\u001B[0m \u001B[0;32mfor\u001B[0m \u001B[0mrole\u001B[0m \u001B[0;32min\u001B[0m \u001B[0mset\u001B[0m\u001B[0;34m(\u001B[0m\u001B[0mself\u001B[0m\u001B[0;34m.\u001B[0m\u001B[0mroles\u001B[0m\u001B[0;34m)\u001B[0m\u001B[0;34m]\u001B[0m \u001B[0;31m# ensure roles are unique and convert to strings\u001B[0m\u001B[0;34m\u001B[0m\u001B[0;34m\u001B[0m\u001B[0m\n\u001B[0m\u001B[1;32m     59\u001B[0m         }\n\u001B[1;32m     60\u001B[0m         \u001B[0mself\u001B[0m\u001B[0;34m.\u001B[0m\u001B[0mredis_client\u001B[0m\u001B[0;34m.\u001B[0m\u001B[0mjson\u001B[0m\u001B[0;34m(\u001B[0m\u001B[0;34m)\u001B[0m\u001B[0;34m.\u001B[0m\u001B[0mset\u001B[0m\u001B[0;34m(\u001B[0m\u001B[0mself\u001B[0m\u001B[0;34m.\u001B[0m\u001B[0mkey\u001B[0m\u001B[0;34m,\u001B[0m \u001B[0;34m\".\"\u001B[0m\u001B[0;34m,\u001B[0m \u001B[0mdata\u001B[0m\u001B[0;34m)\u001B[0m\u001B[0;34m\u001B[0m\u001B[0;34m\u001B[0m\u001B[0m\n",
+      "\u001B[0;32m<ipython-input-6-9f5e400ee42b>\u001B[0m in \u001B[0;36m<listcomp>\u001B[0;34m(.0)\u001B[0m\n\u001B[1;32m     56\u001B[0m         data = {\n\u001B[1;32m     57\u001B[0m             \u001B[0;34m\"user_id\"\u001B[0m\u001B[0;34m:\u001B[0m \u001B[0mself\u001B[0m\u001B[0;34m.\u001B[0m\u001B[0muser_id\u001B[0m\u001B[0;34m,\u001B[0m\u001B[0;34m\u001B[0m\u001B[0;34m\u001B[0m\u001B[0m\n\u001B[0;32m---> 58\u001B[0;31m             \u001B[0;34m\"roles\"\u001B[0m\u001B[0;34m:\u001B[0m \u001B[0;34m[\u001B[0m\u001B[0mUserRoles\u001B[0m\u001B[0;34m(\u001B[0m\u001B[0mrole\u001B[0m\u001B[0;34m)\u001B[0m\u001B[0;34m.\u001B[0m\u001B[0mvalue\u001B[0m \u001B[0;32mfor\u001B[0m \u001B[0mrole\u001B[0m \u001B[0;32min\u001B[0m \u001B[0mset\u001B[0m\u001B[0;34m(\u001B[0m\u001B[0mself\u001B[0m\u001B[0;34m.\u001B[0m\u001B[0mroles\u001B[0m\u001B[0;34m)\u001B[0m\u001B[0;34m]\u001B[0m \u001B[0;31m# ensure roles are unique and convert to strings\u001B[0m\u001B[0;34m\u001B[0m\u001B[0;34m\u001B[0m\u001B[0m\n\u001B[0m\u001B[1;32m     59\u001B[0m         }\n\u001B[1;32m     60\u001B[0m         \u001B[0mself\u001B[0m\u001B[0;34m.\u001B[0m\u001B[0mredis_client\u001B[0m\u001B[0;34m.\u001B[0m\u001B[0mjson\u001B[0m\u001B[0;34m(\u001B[0m\u001B[0;34m)\u001B[0m\u001B[0;34m.\u001B[0m\u001B[0mset\u001B[0m\u001B[0;34m(\u001B[0m\u001B[0mself\u001B[0m\u001B[0;34m.\u001B[0m\u001B[0mkey\u001B[0m\u001B[0;34m,\u001B[0m \u001B[0;34m\".\"\u001B[0m\u001B[0;34m,\u001B[0m \u001B[0mdata\u001B[0m\u001B[0;34m)\u001B[0m\u001B[0;34m\u001B[0m\u001B[0;34m\u001B[0m\u001B[0m\n",
+      "\u001B[0;32m/usr/lib/python3.11/enum.py\u001B[0m in \u001B[0;36m__call__\u001B[0;34m(cls, value, names, module, qualname, type, start, boundary)\u001B[0m\n\u001B[1;32m    712\u001B[0m         \"\"\"\n\u001B[1;32m    713\u001B[0m         \u001B[0;32mif\u001B[0m \u001B[0mnames\u001B[0m \u001B[0;32mis\u001B[0m \u001B[0;32mNone\u001B[0m\u001B[0;34m:\u001B[0m  \u001B[0;31m# simple value lookup\u001B[0m\u001B[0;34m\u001B[0m\u001B[0;34m\u001B[0m\u001B[0m\n\u001B[0;32m--> 714\u001B[0;31m             \u001B[0;32mreturn\u001B[0m \u001B[0mcls\u001B[0m\u001B[0;34m.\u001B[0m\u001B[0m__new__\u001B[0m\u001B[0;34m(\u001B[0m\u001B[0mcls\u001B[0m\u001B[0;34m,\u001B[0m \u001B[0mvalue\u001B[0m\u001B[0;34m)\u001B[0m\u001B[0;34m\u001B[0m\u001B[0;34m\u001B[0m\u001B[0m\n\u001B[0m\u001B[1;32m    715\u001B[0m         \u001B[0;31m# otherwise, functional API: we're creating a new Enum type\u001B[0m\u001B[0;34m\u001B[0m\u001B[0;34m\u001B[0m\u001B[0m\n\u001B[1;32m    716\u001B[0m         return cls._create_(\n",
+      "\u001B[0;32m/usr/lib/python3.11/enum.py\u001B[0m in \u001B[0;36m__new__\u001B[0;34m(cls, value)\u001B[0m\n\u001B[1;32m   1135\u001B[0m                 \u001B[0mve_exc\u001B[0m \u001B[0;34m=\u001B[0m \u001B[0mValueError\u001B[0m\u001B[0;34m(\u001B[0m\u001B[0;34m\"%r is not a valid %s\"\u001B[0m \u001B[0;34m%\u001B[0m \u001B[0;34m(\u001B[0m\u001B[0mvalue\u001B[0m\u001B[0;34m,\u001B[0m \u001B[0mcls\u001B[0m\u001B[0;34m.\u001B[0m\u001B[0m__qualname__\u001B[0m\u001B[0;34m)\u001B[0m\u001B[0;34m)\u001B[0m\u001B[0;34m\u001B[0m\u001B[0;34m\u001B[0m\u001B[0m\n\u001B[1;32m   1136\u001B[0m                 \u001B[0;32mif\u001B[0m \u001B[0mresult\u001B[0m \u001B[0;32mis\u001B[0m \u001B[0;32mNone\u001B[0m \u001B[0;32mand\u001B[0m \u001B[0mexc\u001B[0m \u001B[0;32mis\u001B[0m \u001B[0;32mNone\u001B[0m\u001B[0;34m:\u001B[0m\u001B[0;34m\u001B[0m\u001B[0;34m\u001B[0m\u001B[0m\n\u001B[0;32m-> 1137\u001B[0;31m                     \u001B[0;32mraise\u001B[0m \u001B[0mve_exc\u001B[0m\u001B[0;34m\u001B[0m\u001B[0;34m\u001B[0m\u001B[0m\n\u001B[0m\u001B[1;32m   1138\u001B[0m                 \u001B[0;32melif\u001B[0m \u001B[0mexc\u001B[0m \u001B[0;32mis\u001B[0m \u001B[0;32mNone\u001B[0m\u001B[0;34m:\u001B[0m\u001B[0;34m\u001B[0m\u001B[0;34m\u001B[0m\u001B[0m\n\u001B[1;32m   1139\u001B[0m                     exc = TypeError(\n",
+      "\u001B[0;31mValueError\u001B[0m: 'engineering' is not a valid UserRoles"
+     ]
+    }
+   ],
+   "source": [
+    "# NBVAL_SKIP\n",
+    "tyler = User(redis_client, \"tyler\", roles=[\"sales\", \"engineering\"])\n",
+    "tyler.create()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "WWVJF0UVCt4d",
+   "metadata": {
+    "collapsed": true,
+    "id": "WWVJF0UVCt4d"
+   },
+   "outputs": [],
+   "source": [
+    "# Try again but this time with valid roles\n",
+    "tyler = User(redis_client, \"tyler\", roles=[\"sales\"])\n",
+    "tyler.create()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "DXEyktWLC1cC",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "DXEyktWLC1cC",
+    "outputId": "dbb6e93f-3b81-4c14-f329-daf97a613c89"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<User user_id=tyler, roles=['sales']>"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "tyler"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "O0K_rdC7C6OH",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "O0K_rdC7C6OH",
+    "outputId": "f823f253-cf42-4975-f711-6391b36f83bd"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "21:10:21 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "[{'id': 'doc:f2c7171a-16cc-4aad-a777-ed7202bd7212:chunk_13',\n",
+       "  'vector_distance': '0.60664498806',\n",
+       "  'doc_id': '[\"f2c7171a-16cc-4aad-a777-ed7202bd7212\"]',\n",
+       "  'chunk_id': '[\"chunk_13\"]',\n",
+       "  'allowed_roles': '[\"sales\",\"product\"]'},\n",
+       " {'id': 'doc:f2c7171a-16cc-4aad-a777-ed7202bd7212:chunk_11',\n",
+       "  'vector_distance': '0.613630235195',\n",
+       "  'doc_id': '[\"f2c7171a-16cc-4aad-a777-ed7202bd7212\"]',\n",
+       "  'chunk_id': '[\"chunk_11\"]',\n",
+       "  'allowed_roles': '[\"sales\",\"product\"]'},\n",
+       " {'id': 'doc:f2c7171a-16cc-4aad-a777-ed7202bd7212:chunk_19',\n",
+       "  'vector_distance': '0.62441521883',\n",
+       "  'doc_id': '[\"f2c7171a-16cc-4aad-a777-ed7202bd7212\"]',\n",
+       "  'chunk_id': '[\"chunk_19\"]',\n",
+       "  'allowed_roles': '[\"sales\",\"product\"]'}]"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Query with valid user\n",
+    "results = user_query(\n",
+    "    tyler.user_id,\n",
+    "    query=\"What is the make and model of the vehicle here?\"\n",
+    ")\n",
+    "results[:3]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "454ce79b",
+   "metadata": {},
+   "source": [
+    "Search with a valid user, but incorrect roles."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "irqwMseYDSS_",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 394
+    },
+    "id": "irqwMseYDSS_",
+    "outputId": "acb3fe4b-c451-464f-c214-8a90d835f9ef"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<User user_id=alice, roles=['finance', 'manager']> \n",
+      "\n",
+      "21:10:24 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n"
+     ]
+    },
+    {
+     "ename": "ValueError",
+     "evalue": "No available documents found for alice",
+     "output_type": "error",
+     "traceback": [
+      "\u001B[0;31m---------------------------------------------------------------------------\u001B[0m",
+      "\u001B[0;31mValueError\u001B[0m                                Traceback (most recent call last)",
+      "\u001B[0;32m<ipython-input-19-45d2e7b2400d>\u001B[0m in \u001B[0;36m<cell line: 0>\u001B[0;34m()\u001B[0m\n\u001B[1;32m      3\u001B[0m \u001B[0;34m\u001B[0m\u001B[0m\n\u001B[1;32m      4\u001B[0m \u001B[0;31m# Query with valid user\u001B[0m\u001B[0;34m\u001B[0m\u001B[0;34m\u001B[0m\u001B[0m\n\u001B[0;32m----> 5\u001B[0;31m results = user_query(\n\u001B[0m\u001B[1;32m      6\u001B[0m     \u001B[0malice\u001B[0m\u001B[0;34m.\u001B[0m\u001B[0muser_id\u001B[0m\u001B[0;34m,\u001B[0m \u001B[0mquery\u001B[0m\u001B[0;34m=\u001B[0m\u001B[0;34m\"What is the make and model of the vehicle here?\"\u001B[0m\u001B[0;34m\u001B[0m\u001B[0;34m\u001B[0m\u001B[0m\n\u001B[1;32m      7\u001B[0m )\n",
+      "\u001B[0;32m<ipython-input-13-1890afcb160d>\u001B[0m in \u001B[0;36muser_query\u001B[0;34m(user_id, query)\u001B[0m\n\u001B[1;32m     20\u001B[0m \u001B[0;34m\u001B[0m\u001B[0m\n\u001B[1;32m     21\u001B[0m     \u001B[0;32mif\u001B[0m \u001B[0;32mnot\u001B[0m \u001B[0mresults\u001B[0m\u001B[0;34m:\u001B[0m\u001B[0;34m\u001B[0m\u001B[0;34m\u001B[0m\u001B[0m\n\u001B[0;32m---> 22\u001B[0;31m       \u001B[0;32mraise\u001B[0m \u001B[0mValueError\u001B[0m\u001B[0;34m(\u001B[0m\u001B[0;34mf\"No available documents found for {user_id}\"\u001B[0m\u001B[0;34m)\u001B[0m\u001B[0;34m\u001B[0m\u001B[0;34m\u001B[0m\u001B[0m\n\u001B[0m\u001B[1;32m     23\u001B[0m \u001B[0;34m\u001B[0m\u001B[0m\n\u001B[1;32m     24\u001B[0m     \u001B[0;32mreturn\u001B[0m \u001B[0mresults\u001B[0m\u001B[0;34m\u001B[0m\u001B[0;34m\u001B[0m\u001B[0m\n",
+      "\u001B[0;31mValueError\u001B[0m: No available documents found for alice"
+     ]
+    }
+   ],
+   "source": [
+    "# NBVAL_SKIP\n",
+    "print(alice, \"\\n\")\n",
+    "\n",
+    "# Query with valid user\n",
+    "results = user_query(\n",
+    "    alice.user_id, query=\"What is the make and model of the vehicle here?\"\n",
+    ")\n",
+    "results"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c309b53d",
+   "metadata": {
+    "id": "c309b53d"
+   },
+   "source": [
+    "Empty results because there are no documents available for Alice to view. Add some."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "0e5e990b",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 1000
+    },
+    "id": "0e5e990b",
+    "outputId": "b0b1bc64-6b01-47d3-feb4-3d6d1cc8e38d"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Extracted 155 for doc 42b58f50-d689-4a36-8977-e8ca1a183446 from file resources/aapl-10k-2023.pdf\n",
+      "21:10:32 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:10:32 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:10:32 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:10:32 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:10:32 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:10:33 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:10:33 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:10:33 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:10:34 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:10:34 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:10:34 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:10:34 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:10:35 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:10:35 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:10:36 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:10:36 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:10:36 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:10:36 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:10:36 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:10:37 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:10:37 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:10:37 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:10:37 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:10:37 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:10:38 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:10:38 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:10:38 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:10:39 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:10:39 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:10:39 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:10:39 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:10:40 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:10:40 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:10:40 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:10:40 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:10:40 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:10:41 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:10:41 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:10:41 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:10:41 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:10:41 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:10:42 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:10:42 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:10:42 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:10:42 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:10:43 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:10:43 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:10:43 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:10:43 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:10:44 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:10:44 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:10:44 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:10:44 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:10:45 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:10:45 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:10:45 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:10:45 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:10:46 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:10:46 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:10:46 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:10:46 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:10:47 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:10:47 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:10:47 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:10:47 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:10:48 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:10:48 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:10:51 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:10:52 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:10:52 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:10:52 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:10:52 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:10:52 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:10:53 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:10:53 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:10:53 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:10:53 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:10:53 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:10:54 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:10:54 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:10:54 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:10:54 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:10:55 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:10:55 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:10:55 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:10:55 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:10:56 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:10:56 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:10:56 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:10:56 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:10:56 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:10:57 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:10:57 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:10:57 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:10:58 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:10:58 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:10:58 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:10:58 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:10:58 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:10:59 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:10:59 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:10:59 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:10:59 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:11:00 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:11:00 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:11:00 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:11:00 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:11:01 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:11:01 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:11:01 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:11:02 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:11:02 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:11:02 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:11:02 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:11:03 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:11:03 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:11:03 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:11:03 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:11:03 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:11:03 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:11:04 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:11:04 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:11:04 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:11:04 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:11:05 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:11:05 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:11:05 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:11:06 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:11:06 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:11:06 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:11:06 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:11:06 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:11:07 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:11:07 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:11:07 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:11:08 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:11:08 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:11:08 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:11:08 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:11:09 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:11:09 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:11:09 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:11:09 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:11:10 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:11:10 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:11:10 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:11:10 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:11:11 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:11:11 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:11:11 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:11:11 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:11:11 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:11:12 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:11:12 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:11:12 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "Loaded 155 chunks for document 42b58f50-d689-4a36-8977-e8ca1a183446\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.google.colaboratory.intrinsic+json": {
+       "type": "string"
+      },
+      "text/plain": [
+       "'42b58f50-d689-4a36-8977-e8ca1a183446'"
+      ]
+     },
+     "execution_count": 20,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Add a document that Alice will have access to\n",
+    "kb.ingest(\"resources/aapl-10k-2023.pdf\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "9fcf8cc0",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "9fcf8cc0",
+    "outputId": "bce13955-7d37-472b-f820-5588cd3986b4"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "21:11:30 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "[{'id': 'doc:42b58f50-d689-4a36-8977-e8ca1a183446:chunk_81',\n",
+       "  'vector_distance': '0.343286693096',\n",
+       "  'doc_id': '[\"42b58f50-d689-4a36-8977-e8ca1a183446\"]',\n",
+       "  'chunk_id': '[\"chunk_81\"]',\n",
+       "  'allowed_roles': '[\"finance\",\"executive\"]'},\n",
+       " {'id': 'doc:42b58f50-d689-4a36-8977-e8ca1a183446:chunk_68',\n",
+       "  'vector_distance': '0.353579521179',\n",
+       "  'doc_id': '[\"42b58f50-d689-4a36-8977-e8ca1a183446\"]',\n",
+       "  'chunk_id': '[\"chunk_68\"]',\n",
+       "  'allowed_roles': '[\"finance\",\"executive\"]'},\n",
+       " {'id': 'doc:42b58f50-d689-4a36-8977-e8ca1a183446:chunk_72',\n",
+       "  'vector_distance': '0.354550600052',\n",
+       "  'doc_id': '[\"42b58f50-d689-4a36-8977-e8ca1a183446\"]',\n",
+       "  'chunk_id': '[\"chunk_72\"]',\n",
+       "  'allowed_roles': '[\"finance\",\"executive\"]'}]"
+      ]
+     },
+     "execution_count": 22,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Query with valid user\n",
+    "results = user_query(\n",
+    "    alice.user_id,\n",
+    "    query=\"What was the total revenue amount for Apple according to their 10k?\"\n",
+    ")\n",
+    "results[:3]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b3b432e6",
+   "metadata": {
+    "id": "b3b432e6"
+   },
+   "source": [
+    "## 5. Implementing Role-Based RAG from scratch\n",
+    "*with OpenAI and Redis*"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 39,
+   "id": "794b3c41",
+   "metadata": {
+    "id": "794b3c41"
+   },
+   "outputs": [],
+   "source": [
+    "from openai import OpenAI\n",
+    "from typing import List, Optional\n",
+    "import os\n",
+    "\n",
+    "from redisvl.extensions.message_history import MessageHistory\n",
+    "\n",
+    "\n",
+    "class RAGChatManager:\n",
+    "    \"\"\"\n",
+    "    Manages RAG-enhanced chat interactions with role-based access control and chat history.\n",
+    "\n",
+    "    Attributes:\n",
+    "        kb: A KnowledgeBase instance for searching documents\n",
+    "        client: An OpenAI client for chat completions\n",
+    "        model: Name of OpenAI model to use\n",
+    "        sessions: Dict to store active chat sessions\n",
+    "        system_prompt: The default system prompt\n",
+    "    \"\"\"\n",
+    "\n",
+    "    def __init__(\n",
+    "        self,\n",
+    "        knowledge_base: \"KnowledgeBase\",\n",
+    "        openai_api_key: Optional[str] = None,\n",
+    "        openai_model: str = \"gpt-4\",\n",
+    "        system_prompt: str = \"You are a helpful chatbot assistant with access to knowledge base documents\"\n",
+    "    ):\n",
+    "        \"\"\"Initialize the RAG chat manager.\"\"\"\n",
+    "        self.kb = knowledge_base\n",
+    "        self.client = OpenAI(api_key=openai_api_key or os.getenv(\"OPENAI_API_KEY\"))\n",
+    "        self.model = openai_model\n",
+    "        self.sessions = {}\n",
+    "        self.system_prompt = system_prompt\n",
+    "\n",
+    "    def user_roles(self, user_id: str) -> set:\n",
+    "        \"\"\"\n",
+    "        Get and validate user roles.\n",
+    "\n",
+    "        Args:\n",
+    "            user_id: User identifier\n",
+    "\n",
+    "        Returns:\n",
+    "            Set of user roles\n",
+    "\n",
+    "        Raises:\n",
+    "            ValueError: If user not found or has no roles\n",
+    "        \"\"\"\n",
+    "        user_obj = User.get(self.kb.redis_client, user_id)\n",
+    "        if not user_obj:\n",
+    "            raise ValueError(f\"User {user_id} not found.\")\n",
+    "\n",
+    "        roles = set([role.value for role in user_obj.roles])\n",
+    "        if not roles:\n",
+    "            raise ValueError(f\"User {user_id} does not have any roles.\")\n",
+    "\n",
+    "        return roles\n",
+    "\n",
+    "    def start_session(self, user_id: str) -> None:\n",
+    "        \"\"\"\n",
+    "        Start a new chat session for a user.\n",
+    "\n",
+    "        Args:\n",
+    "            user_id: User identifier\n",
+    "        \"\"\"\n",
+    "        if user_id not in self.sessions:\n",
+    "            self.sessions[user_id] = MessageHistory(\n",
+    "                name=f\"session:{user_id}\",\n",
+    "                redis_client=self.kb.redis_client\n",
+    "              )\n",
+    "\n",
+    "    def prep_msgs(\n",
+    "        self,\n",
+    "        user_id: str,\n",
+    "        system_prompt: str,\n",
+    "        context: str,\n",
+    "        query: str\n",
+    "    ) -> List[dict]:\n",
+    "        \"\"\"\n",
+    "        Get chat history messages including system prompt.\n",
+    "\n",
+    "        Args:\n",
+    "            user_id: User identifier for the session\n",
+    "            system_prompt: Optional system prompt to prepend\n",
+    "            context: Relevant context fetched from the knowledge base\n",
+    "            query: Original user question\n",
+    "\n",
+    "        Returns:\n",
+    "            List of message dictionaries\n",
+    "        \"\"\"\n",
+    "        messages = [{\"role\": \"system\", \"content\": system_prompt}]\n",
+    "\n",
+    "        if user_id in self.sessions:\n",
+    "            messages.extend(self.sessions[user_id].get_recent())\n",
+    "\n",
+    "        messages.append({\n",
+    "            \"role\": \"user\",\n",
+    "            \"content\": f\"\"\"Context information is below.\n",
+    "            ---------------------\n",
+    "            {context}\n",
+    "            ---------------------\n",
+    "            Given the context information above and the chat conversation history, please answer the question faithfully: {query}\"\"\"\n",
+    "        })\n",
+    "\n",
+    "        for msg in messages:\n",
+    "            if msg[\"role\"] == \"llm\":\n",
+    "                msg[\"role\"] = \"assistant\"\n",
+    "\n",
+    "        return messages\n",
+    "\n",
+    "    def chat(self, user_id: str, system_prompt: Optional[str] = None) -> None:\n",
+    "        \"\"\"\n",
+    "        Start an interactive chat loop with the user.\n",
+    "\n",
+    "        Args:\n",
+    "            user_id: User identifier\n",
+    "            system_prompt: Optional system prompt\n",
+    "\n",
+    "        The loop continues until user types 'exit' or 'quit'\n",
+    "        \"\"\"\n",
+    "        self.start_session(user_id)\n",
+    "\n",
+    "        print(\"Starting chat session with GPT4. Type 'exit' or 'quit' to end the session.\")\n",
+    "        while True:\n",
+    "            query = input(\"\\nYou: \").strip()\n",
+    "\n",
+    "            if query.lower() in ['exit', 'quit']:\n",
+    "                print(\"\\nEnding chat session...\")\n",
+    "                break\n",
+    "\n",
+    "            response = self.answer(query, user_id, system_prompt)\n",
+    "            print(f\"\\nAssistant: {response}\")\n",
+    "\n",
+    "    def answer(\n",
+    "        self,\n",
+    "        query: str,\n",
+    "        user_id: str,\n",
+    "        system_prompt: Optional[str] = None\n",
+    "    ) -> str:\n",
+    "        \"\"\"\n",
+    "        Process a chat message with RAG enhancement and role-based access.\n",
+    "\n",
+    "        If any exception occurs at any stage (roles, document search, LLM call),\n",
+    "        we do NOT store anything in the session and simply return the error.\n",
+    "        Otherwise, we store the query and the response (including 'no docs found' case).\n",
+    "\n",
+    "        Args:\n",
+    "            query: User's question\n",
+    "            user_id: User identifier\n",
+    "            system_prompt: Optional system prompt\n",
+    "\n",
+    "        Returns:\n",
+    "            AI response string or error message\n",
+    "        \"\"\"\n",
+    "\n",
+    "        # Start or retrieve an existing session for user\n",
+    "        self.start_session(user_id)\n",
+    "\n",
+    "        try:\n",
+    "            # 1. Validate user roles\n",
+    "            roles = self.user_roles(user_id)\n",
+    "\n",
+    "            # 2. Use provided system prompt or default\n",
+    "            system_prompt = system_prompt or self.system_prompt\n",
+    "\n",
+    "            # 3. Search for relevant documents\n",
+    "            docs = self.kb.search(query, roles)\n",
+    "\n",
+    "            # 4. If no documents, store & return early\n",
+    "            if not docs:\n",
+    "                no_docs_msg = (\n",
+    "                    \"I couldn't find any relevant documents you have permission to access. \"\n",
+    "                    \"Please try rephrasing your question or contact an administrator if you believe this is an error.\"\n",
+    "                )\n",
+    "                self.sessions[user_id].store(query, no_docs_msg)\n",
+    "                return no_docs_msg\n",
+    "\n",
+    "            # 5. Prepare context and messages for the LLM\n",
+    "            context = \"\\n\\n\".join([doc.get(\"content\", \"\") for doc in docs])\n",
+    "            messages = self.prep_msgs(\n",
+    "                user_id=user_id,\n",
+    "                system_prompt=system_prompt,\n",
+    "                context=context,\n",
+    "                query=query\n",
+    "            )\n",
+    "\n",
+    "            # 6. Generate response from the model\n",
+    "            response = self.client.chat.completions.create(\n",
+    "                model=self.model,\n",
+    "                messages=messages\n",
+    "            )\n",
+    "            ai_response = response.choices[0].message.content\n",
+    "\n",
+    "            # 7. Store query and LLM response\n",
+    "            self.sessions[user_id].store(query, ai_response)\n",
+    "\n",
+    "            return ai_response\n",
+    "\n",
+    "        except Exception as e:\n",
+    "            # Catch any exception; do not store anything, just return the error.\n",
+    "            return f\"I encountered an error: {str(e)}\"\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "zJdHMGdUCl_S",
+   "metadata": {
+    "id": "zJdHMGdUCl_S"
+   },
+   "source": [
+    "### Session-aware, role-based RAG"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 40,
+   "id": "1HDy2Ltr12I1",
+   "metadata": {
+    "id": "1HDy2Ltr12I1"
+   },
+   "outputs": [],
+   "source": [
+    "bot = RAGChatManager(kb)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 41,
+   "id": "sM6BQ-ZL2LUf",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 89
+    },
+    "id": "sM6BQ-ZL2LUf",
+    "outputId": "b678b1ac-e177-4d16-9af8-2cd2cf2e48c1"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "21:20:45 redisvl.index.index INFO   Index already exists, not overwriting.\n",
+      "21:20:45 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:20:47 httpx INFO   HTTP Request: POST https://api.openai.com/v1/chat/completions \"HTTP/1.1 200 OK\"\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.google.colaboratory.intrinsic+json": {
+       "type": "string"
+      },
+      "text/plain": [
+       "\"The context information provided does not contain any details about a vehicle's make and model.\""
+      ]
+     },
+     "execution_count": 41,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "bot.answer(\"What is the make and model of the vehicle?\", user_id=\"alice\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 42,
+   "id": "3iJdgsaAjsaA",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 89
+    },
+    "id": "3iJdgsaAjsaA",
+    "outputId": "545b9621-e04e-4d96-ade7-5ad1e1311d3c"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "21:20:50 redisvl.index.index INFO   Index already exists, not overwriting.\n",
+      "21:20:50 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:20:51 httpx INFO   HTTP Request: POST https://api.openai.com/v1/chat/completions \"HTTP/1.1 200 OK\"\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.google.colaboratory.intrinsic+json": {
+       "type": "string"
+      },
+      "text/plain": [
+       "'The make and model of the vehicle is Chevrolet Colorado.'"
+      ]
+     },
+     "execution_count": 42,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "bot.answer(\"What is the make and model of the vehicle?\", user_id=\"tyler\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 43,
+   "id": "17CUi5TXBFSB",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 71
+    },
+    "id": "17CUi5TXBFSB",
+    "outputId": "852635cc-01a4-4a02-d07d-4a48eabafbba"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "21:20:54 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:20:55 httpx INFO   HTTP Request: POST https://api.openai.com/v1/chat/completions \"HTTP/1.1 200 OK\"\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.google.colaboratory.intrinsic+json": {
+       "type": "string"
+      },
+      "text/plain": [
+       "'The vehicle is from the year 2022.'"
+      ]
+     },
+     "execution_count": 43,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "bot.answer(\"What year is it?\", user_id=\"tyler\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 44,
+   "id": "N4IV1bLTCj1N",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "N4IV1bLTCj1N",
+    "outputId": "e456deb7-c15d-4a88-ad31-27782be58f72"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Starting chat session with GPT4. Type 'exit' or 'quit' to end the session.\n",
+      "\n",
+      "You: What is the towing capacity of the truck?\n",
+      "21:22:10 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:22:14 httpx INFO   HTTP Request: POST https://api.openai.com/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
+      "\n",
+      "Assistant: The towing capacity of the truck varies depending on the specific model and engine. The 2.5L DOHC I-4 engine has a maximum towing weight rating of 3,500 lbs, the 3.6L DOHC V6 engine can tow up to 7,000 lbs, and the Duramax 2.8L Turbo-Diesel I-4 engine has a maximum towing weight rating of 7,700 lbs. You should always check the specific towing capacity of your vehicle and never exceed it, as this can lead to vehicle damage or unsafe driving conditions.\n",
+      "\n",
+      "You: Is it generally safe to drive? What safety features are available?\n",
+      "21:22:28 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:22:39 httpx INFO   HTTP Request: POST https://api.openai.com/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
+      "\n",
+      "Assistant: Yes, it's generally safe to drive the 2022 Chevrolet Colorado, but keep in mind that safety also depends on the driver's attentiveness and other factors like road conditions. This particular model comes with various safety features such as:\n",
+      "\n",
+      "1. Electronic Stability Control System and Traction Control - this system helps the driver maintain control of the vehicle during tricky driving conditions such as rainy or icy roads.\n",
+      "2. Hill Start Assist - this feature ensures the vehicle doesn't roll backward when you're on a hill and switching your foot from the brake pedal to the gas pedal.\n",
+      "3. Hitch Guidance - this feature assists with dynamic trailering and towing tasks.\n",
+      "4. An integrated trailer brake controller (with available Duramax 2.8L Turbo-Diesel I-4 engine or with available Trailering Package with 3.6L V6 engine).\n",
+      "5. Teen Driver technology - this feature allows parents to set speed and volume limits for their young drivers.\n",
+      "6. Tire Pressure Monitoring System with Tire Fill Alert.\n",
+      "7. The Recovery Hooks on 4x4 models.\n",
+      "8. The vehicle also includes various airbags: dual-stage frontal airbags for both driver and front passenger seat. Seat-mounted side-impact airbags for driver and front passenger; head-curtain airbags for front and rear outboard seating positions.\n",
+      "\n",
+      "However, it's essential to remember that safety features are not a substitute for the driver's responsibility to operate the vehicle safely. It's also crucial always to use seat belts and the correct child restraints for a child’s age and size.\n",
+      "\n",
+      "You: Do you know if it's better than the 2021 version of the truck?\n",
+      "21:22:57 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:23:03 httpx INFO   HTTP Request: POST https://api.openai.com/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
+      "\n",
+      "Assistant: As a chatbot, I don't have personal opinions, but I can share that the 2022 Chevrolet Colorado continues to offer the same strong performance, versatility, and wide range of configurations that made the 2021 model popular. However, specific improvements or changes may vary based on the trim level or optional packages. It's also important to note that 'better' can depend on your personal needs and preferences. If you are comparing the 2021 and 2022 models, consider factors such as performance, fuel economy, safety features, technology, and price to determine which is better for your needs.\n",
+      "\n",
+      "You: Got it. Thank you. That's all for today.\n",
+      "21:25:32 httpx INFO   HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "21:25:34 httpx INFO   HTTP Request: POST https://api.openai.com/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
+      "\n",
+      "Assistant: You're welcome! If you have any more questions in the future, don't hesitate to ask. Have a great day!\n",
+      "\n",
+      "You: quit\n",
+      "\n",
+      "Ending chat session...\n"
+     ]
+    }
+   ],
+   "source": [
+    "# NBVAL_SKIP\n",
+    "bot.chat(user_id=\"tyler\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "SHg3tFa2u0Nh",
+   "metadata": {
+    "id": "SHg3tFa2u0Nh"
+   },
+   "source": [
+    "## 6. Summary & Next Steps\n",
+    "\n",
+    "In this notebook, we set up a **basic** for a Role-Based RAG system:\n",
+    "\n",
+    "1. **Users** (with `roles`) stored in Redis via JSON.\n",
+    "2. **Documents** (with `allowed_roles`) loaded, parsed, embedded and also stored in Redis.\n",
+    "3. A user search pipeline that honors user roles when retrieving documents.\n",
+    "\n",
+    "\n",
+    "This approach ensures that **only documents** whose roles match the user’s roles are returned.\n",
+    "\n",
+    "\n",
+    "With these building blocks in place, you can integrate an LLM to supply a context from the returned docs, producing a robust retrieval-augmented generation pipeline with role-based access controls.\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "accelerator": "GPU",
+  "colab": {
+   "gpuType": "T4",
+   "provenance": []
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
 }

--- a/python-recipes/agents/02_full_featured_agent.ipynb
+++ b/python-recipes/agents/02_full_featured_agent.ipynb
@@ -1,1016 +1,1038 @@
 {
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "qYvD2zzKobTC"
-      },
-      "source": [
-        "![Redis](https://redis.io/wp-content/uploads/2024/04/Logotype.svg?auto=webp&quality=85,75&width=120)\n",
-        "\n",
-        "# Full-Featured Agent Architecture\n",
-        "The following example demonstrates how to build a tool-enabled agentic workflow with a semantic cache and an allow/block list router. This approach helps reduce latency and costs in the final solution.\n",
-        "\n",
-        "Note: This notebook summarizes this [this workshop](https://github.com/redis-developer/oregon-trail-agent-workshop). For a more detailed step-by-step walkthrough of each element, please refer to the repository.\n",
-        "\n",
-        "## Let's Begin!\n",
-        "<a href=\"https://colab.research.google.com/github/redis-developer/redis-ai-resources/blob/main/python-recipes/agents/02_full_featured_agent.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "NTFxCojYECnx"
-      },
-      "source": [
-        "# Setup\n",
-        "\n",
-        "## Packages"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 1,
-      "metadata": {
-        "id": "Zz62U5COgF21"
-      },
-      "outputs": [],
-      "source": [
-        "%pip install -q langchain langchain-openai \"langchain-redis>=0.2.0\" langgraph sentence-transformers"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "### OPEN_AI_API key\n",
-        "\n",
-        "A open_ai_api key with billing information enabled is required for this lesson."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 2,
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "VO0i-1c9m2Kb",
-        "outputId": "ec942dbf-226a-426d-8964-e03831e0dd99"
-      },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "OPENAI_API_KEY:··········\n"
-          ]
-        }
-      ],
-      "source": [
-        "# NBVAL_SKIP\n",
-        "import os\n",
-        "import getpass\n",
-        "\n",
-        "\n",
-        "\n",
-        "def _set_env(key: str):\n",
-        "    if key not in os.environ:\n",
-        "        os.environ[key] = getpass.getpass(f\"{key}:\")\n",
-        "\n",
-        "\n",
-        "_set_env(\"OPENAI_API_KEY\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "Po4K08Uoa5HJ"
-      },
-      "source": [
-        "## Redis instance\n",
-        "\n",
-        "### For colab"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 3,
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "vlF2874ZoBWu",
-        "outputId": "e5e7ebc0-b70c-4682-d70c-b33c584e72d4"
-      },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "deb [signed-by=/usr/share/keyrings/redis-archive-keyring.gpg] https://packages.redis.io/deb jammy main\n",
-            "Starting redis-stack-server, database path /var/lib/redis-stack\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "gpg: cannot open '/dev/tty': No such device or address\n",
-            "curl: (23) Failed writing body\n"
-          ]
-        }
-      ],
-      "source": [
-        "# NBVAL_SKIP\n",
-        "%%sh\n",
-        "curl -fsSL https://packages.redis.io/gpg | sudo gpg --dearmor -o /usr/share/keyrings/redis-archive-keyring.gpg\n",
-        "echo \"deb [signed-by=/usr/share/keyrings/redis-archive-keyring.gpg] https://packages.redis.io/deb $(lsb_release -cs) main\" | sudo tee /etc/apt/sources.list.d/redis.list\n",
-        "sudo apt-get update  > /dev/null 2>&1\n",
-        "sudo apt-get install redis-stack-server  > /dev/null 2>&1\n",
-        "redis-stack-server --daemonize yes"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "#### For Alternative Environments\n",
-        "There are many ways to get the necessary redis-stack instance running\n",
-        "1. On cloud, deploy a [FREE instance of Redis in the cloud](https://redis.com/try-free/). Or, if you have your\n",
-        "own version of Redis Enterprise running, that works too!\n",
-        "2. Per OS, [see the docs](https://redis.io/docs/latest/operate/oss_and_stack/install/install-stack/)\n",
-        "3. With docker: `docker run -d --name redis-stack-server -p 6379:6379 redis/redis-stack-server:latest`\n",
-        "\n",
-        "## Test connection"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 3,
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "My-zol_loQaw",
-        "outputId": "b58c2466-ee10-480c-ad4c-608cbf747e8b"
-      },
-      "outputs": [
-        {
-          "data": {
-            "text/plain": [
-              "True"
-            ]
-          },
-          "execution_count": 3,
-          "metadata": {},
-          "output_type": "execute_result"
-        }
-      ],
-      "source": [
-        "import os\n",
-        "from redis import Redis\n",
-        "\n",
-        "# Use the environment variable if set, otherwise default to localhost\n",
-        "REDIS_URL = os.getenv(\"REDIS_URL\", \"redis://localhost:6379\")\n",
-        "\n",
-        "client = Redis.from_url(REDIS_URL)\n",
-        "client.ping()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "p8lqllwDoV_K"
-      },
-      "source": [
-        "# Motivation\n",
-        "\n",
-        "The goal of the workshop is to create an agent workflow that can handle five Oregon Trail-themed scenarios, mimicking situations that often arise when implementing agent workflows in practice.\n",
-        "\n",
-        "## Scenario 1 - name of the wagon leader\n",
-        "\n",
-        "**Learning goal:** Test basic LangGraph setup and execution. <br>\n",
-        "\n",
-        "**Question:** `What is the first name of the wagon leader?` <br>\n",
-        "**Answer:** `Art` <br>\n",
-        "**Type:** `free-form` <br>\n",
-        "\n",
-        "## Scenario 2 - restocking tool\n",
-        "\n",
-        "**Learning goal:** Agent interaction with custom defined tool and **structured output** for multiple choice questions. <br>\n",
-        "\n",
-        "**Question:** `In order to survive the trail ahead, you'll need to have a restocking strategy for when you need to get more supplies or risk starving. If it takes you an estimated 3 days to restock your food and you plan to start with 200lbs of food, budget 10lbs/day to eat, and keep a safety stock of at least 50lbs of back up... at what point should you restock?` <br>\n",
-        "**Answer:** `D` <br>\n",
-        "**Options:** `[\"A: 100lbs\", \"B: 20lbs\", \"C: 5lbs\", \"D: 80lbs\"]` <br>\n",
-        "**Type:** `multi-choice` <br>\n",
-        "\n",
-        "## Scenario 3 - retrieval tool\n",
-        "\n",
-        "**Learning goal:** Agent implements Retrieval Augmented Generation.\n",
-        "\n",
-        "**Question:** `You’ve encountered a dense forest near the Blue Mountains, and your party is unsure how to proceed. There is a fork in the road, and you must choose a path. Which way will you go?` <br>\n",
-        "**Answer:** `B` <br>\n",
-        "**Options:** `[\"A: take the northern trail\", \"B: take the southern trail\", \"C: turn around\", \"D: go fishing\"]` <br>\n",
-        "**Type:** `multi-choice` <br>\n",
-        "\n",
-        "## Scenario 4 - semantic cache\n",
-        "\n",
-        "**Learning goal:** Implement semantic cache that bypasses expensive agent workflow for known answer. <br>\n",
-        "\n",
-        "**Question:** `There's a deer. You're hungry. You know what you have to do...` <br>\n",
-        "**Answer:** `bang` <br>\n",
-        "**Type:** `free-form` <br>\n",
-        "\n",
-        "## Scenario 5 - allow/block list with router\n",
-        "\n",
-        "**Learning goal:** Implement semantic router that blocks requests for non-related topics.\n",
-        "\n",
-        "**Question:** `Tell me about the S&P 500?` <br>\n",
-        "**Answer:** `you shall not pass` <br>\n",
-        "**Type:** `free-form` <br>\n",
-        "\n",
-        "\n",
-        "\n",
-        "# Final Architecture\n",
-        "\n",
-        "In the end, we are building a workflow like the following:\n",
-        "\n",
-        "![diagram](../../assets/full_featured_agent.png)\n",
-        "\n",
-        "As a reminder for more detail see: [Redis Developer Oregon Trail Agent Workshop](https://github.com/redis-developer/oregon-trail-agent-workshop).\n",
-        "\n",
-        "# Defining the agent with LangGraph\n",
-        "\n",
-        "## Tools\n",
-        "\n",
-        "Tools are functions that the central LLM powered \"agent\" can determine to invoke depending on the situation.\n",
-        "\n",
-        "### Restock tool\n",
-        "\n",
-        "The first tool we will define implements the restocking formula. LLMs are designed to predict text responses, not to perform deterministic math. In this case, the agent will act as a parser, extracting the necessary information from the human query and calling the tool with the appropriate schema.\n",
-        "\n",
-        "One of the advantages of `LangGraph` is that the schema for the tool can be defined as a `pydantic` model. Note: It is also essential to include a well-written `doc_string` with the tool function so the agent can determine the appropriate situation to use the tool."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 5,
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "from langchain_core.tools import tool\n",
-        "from pydantic import BaseModel, Field\n",
-        "\n",
-        "class RestockInput(BaseModel):\n",
-        "    daily_usage: int = Field(\n",
-        "        description=\"Pounds (lbs) of food expected to be consumed daily\"\n",
-        "    )\n",
-        "    lead_time: int = Field(description=\"Lead time to replace food in days\")\n",
-        "    safety_stock: int = Field(\n",
-        "        description=\"Number of pounds (lbs) of safety stock to keep on hand\"\n",
-        "    )\n",
-        "\n",
-        "\n",
-        "@tool(\"restock-tool\", args_schema=RestockInput)\n",
-        "def restock_tool(daily_usage: int, lead_time: int, safety_stock: int) -> int:\n",
-        "    \"\"\"restock formula tool used specifically for calculating the amount of food at which you should start restocking.\"\"\"\n",
-        "    print(f\"\\n Called restock tool: {daily_usage=}, {lead_time=}, {safety_stock=} \\n\")\n",
-        "    return (daily_usage * lead_time) + safety_stock"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "## Retriever tool\n",
-        "\n",
-        "Sometimes an LLM might need access to data that it was not trained on, whether because the data is proprietary, time-sensitive, or otherwise unavailable.\n",
-        "\n",
-        "In such cases, Retrieval-Augmented Generation (RAG) is often necessary. Here, a vector search is used to augment the final LLM prompt with helpful and necessary context.\n",
-        "\n",
-        "RAG and agents are not mutually exclusive. Below, we define a retriever tool that performs RAG whenever the agent determines it is necessary."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 6,
-      "metadata": {},
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "09:04:55 redisvl.index.index INFO   Index already exists, not overwriting.\n"
-          ]
-        }
-      ],
-      "source": [
-        "\n",
-        "from langchain.tools.retriever import create_retriever_tool\n",
-        "\n",
-        "from langchain_redis import RedisConfig, RedisVectorStore\n",
-        "from langchain_core.documents import Document\n",
-        "from langchain_openai import OpenAIEmbeddings\n",
-        "\n",
-        "## Helper methods\n",
-        "\n",
-        "INDEX_NAME = os.environ.get(\"VECTOR_INDEX_NAME\", \"oregon_trail\")\n",
-        "REDIS_URL = os.environ.get(\"REDIS_URL\", \"redis://localhost:6379/0\")\n",
-        "CONFIG = RedisConfig(index_name=INDEX_NAME, redis_url=REDIS_URL)\n",
-        "\n",
-        "def get_vector_store():\n",
-        "    try:\n",
-        "        CONFIG.from_existing = True\n",
-        "        vector_store = RedisVectorStore(OpenAIEmbeddings(), config=CONFIG)\n",
-        "    except:\n",
-        "        print(\"Init vector store with document\")\n",
-        "        CONFIG.from_existing = False\n",
-        "        vector_store = RedisVectorStore.from_documents(\n",
-        "            [doc], OpenAIEmbeddings(), config=CONFIG\n",
-        "        )\n",
-        "    return vector_store\n",
-        "\n",
-        "## Relevant data\n",
-        "\n",
-        "doc = Document(\n",
-        "    page_content=\"the northern trail, of the blue mountains, was destroyed by a flood and is no longer safe to traverse. It is recommended to take the southern trail although it is longer.\"\n",
-        ")\n",
-        "\n",
-        "## Retriever tool\n",
-        "vector_store = get_vector_store()\n",
-        "\n",
-        "retriever_tool = create_retriever_tool(\n",
-        "    vector_store.as_retriever(),\n",
-        "    \"get_directions\",\n",
-        "    \"Search and return information related to which routes/paths/trails to take along your journey.\",\n",
-        ")\n",
-        "\n",
-        "## Store both tools in a list\n",
-        "tools = [retriever_tool, restock_tool]"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "# State\n",
-        "\n",
-        "State is the set of messages that is passed between nodes in our graph so that the proceeding node knows what happened at the last node and so on. In this case, our state will extend the normal `MessageState` but also add a custom field for `multi_choice_responses`. "
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 7,
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "from typing import Literal\n",
-        "\n",
-        "from langgraph.graph import MessagesState\n",
-        "from pydantic import BaseModel, Field\n",
-        "\n",
-        "\n",
-        "class MultipleChoiceResponse(BaseModel):\n",
-        "    multiple_choice_response: Literal[\"A\", \"B\", \"C\", \"D\"] = Field(\n",
-        "        description=\"Single character response to the question for multiple choice questions. Must be either A, B, C, or D.\"\n",
-        "    )\n",
-        "\n",
-        "\n",
-        "class AgentState(MessagesState):\n",
-        "    multi_choice_response: MultipleChoiceResponse\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "# Nodes\n",
-        "\n",
-        "Nodes are steps in the process flow of our agent where functions can be invoked."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 25,
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "from functools import lru_cache\n",
-        "\n",
-        "from langchain_core.messages import HumanMessage\n",
-        "from langchain_openai import ChatOpenAI\n",
-        "from langgraph.prebuilt import ToolNode\n",
-        "\n",
-        "\n",
-        "## Function definitions that invoke an LLM model\n",
-        "\n",
-        "### with tools\n",
-        "@lru_cache(maxsize=4)\n",
-        "def _get_tool_model(model_name: str):\n",
-        "    if model_name == \"openai\":\n",
-        "        model = ChatOpenAI(temperature=0, model_name=\"gpt-4o\")\n",
-        "    else:\n",
-        "        raise ValueError(f\"Unsupported model type: {model_name}\")\n",
-        "\n",
-        "    model = model.bind_tools(tools)\n",
-        "    return model\n",
-        "\n",
-        "### with structured output\n",
-        "@lru_cache(maxsize=4)\n",
-        "def _get_response_model(model_name: str):\n",
-        "    if model_name == \"openai\":\n",
-        "        model = ChatOpenAI(temperature=0, model_name=\"gpt-4o\")\n",
-        "    else:\n",
-        "        raise ValueError(f\"Unsupported model type: {model_name}\")\n",
-        "\n",
-        "    model = model.with_structured_output(MultipleChoiceResponse)\n",
-        "    return model\n",
-        "\n",
-        "### Functions for responding to a multiple choice question\n",
-        "def multi_choice_structured(state: AgentState, config):\n",
-        "    # We call the model with structured output in order to return the same format to the user every time\n",
-        "    # state['messages'][-2] is the last ToolMessage in the convo, which we convert to a HumanMessage for the model to use\n",
-        "    # We could also pass the entire chat history, but this saves tokens since all we care to structure is the output of the tool\n",
-        "    model_name = config.get(\"configurable\", {}).get(\"model_name\", \"openai\")\n",
-        "\n",
-        "    print(\"Called multi choice structured\")\n",
-        "\n",
-        "    response = _get_response_model(model_name).invoke(\n",
-        "        [\n",
-        "            HumanMessage(content=state[\"messages\"][0].content),\n",
-        "            HumanMessage(content=f\"Answer from tool: {state['messages'][-2].content}\"),\n",
-        "        ]\n",
-        "    )\n",
-        "    # We return the final answer\n",
-        "    return {\n",
-        "        \"multi_choice_response\": response.multiple_choice_response,\n",
-        "    }\n",
-        "\n",
-        "\n",
-        "# Function for conditional edge\n",
-        "def is_multi_choice(state: AgentState):\n",
-        "    return \"options:\" in state[\"messages\"][0].content.lower()\n",
-        "\n",
-        "\n",
-        "def structure_response(state: AgentState, config):\n",
-        "    if is_multi_choice(state):\n",
-        "        return multi_choice_structured(state, config)\n",
-        "    else:\n",
-        "        # if not multi-choice don't need to do anything\n",
-        "        return {\"messages\": []}\n",
-        "\n",
-        "\n",
-        "system_prompt = \"\"\"\n",
-        "    You are an oregon trail playing tool calling AI agent. Use the tools available to you to answer the question you are presented. When in doubt use the tools to help you find the answer.\n",
-        "    If anyone asks your first name is Art return just that string.\n",
-        "\"\"\"\n",
-        "\n",
-        "\n",
-        "# Define the function that calls the model\n",
-        "def call_tool_model(state: AgentState, config):\n",
-        "    # Combine system prompt with incoming messages\n",
-        "    messages = [{\"role\": \"system\", \"content\": system_prompt}] + state[\"messages\"]\n",
-        "\n",
-        "    # Get from LangGraph config\n",
-        "    model_name = config.get(\"configurable\", {}).get(\"model_name\", \"openai\")\n",
-        "\n",
-        "    # Get our model that binds our tools\n",
-        "    model = _get_tool_model(model_name)\n",
-        "\n",
-        "    # invoke the central agent/reasoner with the context of the graph\n",
-        "    response = model.invoke(messages)\n",
-        "\n",
-        "    # We return a list, because this will get added to the existing list\n",
-        "    return {\"messages\": [response]}\n",
-        "\n",
-        "\n",
-        "# Define the function to execute tools\n",
-        "tool_node = ToolNode(tools)\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "# Graph\n",
-        "\n",
-        "The graph composes the tools and nodes into a compilable workflow that can be invoked."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 28,
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "from typing import Literal, TypedDict\n",
-        "from langgraph.graph import END, StateGraph\n",
-        "\n",
-        "\n",
-        "# Define the config\n",
-        "class GraphConfig(TypedDict):\n",
-        "    model_name: Literal[\"anthropic\", \"openai\"]\n",
-        "\n",
-        "# Define the function that determines whether to continue or not\n",
-        "def should_continue(state: AgentState):\n",
-        "    messages = state[\"messages\"]\n",
-        "    last_message = messages[-1]\n",
-        "    # If there is no function call, then we respond to the user\n",
-        "    if not last_message.tool_calls:\n",
-        "        return \"structure_response\"\n",
-        "    # Otherwise if there is, we continue\n",
-        "    else:\n",
-        "        return \"continue\"\n",
-        "\n",
-        "\n",
-        "# Define a new graph\n",
-        "workflow = StateGraph(AgentState, config_schema=GraphConfig)\n",
-        "\n",
-        "# Add nodes\n",
-        "workflow.add_node(\"agent\", call_tool_model)\n",
-        "workflow.add_node(\"tools\", tool_node)\n",
-        "workflow.add_node(\"structure_response\", structure_response)\n",
-        "\n",
-        "# Set the entrypoint\n",
-        "workflow.set_entry_point(\"agent\")\n",
-        "\n",
-        "# add conditional edge between agent and tools\n",
-        "workflow.add_conditional_edges(\n",
-        "    \"agent\",\n",
-        "    should_continue,\n",
-        "    {\"continue\": \"tools\", \"structure_response\": \"structure_response\"},\n",
-        ")\n",
-        "\n",
-        "\n",
-        "# We now add a normal edge from `tools` to `agent`.\n",
-        "workflow.add_edge(\"tools\", \"agent\")\n",
-        "workflow.add_edge(\"structure_response\", END)\n",
-        "\n",
-        "\n",
-        "# This compiles it into a LangChain Runnable,\n",
-        "# meaning you can use it as you would any other runnable\n",
-        "graph = workflow.compile()\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "# Evaluate graph structure\n",
-        "\n",
-        "When we invoke the graph, it follows four primary steps:  \n",
-        "\n",
-        "1. **Evaluate Conditional Edge**: The graph evaluates the conditional edge between tools and the agent via the `should_continue` function. This determines whether it should `continue` and call a tool or move to `structure_response` to format the output for the user.  \n",
-        "2. **Invoke Tools**: If it decides to invoke the tools, the response from the tool is appended as a message to the state and passed back to the agent.  \n",
-        "3. **Determine Next Step**: If tools have already been called or are deemed unnecessary, the graph moves to the `structure_response` node.  \n",
-        "4. **Handle Multiple-Choice Questions**: If the question is identified as a **multiple-choice question** within the `structure_response` node, a model is invoked to ensure the response is returned as a literal `A, B, C, or D`, as expected by the game. Otherwise, it simply proceeds forward.  "
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 29,
-      "metadata": {},
-      "outputs": [
-        {
-          "data": {
-            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAUkAAAFlCAIAAADpho2yAAAAAXNSR0IArs4c6QAAIABJREFUeJzt3XdcE/f/B/BPBiQhIYQpS0DEgSigorWKW6riwlkV3LbYOmqddbXWr9U6aofWUb+u1lUH1r03LhQHqIiLIbITIHvn98d9f3z5sgyQ8Lk73s+Hf+CRfPLOJS/u7nN3nw/DZDIhAADtMHEXAACwCsg2APQE2QaAniDbANATZBsAeoJsA0BPbNwF0FB+hkYu1Sulep3OpFUZcZdjFg6PacNh8oUsvoONq7ct7nKABUC2LebVI/nbZPnbp4omrfgGg4kvZDs1smWycJdlHhNC+ZlqhVRvy2Vlpir8Wwv82wj8guxw1wVqjwHXrtTd83vS2ycLfQP5foH8Jm34bBsG7orqRK0wvE1WZKepc9NUnQe5+Lfh464I1AZku06KC3Tn/8x18eJ0GeTM5VNkG222onzd7ZOFTAYjYlwjqv/BaoAg27X3+rH87hnxoM89HVxscNdiRfnvNEc3Zg2b7tXIl4u7FlADkO1aynqpenq7pN9Ed9yF1JPDP7+LiHEXudL5rxjNQLZrI+lmSdYrZeRkD9yF1KvDv2R17OvkGwgdbNQA57drLPuN6vVjWUMLNkJo5GzvKwfzFCUG3IUAs0C2a0atND64VDRspjfuQvAYu8jv0oE83FUAs0C2ayb+n4JmbQW4q8CGw2U08uE8uFiEuxDwYZDtGijK0+VlqAM7CnEXglOnSOd758RGalxu16BBtmsgOb6k61C3+nktuVz+4sULXE+vXs+Rbg8vw6ab7CDb5jKZUNKtYp+WvPp5udGjRx8/fhzX06vn3Yz3/F6JlRoHlgLZNldassK/df1dfanVamv3ROKkZq2fbg6hsw3bhinJteJLgLqDbJvr/VtV83b21mh59+7dkZGR4eHhU6ZMSUhIQAgNHDhQIpEcPnw4LCxs4MCBRFZ///33wYMHf/TRRwMGDNi8ebPB8J9zUWvWrPnkk09u3LgxdOjQsLCw+/fvV3y6xbUIE75LVVqjZWApcB+YufIy1M1CLd9DnpCQsGnTpn79+nXu3Pn27dtKpRIhtHbt2hkzZrRv3z46OtrW1hYhxGKx7t27161bN29v79TU1J07dwqFwpiYGKIRuVy+efPmb775RqVSdejQoeLTLc5OwMx+q7ZGy8BSINvmUkr1dvaWX13Z2dkIoVGjRgUHB0dGRhILW7VqxWazXVxcQkNDiSUsFmvPnj0Mxn9u2MjKyrpy5UpptrVa7dKlS1u3bl3V0y2O78BWlOit1DiwCMi2uRQyg53Q8nd6hYeHC4XCZcuWzZ8/Pzw8vJpHSiSS7du33717VyqVIoTs7f97gMDlckuDXT/shGyFFLJNanC8bR4T4nCZTKbl73N0cXHZuXOnr6/v7Nmzp0yZkp+fX+nDxGJxdHR0QkLCF198sXHjxsDAwNLjbYSQnV19X+PNZjPYNvDlITX4eMzDQEwWw0pbKj8/v99++23Lli2vX79evnx56fKyt/EcPXpUIpFs3ry5b9++QUFB7u4fvv/MqncByYv1Nhy4o5vUINvmsrNnqWRWuU2COF/VoUOHrl27ll5wwuPxCgsLSx9TXFzs6OhYGuni4uLqo1vu6RankOr5QjigIzX4eMzl7sdTyS2f7WfPni1cuHDUqFF2dna3b99u1aoVsbxt27bnzp3bvXu3UCgMDg4OCws7dOjQli1bQkJCrly5cuvWLaPRWFxcLBKJKm223NMDAgIsW7ZWbXT25Fi2TWBZrLI7gaAaKpkh/bnCv42FT4OVlJS8fPnywoULCQkJ7dq1W7x4sUAgQAgFBwenpqaeOXPmxYsXQUFBvXr1MhqNhw8fvnz5cuPGjZctW/bo0SOlUhkWFnbr1q20tLRx48aVbbbc05s0aWLZsm/EFbb+WCgQwbaBvGBsBnNpVMY9K9I/X+2PuxD81ArD3tUZU1fCqiA1+LtrLg6P6d9GkJehrmbYsPXr1586dari8sDAwJSUlEqfsmvXLotvVMuJj49funRppb/y9vbOysqqaVXvXqlbdXKwaI3A8mC7XQPvX6sSzkmGzvCq6gHFxcXEhWXlMBhVrmc3Nzc227p/YdVqtUQiqfRXVRVWfVW7lqePnO0NO+QkBx9PDXgF8Fg2jIwUZVVjholEoqo6tzDicrmenp6Wai3pZol/Gz4Em/zgHFjNdBnskvpAhrsKnNKeKboMcsFdBfgwyHbNOHvYejfnXT5Y+dVjtBe3MatDhCPbFq5aoQDIdo21+khoy2HeOSXGXUh9u/BXXkCovWfTehqdAtQR9KXV0pPrxSqFsVOkE+5C6snFvXnN2tn7tYLBySkDttu1FNJdxGCgM7tycBdidXqt6dCGd14BPAg2tcB2u07eJCmuHclv38sxtAfpusct4u4ZceYLZY8Rbm4+cIUpxUC268pgQHdOFqYmykK7i/yC+M4edJiYPi9DnfVKdfes+KN+zmF9HBH0nVEQZNsylDJDcnzJmyS5XmcMCLZnsBBfyLZ3ZBsM1Fi9TAZDKtEpZQYGAz2/JxU6sQNC7UO6i5hw0EZZkG0Lk4p12WkaeZFOKdMzmAx5sYVv+U5PT+dyuebcv10jfAcWk8GwE7LsHW28Anh29nSbS7wBgquLLEzobCN0tuJEtmvX/unk69v/U2sNhAZoA3a5AKAnyDYA9ATZphihUMjlVnmTKQClINsUI5VK1WoY9B98GGSbYjgcjrXv9wb0ANmmGI1Go9fDoP/gwyDbFMPj8WxsrHiODdAGZJtiVCqVTqfDXQWgAMg2xTg6OvJ4cAc1+DDINsUUFRWpVCrcVQAKgGwDQE+QbYrhcrksFtzIAT4Msk0xarW67Oy8AFQFsk0xXC4XzoEBc0C2KUatVsM5MGAOyDYA9ATZphihUMjhwLCE4MMg2xQjlUo1Gg3uKgAFQLYBoCfINsWIRCIYmwGYA7JNMcXFxTA2AzAHZBsAeoJsUwzcBwbMBNmmGLgPDJgJsg0APUG2KQbGMAZmgmxTDIxhDMwE2QaAniDbFAPjkwMzQbYpBsYnB2aCbFMM3AcGzATZphi4DwyYCbINAD1BtimGx+NBXxowB2SbYlQqFfSlAXNAtilGJBLBvSLAHJBtiikuLoZ7RYA5INsUA9ttYCbINsXAdhuYCbJNMXw+39bWFncVgAIYJpMJdw3gwwYPHkx8UjKZjM1mE7vlDAbjxIkTuEsDJAVnSqnBzc0tMTGxdAbP4uJio9HYp08f3HUB8oJ9cmqIjo52dnYuu8TFxWXChAn4KgJkB9mmhp49e/r5+ZX+12QyBQcHBwUFYS0KkBpkmzLGjBkjFAqJn52dnadMmYK7IkBqkG3K6N27d7NmzUwmE7HRDgwMxF0RIDXINpWMHj1aJBI5OztPnToVdy2A7KCf3PLUSmNhlkatMli85cZOHVr59nJ0dGRrvF8/kVu8fb4928WLY8NhWLxlUP/g/LYlmUzo/F95714ovJrzDXrqrVid2iDO0QSECHqOcsNdC6gryLbF6DSmI79lte3l7BVgh7uWOkl9UPL+tWJIrCfuQkCdQLYtZv/azPAod8dGdLggNC1Z/u6lbMBkD9yFgNqDvjTLSL0v82rKp0ewEUJN2giYTGb2G5jkgMIg25aRn6Xh8lm4q7AkGw5TnAODLlIYZNsyNCqj0IUmG22Cg4utQgqDN1EYZNsytCqD0WDEXYUlGfRGA0SbyiDbANATZBsAeoJsA0BPkG0A6AmyDQA9QbYBoCfINgD0BNkGgJ4g2wDQE2QbAHqCbANAT5BtmjMYDMnJj3FXATCAbNPcup/+teGXVbirABhAtsnufXZWXcbG0WrgHuwGCsY5xUOr1f751/YrV87nF+Q5O7t8EjFg4oRYYrovnU63c9eWS5fPqlTK4OB2L1+mjIuZOmTwCITQo8cPtv9705s3Lx0dndqGdpg6ZbqzswtCaNCQHrO/WhQff/XuvXg+XzBo4PAJ4z9DCP24dvnVaxcRQj17hyGEDv991sXFFfdbB/UEso0Hi8VKTLz3cedunh7er1+n7t23095eOGpkDEJo6x+/njhxZOqU6S4ublu2/qzRqPv3G4wQSnyY8M2iWRF9IodGfSqTlhyNOzBn3rRtW/ZyuVyE0I9rvps4IXb06AnXrl3cvWdbi+aBnTqFx4ydXJCfl5PzftE3KxBCDg4i3O8b1B/INh4sFmvz73sYjP+MBJ6dk3Xj5pVRI2MMBsOpU3EDIqM+HTWOmPfrh1VLk58+bt+u48ZN6wYNHDZr5gLiKWFhnSZMGnH/wZ2u4T0RQpH9h0SPnYQQCmja/PSZfxIe3OnUKdzb28fBQSQpErdpE4r17QIMINvYFBVJ/vxr+/0Hd2UyKULIXmCPECopKdZqtV5ejYnHED/IZNLc3JyMjLT379+dOn2sbCP5+XnED1wuj/iBxWK5urqJCwvq/Q0BcoFs4yGRiD+fFs3j2U2e9IWnp/fOnZvfZWUQu80CviA5+fHIEdEIoZSUpwihpv7NiorECKEJ4z/v1rVX2XacnFwqNs5msQ1Gy89qAqgFso3HiZNHi4okv2/c3aiRO0LIzc2dyDaLxRozZuL2f29a+cMSFxe34ycODx82pnFj33fvMhBCGo3ax8fPjOb/BwxB3zDBOTA8pNJikciRCDZCqERaXJrAqCGjOoR1KiqSyOWyJYtXzpg+FyHk7e3TqJH72XMnVCoV8TC9Xq/T6T74QlwuTyIRG420GqcRmAOyjUdoaJhEIt65a8u9hNvrf1p5796twsKCkpJihNC/flgsFDpERka1bduBgRh5ebkIIQaDMf3LuWJx4fSZE/85fjgu7uD0GROPnzj8wRcKCW4nk0k3/Lzq/PlTT548rJc3B0iBtXz5ctw10MGrR3KRG8fB7CHKfX2bmEzGf44fvnnjsqdX43lzlyUnP1KplKGhYUVF4lOn4y5fOX/j5pUrVy8c++dv90aeTZs29/Vp0rJFq6SkRxcunk558bSpf7OIiAHE+e0DB3c3a9ayQ1gnovFTp+L4fEGvnn0RQv7+ATJZyeUr554kPfT29g0MbG1mhQXv1CajyacFtec2a8hgPjDLOLMjx7e1vU9LQd2bMhgMxEUsCCGpTPrNollsNvu3X/5d95Zr5NntIoPO2GWwcz2/LrAU6EsjnZ82/PDmzcuPP+4mEjlmvkt/+/bVgAFDcRcFqAeyTTodO3bOz889Grdfp9N5eHiNH/cZcT4MgBqBbJNOj+59enTvg7sKQHnQTw4APUG2AaAnyDYA9ATZBoCeINsA0BNkGwB6gmwDQE+QbQDoCbINAD1BtgGgJ7jm1DL4IrqtSRabaWvuHauAjGC7bRksW11hFq1G+c/LUAmdbXBXAWoPsm0Be/fu/ef8v2VFHx7hiEJUcr1PCz7uKkDtQbbrJC8vjxhscP2mb72acuOP5eGuyDIu78tu18sxt+Ad7kJA7cG4K7Wk1+uXLFkSFRX18ccfly5MviV9m6xo3JLv4sll2zCwFlgbGqVRkqt5eruo50g3n5a8mJiYmJiYfv364a4L1AZku5bi4+PVanWfPuVvtM5+q065J1XI9MV5VtlFl8tlLBaLx7PKMGYCEdvZ0za0u8jB5T9H2qdPnx4wYEBhYaGLSyUDoQMyg2zXzOvXr5ctW3bgwAEsr56TkxMbG8tisY4dO2bGwy1m69atDAYjNja2Pl8U1BEcb5uL+CN4/PjxH3/8EVcNBw4ceP/+fXZ29sGDB+vzdadNm8ZgMNRqtVKprM/XBXUB222znDp16uXLl3PmzMFYQ0FBweTJk3NychBCvr6+R48erecCTCbTkydP7ty588UXX9TzS4NagO32B6hUKqVS+erVK7zBRgj9+eef2dnZxM+5ublxcXH1XACDwQgNDbWxsbl06VI9vzSoBch2ddavX5+WlsbhcL7++mu8leTl5V2/fr10Tl+NRrN//34slUydOrVTp04IoS1btmApAJgJsl2lP/74w8vLq1WrVqUzAWB0+PDh0o02ITs7u/433QSBQIAQ4vF4v/76K5YCgDngeLs8qVS6devWBQsWaLVaW9JcUR0VFZWVlVVuIZaj7rKKioocHR0vXrwYERGBsQxQKbrd4VB3X3755bx58xBC5Ak2Quiff/4hfli7dq2vr++nn36KuyKEEHJ0dEQIcbncESNGHDlyBHc54H9Atv/j7du3mZmZPXr02Lt3L+5aqsPlcm1syHULR9euXZs0aYIQSk1NbdGiBe5ywH/A8TZCCL1//37hwoWhoaG4C/kwpVJpMBhwV1Get7c30ZH+6aefwjlwkmjo2X769Gl+fj6LxTp8+LBIJMJdjllKe8vJpnnz5j/88MPDhw9VKhXuWkDDzvatW7fWrVvn5OTk7u6OuxZzcTgcLpeLu4oqBQQEhIeHm0ym2NhYvV6Pu5wGrYFm+82bN8S5nD179rDZVOp0kEgkTCbZPzU7O7vPPvuM5D0XtEf2b4k17N27d9euXQihkJAQ3LXUmMlk4vF4uKv4sLCwsIkTJyKENmzYgLuWBqphZVsmkxEXXaxcuRJ3LbUkFov5fCoNhxIcHEycUwT1rAFle//+/ZcvX0YIDR8+HHcttUdcLoK7ihro06fPd999hxBKSEjAXUvD0lCy/fr165ycnKioKNyF1FVxcTG1so0Qsre3J3aaZs+ejbuWBoRK3Ui1c//+fV9fX3d397lz5+Kupa6MRiODwaDoECi9e/e2tbWVy+WlV6QDq6L5djshIWHHjh1ubm70+DJlZGRQ62C7nK5duwoEgtevX//999+4a6E/mmebyWRu3boVdxUWk5GR4efnh7uKugoNDc3IyHj16hXuQmiOntlOT08nDq3DwsJw12JJhYWFrVu3xl2FBSxYsMDR0TE/P5/YRQfWQM9sHz58uPTGKTq5e/cuDbbbBBcXFycnpwEDBuTn5+OuhZ7olu1Dhw4hhObPn4+7EKt4/PgxFa+3qQqbzb5+/XpSUhIMImANtMr2qlWrPDw8cFdhLe/evRMIBJQ7AfZBffr0MZlMq1evxl0I3VR5DoxaB0JGo5HJZI4dO9bFxaWayk0mE3GulYpSUlIqTnVAD0wms1mzZsQ8B7hroY8qs02hu3CNRqNcLhcKhXZ2dtWXzWAwqJvtM2fOUPqKuuqNGDGi4qBRoC7osE+uUCiEQiHuKqxLr9ffvXu3a9euuAuxImKAh06dOmm1Wty10AEdsk3dTbH5rly50rNnT9xV1If4+PhDhw5B71rdUTjber2+pKQEdxX15NmzZw1kPk02mx0TE6PX61NTU3HXQm3Ysv3ixQuNRlN2yYYNG7766iszn240Go1Go4ODg3WqI5fCwsJz5851794ddyH1x8bG5vvvvy8qKsJdCIXhyfbFixfnzJmjVqvLLrSzs6vRqAOkGmPYqg4ePDh69GjcVdS3/fv3Jycn466CwvDcB1ZpZ8m0adPMea7JZJJIJM7Ozlaoi6QOHjx48eJF3FVg0K1bt2vXroWGhlJlmEpSqXJekYpXAqrV6oMHD16/fl0sFru5ufXu3XvUqFEsFksikWzfvv3BgwcGg6FVq1ZTpkwhRqtesWKFt7c3i8U6d+6cXq/v0KHD9OnT+Xz+xYsXf/7559Jmv/7664iIiIkTJ+bn57dq1Wr9+vUIoZEjR06fPv3OnTsJCQl8Pj8yMnLs2LEIoUePHi1ZsmTDhg0tW7Yknj506NDBgwdPmjSJmAFv+/btjx494nA4TZs2HT9+fPPmzf/n3TIYrq6uVliNVnTu3LlXr17NnDkTdyHYDB48eMuWLV5eXrgLoRhz98kNBsPy5cvj4uK6dOkye/bs8PDwrKwsFoulVqsXLVr0+PHjyZMnz5gxQywWL168uPTqkbi4uLy8vOXLl8fGxsbHxxOzRoeFhQ0bNgwhtHz58nXr1hG3c8yaNatp06ZlX3HDhg3+/v5r167t1avX3r17Pzhqh0QimTdvnkwmi42NnTRpkl6vX7BgQXp6ei1XDGmsX79+3LhxuKvA6cSJEzweD3rOa8rcffL4+PikpKSvvvqqb9++ZZdfvXr13bt3q1atIgbuDwoKmjx58okTJ4jNrJeX1/z58xkMRosWLW7dupWYmDhlyhRHR0fiytAWLVqUdoa1a9cuLi6u7BH4J598QsyM4+/vf/78+YcPH7Zp06bcIXpZBw4cEIlEq1atIsYt7dWr19SpU8+fPx8bG1vblYPfrl27oqKiYI+Uz+cfP36cBsPm1Cdzs52YmMjhcCpe85iUlMTn80tn5GjUqFHjxo1fvnxJ/JfD4ZQOlN+oUaOUlBTzKysdhZvFYjk7OxcWFjIYjGqG5n7w4EFBQUHZK7d0Ol1BQYH5r0g2Op1u27Ztd+/exV0IfhwOx8/Pb+XKlUuXLsVdC2WYm+2ioiInJ6eKs9UqlcpyJ6Ls7e0lEkklr8Rm13qyGzabbTQaqx9zv6ioqGPHjsSBdylKj1KyYcOGOXPm4K6CLEJDQwMCAmQyWUO4VMkizM22QCCo9GSjs7Pzixcvyi4pKioys7/K/CMok8lkNBqrny5HIBBIpdLGjRub2SbJpaSkvHjxYuHChbgLIRFiPCaDwQAHKeYwty8tJCRErVZfu3atdAkxI0xgYKBMJiuNd1paWnZ2dlBQUPWtEVvgSjfvlTIYDMRkGsSHKhaLieUSiaR0YprQ0NDnz5+XHamH0rNSzZkzZ82aNbirIB0/P79yPT6gKuZut3v27Hny5MkNGza8fPnS398/PT390aNHGzdu7Nmz56FDh1avXj1mzBgGg3Hw4EEHB4cP3qnXqlUrFou1bdu2iIgIrVYbGRn5gSr/f1ofb29vNze3gwcPikQilUq1Z88eYnuOEIqOjr5///7SpUuHDh0qEokSExMNBsO3335r5hsklR9//HHKlClubm64CyEdNpt97NixxMTE9u3b466F7MzdbnM4nNWrV/fu3fvq1aubN29OTEwMDw/X6/VsNnvlypXNmjXbvn37tm3bvL29165d+8HxAzw8PGbOnJmVlbVt27YbN25U/+DS9BIf7eLFi9ls9tKlS3fu3Dl27NjSq9M8PDzWr18fGBh46NChP/74o6SkhKI3V9y+ffv9+/cjRozAXQhJeXp6QrDNUYNrV7DQ6XQVu+tqjRLXrsTGxm7evLlityUolZubu2DBgj///BN3IaRG9vvA9Ho9Jaa2s5SYmJjZs2dDsKvn7u7eu3fvM2fO4C6E1Mi+3bYskm+3V6xYERISMmTIENyFADog+3Zbp9PhLqGeHDx4kMfjQbDNl5KSQsyjDipF6mxrtVpKn8cyX1JS0uPHj+k69LKVuLq6Tp8+HXcV5EXqfXKtVmsymTgcjqUaJOc+eXZ2dmxs7MmTJ3EXQj0nTpxo3rx56U2BoCxSZ9viSJhttVrdu3fvW7du4S4E0E2V2S57VhmXZ8+eubm5WTCNRqOx9DIYkujatev58+ft7OxwF0JVe/bsGTlyJKzAiqo83maSwL59+5KTky3YINmCHRUVdeDAAfhe1kVubu6pU6dwV0FG5PqulxMcHEy2XWgL+uyzz9asWUMMyg1q7fPPP09LS8NdBRlVuU8OrCo6OnrZsmXQCQSsh9TnwF69ekXLP8kxMTEQbAtavHgxjIhaEdmzvXPnTtxVWFh0dPSSJUsg2Bbk4eGRmJiIuwrSIfvx9pMnT3BXYUnDhg3bv39/9QPIgJoaP348zFJQERxv158BAwb8+uuvAQEBuAsBDQKp98kRQo8fPy4uLsZdhQV07959x44dEGxr0Ol0M2bMwF0F6ZA928nJybt378ZdRZ0UFxeHhYWdPn3a3d0ddy30ZGNj8+LFC9gtL4fs2R40aBClhxZKTU2NiYl58OCBQCDAXQudHTx4ENZwOXC8bUXx8fGbN2/ev38/7kJAQ0T27TZC6Pnz51Qcf//YsWNHjhyBYNePn3/++dGjR7irIBdSnwMjNG/evEuXLvfu3cNdSA38/vvvMpnsl19+wV1IQ5GTk2P+kNgNBDX2yR88eODk5OTv74+7ELMsXrw4ICBg8uTJuAtpQNLS0hwcHJycnHAXQiLUyDaFTJgwYezYsTA+PsCOAsfbhO+//57kR90lJSVfffXV/PnzIdj1b8WKFefOncNdBblQZrv97NmzAwcOrFy5MiIiQiwWR0dHz507F3dR/5WUlDR79uyjR49+cN4FYEF9+vQhxntWKBQ2NjbERBQCgeDo0aO4S8OPAn1phKCgoPj4+Hbt2jGZTAaDYcFB1Oru4sWL+/fvv3LlCu5CGhyBQJCVlUX8TMzNbjQa27Zti7suUqBAtqOiosRisUKhIMZOIRZaaqaRutu4cSODwdi1axfuQhqigQMHbtmypezsrl5eXtHR0ViLIgsKHG8HBwdzOJzSVBNIMgnzvHnz7O3t4WJmXEaPHu3j41N2SevWrdu0aYOvIhKhQLZXrFgRHR3t4eFRuoTFYpWLOhYjRowYOHDgxIkTcRfScAkEgv79+5dut93d3WGjXQp/QswxadKk+fPnBwQEED1/bDbbxsYGYz0ZGRlhYWHr16/v0aMHxjIAQmjs2LGlm+6QkJDWrVvjrogsqJFthFC3bt3WrVsXFBTEZDJZLBbGvrQbN258/fXX9+/f9/Pzw1UDKCUQCAYNGsRisdzd3UePHo27HBIhRV+avMhgMHx4OHQhz33jhh3r1q17+vSpScsrKazXqcJYLKbAkRUXF3fz5s24uLj6fOlaKynQIYYZj6O4vr2Gnj1xPSAgwMejZT1/K7AgvooffBjm89vXjxa+TJS6+fCK87XmP8ug17PqfaRxkZttfqbKzq0kejbZT7FIxbrbpyRvkmQ+LQWSHA3ucoCFidxs8jPVLcKE3Ya5VPMwbNk26E37Vme2j3Bp5Mfj8KhxaKBRGfMyVIkXC6O/8WGxSbpBLM7XH9uc1XuMp4OrLROm8aYpjdKYm656eLm6ryK2bP/1Q0bXYR7OnrYcp+CcAAAWvUlEQVRYXr0uJDma60dyxy/1xV1IJaRiXdzG98O/ho6ABkGcrbkZlztuSeVfRTzZfnytWKtlBH5ElutPaupFQgmbbWrbU4S7kPLO/5kX+JGjozv1/mKC2km5V2LLMYV2r+SriGdnOOuVSiAiRTde7fAd2FmvyTgx+OsnMgdXCHYDwhey31fxVcR1oMtwdCPRBeE15ejGYZCvA7qkQOfTUgDH2A2KYyMOMlX+VcST7aJ8jZEi959VymgyFeWRr/+ZgYpyyVcVsCaj0VRUUPmHTo0OagBATUG2AaAnyDYA9ATZBoCeINsA0BNkGwB6gmwDQE+QbQDoCbINAD1BtgGgJ8g2APREmWwbDIbk5Md1bOTX39YMG/GJhSqiLYus6ko9T3mq0cAV7/WEMtle99O/NvyyCncVDYKVVvW58yenz5ioVpPx3lhaoky2tfD3vr58cFXXbjyPumyxLTKCCFWmvrMUamT7x7XLr167mJ7+tmfvsJ69w3JysxFCer1++783jRjVL6Jvp6mfj4m/da308c9Tns6aPbVv/85DhvZes/Z7qUxaabP7D+weNTqy/4DwmV9NSXyYUI9viCzu3o2fPPXTfpFdJk4eGXfs76pWNXEsc/v2jZjxQ3v2Dnv46P6OnZs/6fdxaTsvUp/37B12L+E28d/k5Mfz5n8ZObBr5MCui5bMfvnqxbnzJ3/59UeEUNSwPj17h507fxIhVE0jFV8RIfTo8YMvZ0zs27/z6LED16z9XiwurP7dXbt+qWfvsPj4azO/mhLRt9Ou3VuJacM2/f7T0OERAwZ1m/bFuCtXLxAPfvcuY87caf0HhI8aHbnh51VGoxEhNGhIj/kLps+YNblfZJdPxwzYuWuLXq8nHi8WF678YcmgIT36DwhfsHDG27evieVHju7/csbEq9cuxoyL6j8gfNbsqZmZ6VWt7WrqqTtqDH4SM3ZyQX5eTs77Rd+sQAg5O7kghNb/tPLS5bMx0ZP9/Jpeunx22bfzfv15e3Bw2/T0t3PnTfPza7pg/nclxUW7dm/Nz8/9af2Wcm0mPkzY/u9NvXv3+6hD54T7t1VKJaY3h41Go1m+YqGfr//cOUvT0l6LxQVVrWqEkEIh37Fr8+yvvlGrVe3adnj8+EFVzd5/cHfR4q+a+jebFjvbaDTeuXPDoNd/1LHLqJExhw7vXf3DL3y+wNvbp6qnlyr3iokPE75ZNCuiT+TQqE9l0pKjcQfmzJu2bcteLpdbfTu/blwzdfL0yZO+8PbyMRqNS5Z+nZubHT12kkjk9Pjxg3+tXKxWqyL7D1n3078yM9OnfzlXqVQ8evygdOKazHfpX0z72sXZ9c7dm/v275LLZbNmLlCr1XPmTZNKSz7/bBaXwz3w954586b99ecxe4E9Qigl5emhQ3/NnbtUr9dv2PDD6jXfbfl9j1KprLi2q6mnhh9mJaiRbW9vHwcHkaRI3KZNKLEkMzP9/IVT48dNnTghFiHUvVvvmPFDd+/ZtuGnrXv37WAymWvXbCJWtL29cNWP3z558jAkpF3ZNnNzsxFCQ4eMCgoKjoiIxPTOcFIqFRqNpmvXXhF9+pcurLiqCVqtdt6cpYGBH561Y9Pv693dPTf+tpOYMTdqyEhiuaenN0IoMLC1g4NZ48yVe8WNm9YNGjhs1swFxH/DwjpNmDTi/oM7XcN7Vt/O0KhP+/YdSPx87fqlpORHB/addHFxRQj16d1PpVIejTsQ2X9Ibm5282YtBw4YihAaNTKm9Ok9ukf06N4HIdS6dYhUWnLyVNyECbE3blzOzEz/af2Wdm07IITatGk7NmZwXNzBCeM/I571w8qfnZycEULDho3evOXnEmmJXC6ruLZv3LxSVT3mrKLqUSPbFT1JeogQCv//z5XBYHQI63Tx0hmE0OMniW3bdiCCjRDq0OFjhFDqy+flst3po3B7e+Gq1ctmzpjfqVM4jjeBmUjkGBQUvHffDi6XN2jgMCKKVeFyueYEOyc3OzMzfeqU6dW3Zo6yr5ibm5ORkfb+/btTp4+VfUx+ft4H22nXrmPpz3fvxuv1+rExg0uXGAwGPl+AEIroE7n/wO7fNq4dFzPV0dGp0qY6dux86vSxV69ePHmSKOALiGAjhNzdPXx8/FJfPi9TPI/4oVEjD4SQuLCgSZOmFdd2NfXUHVWzrVDIEUKOov9+BkKhg1KpVCgUCoVc5PDfCe7t7YUIocLCgnItODu7bPpt5+9bNixaMrt165Bvl652dXWrx3eAH4PB+HHVb//esWnrtl8OH9m7aOGKcn/+yuLx7Mxps7hIghByc21U9/LKvmJRkRghNGH859269ir7GCen6gbfJ9j9bzvOzi4b1m8t+wBiHoupU6Y7Ojrt3bfz7LkTn382a2jUqIpNCQT2CCGVSilXyB1EjmV/JRQ6iCt8xxBCNmwbhJDBaKh0bVdTT91Roy+NULaf08XFDSEklZaULpFIxGw2m8vluri4lV1eVCQp/VTK8fHxW7P6t5/Wb0lLe71m7XLrvwPSEQgEs7/6Zs/uo3y+YOmyOcr/73T4YJdy2SmvyyK2OZIicVVPLNtyVY1UVqc9QkijUfv4+JX9JxDUbBNnby8sLi5q1MijbCNent5EMSOGj9331/Eunbv/tnFtpWf4CwvyEUKuro1c//c7Rnz9Kv2O/e+7KL+2q6mn7iiTbS6XJ5GIid5L4rCNwWDcvRdP/Fer1d69Fx8UFMxisYKCgh8/SVSr1cSvbty4jBAijh5tbGxVKmVpV6dWq0UItWvboVOnri9fvcD0znAizkt5engNGzparpATfRDlVnWlHBwcdTpdyf9/v4knIoQaN/Z1dXU7f+FU6Uo2mUxEUzwur9wOVFWNVOTt7dOokfvZcydUqv+cHtfr9Tpdjaf+ateuo8FgOHHySOmS0gaJVcHn8ydOnIYQqvh9MJlMZ8+dsBfY+/o0CQoKlsmkKSlPiV+9efPq/ft35XooKqq4tqupp+4os08eEtzu7LkTG35e1aZ1qL29sHPnbn0/Gbh7zzaDweDp6X369DGJRLx40b+Int4rV84vXDRz0MDh+fm5e/78o21oWGhIe4RQs4AWarV6+YqFX0z7Wiot+X7Fwqgho3g8u4SE2y1btML9FuubXq+fMGl4j+4RTfyaHj9+WMAXEN1dFVd1xeeGtf+IwWBs+n39iOFj09PebNv+G7GcwWB8/tmsH1YtnT5jYt++g5hM5oWLp4cOGRURERnUOoTFYm3avL5/38EarWbwoOFVNVIRg8GY/uXcb7+bP33mxMGDRhgNhvMXTkVERI4YPrZGbzmiT+TJU3Fbt/2ak5vdvFnL169fxt+6unvnES6Xu3zFQgFfENa+E7HBaNE8kHjK1WsXnJ1dOBzu9euXHj1+EPv5LB6P16d3/337dy1fsXBczFQmk/nXX/8WiRyHDB5ZzUvrdLqKa7txY9+q6qnR+6oUa/lyDPuiSTdLmrSx5/BqMJS2v3+ATFZy+cq5J0kPHRxE7dt17BD2sUIhP3vu+JUr5/l2/HlzlxLdZkKhQ5vWbe8/uHPy1NHUlyk9e3wyf963xJy+TZo0VatV9+/fCWwR5OAgevPm5dWrFx4+TAgJaff17MXm92FoVMa0ZFlIN3LNK6JRGlMfyAI/MrcqjUaTmZkef+vqzfgrzs6u3yxY7uXlXemqvnfvVkZG2qejxpU+VyRy9HD3unz5bNyxg0qlYuSI6Phb1/r06e/t1djfPyAgoPmTJ4kXL515+TLFy6txeHhPV1c3ob3Q1bXRtWsX79y5KZNJ+/YdWE0jFV/R16dJyxatkpIeXbh4OuXF06b+zSIiBjg7V3e8nZ7x9vr1S0OjRpX2zLNYrB7dI+Ry6bVrF2/cvKJQyvv3G9KmTSiTyczOzrp7L/7ylXMqterzz2aGh/dACB04uNvDwyv15fNLl88ihKLHThr96XiEEJPJ7Pxxt7S01ydOHrl371bz5oHfLlvt7u6BEHqeknz//p3osZOIKeKzsjIvXzk/aNBwDpeblZVZbm1XU4/5H3r6M1lw10o+dDxzBv31Q0avsZ5CJ5v6f2mLkEp0V/ZljyPZlGAlhbrjW7KHziJXVZQ2aEiPyP5RX0ybjbuQKpUU6q4dyo5ZVMmHTpl9cgAqksvlY6IHVvqr2M+/Ik5WN1iQbUBhdnZ2f2zbX+mvhPZUnUnSUiDbgMKYTKaHu6f12j95/JoZjyIpypwDAwDUCGQbAHqCbANAT5BtAOgJsg0APUG2AaAnyDYA9ATZBoCeINsA0BNkGwB6wpNtJ3dbptljbpAQk8FwcufgrqICE8PJg3xVAWtiMpFjo8o/dDzZZjCROEeN5aUtQpKrQQzSDWTv4Mp+l6ow6EhXGLAecY6mqnu98WTbp7mdvEiP5aUtQl6sa9zcrLEB61mztoKiPC3uKkD9URTrvJvxKv0Vnmy37uKQmSrLeC7H8up1lJmiSH8mC+5KxlsIw6NcL+59j7sKUE8ynsszU+VtulT+VcQz7gpCyGRCR39736SNvVtjrsitrmNZ14/ifG1+pjrtqXTELG9E1u4Clcywe0V6r9GeDq42fAe4h5eeivK0+Zmq9Gey4bO8q+q5wpZtwoOLRS8fyjg8ZuF7sk/l5+LF0aiMzdvah33iaMbDcTLoTPEnCtOeKoTONgXvKNyvYT6j0chgMMwfFJnSnD25WrWheTv7sIjqvoqYs00wGJBRj7+M6jHZDFYNxm4kBZ2G7GvVUlauXNmxY8dPPmkQk6ub+VUkxT4bi4VYrAbxF7ee2XAaylo1MXQMlqHhvF9zwLUrANATZBvQgUgkIsYDB6Ug24AOiouLazGFEL1BtgEdODs7131WYJqBbAM6EIvFxMyNoBRkG9ABbLcrgmwDOoDtdkWQbUAHtra25s992UDA6gB0oNVqjUYj7irIBbINAD1BtgEduLi4QF9aOZBtQAeFhYXQl1YOZBsAeoJsAzoQCoVwPXk5kG1AB1KpFK4nLweyDQA9QbYBHcC1KxXB6gB0ANeuVATZBnTQQEZBrBHINqADMgzpSTaQbQDoCbIN6IDL5UJfWjmwOgAdqNVq6EsrB7INAD1BtgEdODg4wH1g5UC2AR2UlJTAfWDlQLYBoCfINqADGOe0Isg2oAMY57QiyDYA9ATZBnRgY2MDl5SXA9kGdKDT6eCS8nIg24AOYJzTiiDbgA5gnNOKINuADmAsxIog24AOYCzEiiDbgA4EAgGbzcZdBblAtgEdyOVyvV6PuwpygWwDOoBrTiuCbAM6gGtOK2LAGX9AXYMGDcrJySkdC5HBYJhMptDQ0B07duAuDT/YbgMK6969e2mqiWtORSLRpEmTcNdFCpBtQGHR0dFeXl6l/zWZTM2aNQsPD8daFFlAtgGFeXh4dOvWrfS/Dg4OMTExWCsiEcg2oLYxY8b4+fkRG+0WLVrARrsUZBtQm5eXF7Hpho12OZBtQHkjR4709vYOCAjo0qUL7lpIBM6BgXqVm65+m6zKzVSpZAaVQm/LYyuKLHBe2mgwMBgMhiWmFnH04KmkWq6ALXKxdfe1bRosEDpT8mpWyDaoD3qd6e7Zoud3im3tbOxdBbZ2bDaHxbZls2yZiGzTgTCRXm3Qaw0GnUEuVsnFSlsuM7SbQ0g3B9yV1QxkG1hd/HFJ0s0iz5YuAlc7ti31DgPVcl3xe6lcrAwf4tIyTIC7HHNBtoEViXMNZ/fk2vK5bk1FuGupK51an/dKwrNDQ6Z5UOKWM8g2sJb3r9SnduQEdPZm2VBvW12VkjyFJKNowjJf8s8aCtkGVlGQpTu7J8+nnQfuQixPo9AVvikcPdeLxSb1yKqk/+MDKEiSqz25PZuWwUYIcfg2rs1c9/wrA3chHwDZBpa3f02m/0feuKuwIlse27Wp87HN2bgLqQ5kG1jY6X/n+bX3QKTeXbUAe1c7vdHm6W0p7kKqBNkGlpT9Vl2YpxM4c3EXUh+cfUXx/xTgrqJKkG1gSdePFrr6O+Guop4w2UwnH4d754pwF1I5yDawmLwMjdHItBNxcBdSiXsPjs9b9pFUWmjZZp19HJ7fI+luOWQbWMybZLmtgIzBth6WDZPBYuakqXEXUgnINrCYN08U9q52uKuob3wn/pskBe4qKkGFa+cAFShlBpYti2tvlYGEtVr12UtbHiWd1+k0ri6+PcKjQ9tEIIRu3D7wOPlSt85jzl7aIpMVenm2HDlkkZurH/Gs99mp/5zZ8O79c6G9i6uzjzUKIzrMxblkPOSGbAPLUMoMGpXBGi0bjcad++YWFeX06jZBIHB68zZx76GlGq3qo/aDEUKZWU+v39o3cshig0F/5MTqg3ErZsXuRAjlFaRv2fkF304UGfEli8m+eM1aI5+ybZhZ78i4Tw7ZBpahlOptOCxrtJz8/Gpa+uPFc/9xELoihNoF99VolfF3/iayjRCaFL1eaO+MEArvNOrkuV8VyhK+ncPp8xsZDObM2B0CviNCiMFkxp1ca43y2ByWWmGVP2p1BNkGlqFWGrnW6UhLSb1lMOpXbRhausRoNPC4/73XkmPLI35wFHkghKTSAhs2J/X13Y87DCeCjRBiMa34VXdpbKcsMdg5WOVPW61BtoFl2Ngy1AqrzOwhk4uF9i7TJv1ediGzsqyyWTZE8qWyQoNB7+RYTxe0i98ruQLSdUtDtoFl8IVsvcYqu6Z2PKFcUeQo8rCxMXe/gNhcy+X10cVl0BnZNkwmi3QX2ZLujw2gKL6QrddaJdsBTTsYjYbbCUdLl2i0quqfwuXyXZwbP3l2Wa+3+qTceo1B4GBj7VepBdhuA8vgi1jIZNJrDGxL96i1D+l/78E/p85vLCrO8fJokZ37Kvn5tQWz/ra1re6q9U96Tt1/5LuNf0zt2G4gg8m8eedvy1ZVSlmidvEm4xU7kG1gMX6t+NICpZO3vWWbZbNtPpvw25kLvz9KunDn/jFXZ5/OHYexWB/46rYL6adSya7d2nfqwsZGrv6+jVsXFFrljmuFRBnSn4zDJMK4K8Bi0p8pbp4qaRzcCHch9erphbQZPwfgrqISsN0GFuMXxL/xj8SgM1YzQNrSH3pXulxgJ5IriysuD2rZbczw7yxVoUot/+GnIZX+yrdxm4x3yRWX83kOi+bEVdVgSY6iZUcybrRhuw0s7NldadJtlUegS1UPkBRVPlaJXq9jsyvpkbK15ZWeo647o9FYXJJb+e9MDMSoJAsMBtNR5F5Vg6k3MsYv8eUJyHVmmwDbbWBJQZ2E988XaRQ6Dr/yrmMnR896L+q/mEymBQsQZ5S0CBOSM9hwDgxYXv+J7oVpYtxVWJ1BZ1SI5T2GV7mHgh1kG1hYI19OcBf7vFQLj4JANm/uZI2Y5YW7iupAtoHlteksbBbCzU6hbbzfJeVGTfe0syfp3jgBsg2sol1PB/9A25zn5B0qsHYMOuOr+Mz+41zdSHm9SlnQTw6sKCVBlnRLbu/uQM5B1GqqKEuW91oSs8hHIKJAJzRkG1iXOFt7YX++wcB0C3C2taNAJColK1DmvZI0bsbrO94Ndy3mgmyD+pD2TPHwqrSkUMd3tnNoJODw2Qwm6W6cKsdoMCkkKlmBUlao9GzC6zrUWeRKxntCqgLZBvWnMFv7+on8Xao6/52SxWbaclk8BxutdUZiqjU7e05JgVKrMvAdbOwd2S3aC5q05pO826xSkG2Ah0ZpVEj1WpXRSLJvIIvF5PKZfAc224bsexbVg2wDQE9wDgwAeoJsA0BPkG0A6AmyDQA9QbYBoCfINgD09H8glswvq62G0wAAAABJRU5ErkJggg==",
-            "text/plain": [
-              "<IPython.core.display.Image object>"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        }
-      ],
-      "source": [
-        "from IPython.display import Image, display\n",
-        "\n",
-        "display(Image(graph.get_graph(xray=True).draw_mermaid_png()))"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "# Run scenarios\n",
-        "\n",
-        "Note: LLMs are fundamentally probabilistic so wrong answers are possible even if implemented correctly.\n",
-        "\n",
-        "## Scenario 1 - name of wagon leader\n",
-        "\n",
-        "This test confirms that our graph has been setup correctly and can handle a case where tools don't need to be invoked."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 32,
-      "metadata": {},
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "\n",
-            " Question: What is the first name of the wagon leader? \n",
-            "\n",
-            "\n",
-            " Agent response: Art\n",
-            "\n"
-          ]
-        }
-      ],
-      "source": [
-        "scenario = {\n",
-        "    \"question\": \"What is the first name of the wagon leader?\",\n",
-        "    \"answer\": \"Art\",\n",
-        "    \"type\": \"free-form\",\n",
-        "}\n",
-        "\n",
-        "print(f\"\\n Question: {scenario['question']} \\n\")\n",
-        "\n",
-        "res = graph.invoke({\"messages\": scenario[\"question\"]})\n",
-        "\n",
-        "print(f\"\\n Agent response: {res['messages'][-1].content}\\n\")\n",
-        "\n",
-        "assert res[\"messages\"][-1].content == scenario[\"answer\"]"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "## Scenario 2 - restocking tool\n",
-        "\n",
-        "In this test we want to see the agent choose the restocking tool and choose to use the multiple choice output."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 34,
-      "metadata": {},
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "\n",
-            " Question: In order to survive the trail ahead, you'll need to have a restocking strategy for when you need to get more supplies or risk starving. If it takes you an estimated 3 days to restock your food and you plan to start with 200lbs of food, budget 10lbs/day to eat, and keep a safety stock of at least 50lbs of back up... at what point should you restock? \n",
-            "\n",
-            "\n",
-            " Using restock tool!: daily_usage=10, lead_time=3, safety_stock=50 \n",
-            "\n",
-            "Called multi choice structured\n",
-            "\n",
-            " Agent response: D\n"
-          ]
-        }
-      ],
-      "source": [
-        "# helper function for multi-choice questions\n",
-        "def format_multi_choice_question(q):\n",
-        "    question = q[\"question\"]\n",
-        "    options = q.get(\"options\", \"\")\n",
-        "    formatted = f\"{question}, options: {' '.join(options)}\"\n",
-        "    return [HumanMessage(content=formatted)]\n",
-        "\n",
-        "scenario = {\n",
-        "        \"question\": \"In order to survive the trail ahead, you'll need to have a restocking strategy for when you need to get more supplies or risk starving. If it takes you an estimated 3 days to restock your food and you plan to start with 200lbs of food, budget 10lbs/day to eat, and keep a safety stock of at least 50lbs of back up... at what point should you restock?\",\n",
-        "        \"answer\": \"D\",\n",
-        "        \"options\": [\"A: 100lbs\", \"B: 20lbs\", \"C: 5lbs\", \"D: 80lbs\"],\n",
-        "        \"type\": \"multi-choice\",\n",
-        "    }\n",
-        "\n",
-        "print(f\"\\n Question: {scenario['question']} \\n\")\n",
-        "\n",
-        "res = graph.invoke({\"messages\": format_multi_choice_question(scenario)})\n",
-        "\n",
-        "print(f\"\\n Agent response: {res['multi_choice_response']}\")\n",
-        "\n",
-        "assert res[\"multi_choice_response\"] == scenario[\"answer\"]\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "## Scenario 3 - retriever tool\n",
-        "\n",
-        "In this test, we want to see the retrieval tool invoked and multiple choice structured response."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 35,
-      "metadata": {},
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "\n",
-            " Question: You’ve encountered a dense forest near the Blue Mountains, and your party is unsure how to proceed. There is a fork in the road, and you must choose a path. Which way will you go? \n",
-            "\n",
-            "Called multi choice structured\n",
-            "\n",
-            " Agent response: B\n"
-          ]
-        }
-      ],
-      "source": [
-        "scenario = {\n",
-        "        \"question\": \"You’ve encountered a dense forest near the Blue Mountains, and your party is unsure how to proceed. There is a fork in the road, and you must choose a path. Which way will you go?\",\n",
-        "        \"answer\": \"B\",\n",
-        "        \"options\": [\n",
-        "            \"A: take the northern trail\",\n",
-        "            \"B: take the southern trail\",\n",
-        "            \"C: turn around\",\n",
-        "            \"D: go fishing\",\n",
-        "        ],\n",
-        "        \"type\": \"multi-choice\",\n",
-        "    }\n",
-        "\n",
-        "print(f\"\\n Question: {scenario['question']} \\n\")\n",
-        "\n",
-        "res = graph.invoke({\"messages\": format_multi_choice_question(scenario)})\n",
-        "\n",
-        "print(f\"\\n Agent response: {res['multi_choice_response']}\")\n",
-        "\n",
-        "assert res[\"multi_choice_response\"] == scenario[\"answer\"]"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "## Scenario 4 - Semantic caching\n",
-        "\n",
-        "Agent workflows are highly flexible and capable of handling a wide range of scenarios, but this flexibility comes at a cost. Even in our simple example, there can be multiple large-context LLM calls in the same execution, leading to high latency and increased service costs by the end of the month.<br>\n",
-        "\n",
-        "A good practice is to cache answers to known questions. Chatbot interactions are often fairly predictable, particularly in support or FAQ-type use cases, making them excellent candidates for caching.\n",
-        "\n",
-        "\n",
-        "![diagram](../../assets/cache_diagram.png)\n",
-        "\n",
-        "## Creating a cache"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 43,
-      "metadata": {},
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "09:20:47 redisvl.index.index INFO   Index already exists, not overwriting.\n"
-          ]
-        },
-        {
-          "data": {
-            "text/plain": [
-              "'oregon_trail_cache:602ac35f09671fc9e2a4f4902c6f82f06b9560ea6b5a5dd3e9218fcc1ff47e52'"
-            ]
-          },
-          "execution_count": 43,
-          "metadata": {},
-          "output_type": "execute_result"
-        }
-      ],
-      "source": [
-        "import warnings\n",
-        "from redisvl.extensions.llmcache import SemanticCache\n",
-        "warnings.filterwarnings(\"ignore\")\n",
-        "\n",
-        "hunting_example = \"There's a deer. You're starving. You know what you have to do...\"\n",
-        "\n",
-        "semantic_cache = SemanticCache(\n",
-        "    name=\"oregon_trail_cache\",\n",
-        "    redis_url=REDIS_URL,\n",
-        "    distance_threshold=0.1,\n",
-        ")\n",
-        "\n",
-        "semantic_cache.store(prompt=hunting_example, response=\"bang\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "## Testing the cache"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 42,
-      "metadata": {},
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "\n",
-            " Question: There's a deer. You're hungry. You know what you have to do... \n",
-            "\n",
-            "Cache hit\n",
-            "Response time 0.18901395797729492s\n",
-            "\n",
-            " Question: You’ve encountered a dense forest near the Blue Mountains, and your party is unsure how to proceed. There is a fork in the road, and you must choose a path. Which way will you go? \n",
-            "\n",
-            "Invoking agent\n",
-            "Called multi choice structured\n",
-            "Response time 3.500865936279297s\n"
-          ]
-        }
-      ],
-      "source": [
-        "import time\n",
-        "\n",
-        "scenarios = [\n",
-        "    {\n",
-        "        \"question\": \"There's a deer. You're hungry. You know what you have to do...\",\n",
-        "        \"answer\": \"bang\",\n",
-        "        \"type\": \"cache_hit\",\n",
-        "    },\n",
-        "    {\n",
-        "        \"question\": \"You’ve encountered a dense forest near the Blue Mountains, and your party is unsure how to proceed. There is a fork in the road, and you must choose a path. Which way will you go?\",\n",
-        "        \"answer\": \"B\",\n",
-        "        \"options\": [\n",
-        "            \"A: take the northern trail\",\n",
-        "            \"B: take the southern trail\",\n",
-        "            \"C: turn around\",\n",
-        "            \"D: go fishing\",\n",
-        "        ],\n",
-        "        \"type\": \"multi-choice\",\n",
-        "    }\n",
-        "]\n",
-        "\n",
-        "for scenario in scenarios:\n",
-        "    print(f\"\\n Question: {scenario['question']} \\n\")\n",
-        "\n",
-        "    start = time.time()\n",
-        "\n",
-        "    cache_hit = semantic_cache.check(prompt=scenario[\"question\"], return_fields=[\"response\"])\n",
-        "\n",
-        "    if not cache_hit:\n",
-        "        print(\"Invoking agent\")\n",
-        "        res = graph.invoke({\"messages\": format_multi_choice_question(scenario)})\n",
-        "    else:\n",
-        "        print(\"Cache hit\")\n",
-        "\n",
-        "    response_time = time.time() - start\n",
-        "\n",
-        "    print(f\"Response time {response_time}s\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "## Scenario 5 - Allow/block list router\n",
-        "\n",
-        "When ChatGPT first launched, there was a famous example where a car dealership accidentally made one of the latest language models available for free to everyone. They assumed users would only ask questions about cars through their chatbot. However, a group of developers quickly realized that the model was powerful enough to answer coding questions, so they started using the dealership's chatbot for free. <br>\n",
-        "\n",
-        "To prevent this kind of misuse in your system, adding an allow/block router to the front of your application is essential. Fortunately, this is very easy to implement using `redisvl`.\n",
-        "\n",
-        "![diagram](../../assets/router_diagram.png)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "## Creating the router"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 52,
-      "metadata": {},
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "10:35:18 redisvl.index.index INFO   Index already exists, not overwriting.\n"
-          ]
-        }
-      ],
-      "source": [
-        "from redisvl.extensions.router import Route, SemanticRouter\n",
-        "\n",
-        "# Semantic router\n",
-        "blocked_references = [\n",
-        "    \"thinks about aliens\",\n",
-        "    \"corporate questions about agile\",\n",
-        "    \"anything about the S&P 500\",\n",
-        "]\n",
-        "\n",
-        "blocked_route = Route(name=\"block_list\", references=blocked_references)\n",
-        "\n",
-        "router = SemanticRouter(\n",
-        "    name=\"bouncer\",\n",
-        "    routes=[blocked_route],\n",
-        "    redis_url=REDIS_URL,\n",
-        "    overwrite=False,\n",
-        ")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "## Testing the router"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 53,
-      "metadata": {},
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "\n",
-            " Question: Tell me about the S&P 500? \n",
-            "\n",
-            "Blocked!\n"
-          ]
-        }
-      ],
-      "source": [
-        "scenario = {\n",
-        "        \"question\": \"Tell me about the S&P 500?\",\n",
-        "        \"answer\": \"you shall not pass\",\n",
-        "        \"type\": \"action\",\n",
-        "    }\n",
-        "\n",
-        "print(f\"\\n Question: {scenario['question']} \\n\")\n",
-        "\n",
-        "blocked_topic_match = router(scenario[\"question\"], distance_threshold=0.2)\n",
-        "\n",
-        "assert blocked_topic_match.name == \"block_list\"\n",
-        "\n",
-        "print(\"Blocked!\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "## Putting it all together\n",
-        "\n",
-        "Once you have defined all the pieces, connecting the various aspects of the full architecture becomes easy and you can tie them together with whatever logic you wish. \n",
-        "\n",
-        "This could be as simple as:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 54,
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "def respond_to_question(question):\n",
-        "    blocked_topic_match = router(question, distance_threshold=0.2)\n",
-        "\n",
-        "    if blocked_topic_match.name == \"block_list\":\n",
-        "        print(\"App block logic - short circuit\")\n",
-        "        return\n",
-        "\n",
-        "    cache_hit = semantic_cache.check(prompt=question, return_fields=[\"response\"])\n",
-        "\n",
-        "    if cache_hit:\n",
-        "        print(\"Cache hit - short circuit\")\n",
-        "        return cache_hit\n",
-        "    \n",
-        "    return graph.invoke({\"messages\": question})\n"
-      ]
-    }
-  ],
-  "metadata": {
-    "colab": {
-      "provenance": []
-    },
-    "kernelspec": {
-      "display_name": "Python 3",
-      "name": "python3"
-    },
-    "language_info": {
-      "codemirror_mode": {
-        "name": "ipython",
-        "version": 3
-      },
-      "file_extension": ".py",
-      "mimetype": "text/x-python",
-      "name": "python",
-      "nbconvert_exporter": "python",
-      "pygments_lexer": "ipython3",
-      "version": "3.11.9"
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "qYvD2zzKobTC"
+   },
+   "source": [
+    "![Redis](https://redis.io/wp-content/uploads/2024/04/Logotype.svg?auto=webp&quality=85,75&width=120)\n",
+    "\n",
+    "# Full-Featured Agent Architecture\n",
+    "The following example demonstrates how to build a tool-enabled agentic workflow with a semantic cache and an allow/block list router. This approach helps reduce latency and costs in the final solution.\n",
+    "\n",
+    "Note: This notebook summarizes this [this workshop](https://github.com/redis-developer/oregon-trail-agent-workshop). For a more detailed step-by-step walkthrough of each element, please refer to the repository.\n",
+    "\n",
+    "## Let's Begin!\n",
+    "<a href=\"https://colab.research.google.com/github/redis-developer/redis-ai-resources/blob/main/python-recipes/agents/02_full_featured_agent.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 0
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "NTFxCojYECnx"
+   },
+   "source": [
+    "# Setup\n",
+    "\n",
+    "## Packages"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "id": "Zz62U5COgF21"
+   },
+   "outputs": [],
+   "source": [
+    "%pip install -q langchain langchain-openai \"langchain-redis>=0.2.0\" langgraph sentence-transformers"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### OPEN_AI_API key\n",
+    "\n",
+    "A open_ai_api key with billing information enabled is required for this lesson."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "VO0i-1c9m2Kb",
+    "outputId": "ec942dbf-226a-426d-8964-e03831e0dd99"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "OPENAI_API_KEY:··········\n"
+     ]
+    }
+   ],
+   "source": [
+    "# NBVAL_SKIP\n",
+    "import os\n",
+    "import getpass\n",
+    "\n",
+    "\n",
+    "\n",
+    "def _set_env(key: str):\n",
+    "    if key not in os.environ:\n",
+    "        os.environ[key] = getpass.getpass(f\"{key}:\")\n",
+    "\n",
+    "\n",
+    "_set_env(\"OPENAI_API_KEY\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "Po4K08Uoa5HJ"
+   },
+   "source": [
+    "## Redis instance\n",
+    "\n",
+    "### For colab"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "vlF2874ZoBWu",
+    "outputId": "e5e7ebc0-b70c-4682-d70c-b33c584e72d4"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "deb [signed-by=/usr/share/keyrings/redis-archive-keyring.gpg] https://packages.redis.io/deb jammy main\n",
+      "Starting redis-stack-server, database path /var/lib/redis-stack\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "gpg: cannot open '/dev/tty': No such device or address\n",
+      "curl: (23) Failed writing body\n"
+     ]
+    }
+   ],
+   "source": [
+    "# NBVAL_SKIP\n",
+    "%%sh\n",
+    "curl -fsSL https://packages.redis.io/gpg | sudo gpg --dearmor -o /usr/share/keyrings/redis-archive-keyring.gpg\n",
+    "echo \"deb [signed-by=/usr/share/keyrings/redis-archive-keyring.gpg] https://packages.redis.io/deb $(lsb_release -cs) main\" | sudo tee /etc/apt/sources.list.d/redis.list\n",
+    "sudo apt-get update  > /dev/null 2>&1\n",
+    "sudo apt-get install redis-stack-server  > /dev/null 2>&1\n",
+    "redis-stack-server --daemonize yes"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### For Alternative Environments\n",
+    "There are many ways to get the necessary redis-stack instance running\n",
+    "1. On cloud, deploy a [FREE instance of Redis in the cloud](https://redis.com/try-free/). Or, if you have your\n",
+    "own version of Redis Enterprise running, that works too!\n",
+    "2. Per OS, [see the docs](https://redis.io/docs/latest/operate/oss_and_stack/install/install-stack/)\n",
+    "3. With docker: `docker run -d --name redis-stack-server -p 6379:6379 redis/redis-stack-server:latest`\n",
+    "\n",
+    "## Test connection"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "My-zol_loQaw",
+    "outputId": "b58c2466-ee10-480c-ad4c-608cbf747e8b",
+    "ExecuteTime": {
+     "end_time": "2026-02-16T16:02:18.501556Z",
+     "start_time": "2026-02-16T16:02:18.449853Z"
+    }
+   },
+   "source": [
+    "import os\n",
+    "from redis import Redis\n",
+    "\n",
+    "# Use the environment variable if set, otherwise default to localhost\n",
+    "REDIS_URL = os.getenv(\"REDIS_URL\", \"redis://localhost:6379\")\n",
+    "\n",
+    "client = Redis.from_url(REDIS_URL)\n",
+    "client.ping()"
+   ],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 1,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "execution_count": 1
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "p8lqllwDoV_K"
+   },
+   "source": [
+    "# Motivation\n",
+    "\n",
+    "The goal of the workshop is to create an agent workflow that can handle five Oregon Trail-themed scenarios, mimicking situations that often arise when implementing agent workflows in practice.\n",
+    "\n",
+    "## Scenario 1 - name of the wagon leader\n",
+    "\n",
+    "**Learning goal:** Test basic LangGraph setup and execution. <br>\n",
+    "\n",
+    "**Question:** `What is the first name of the wagon leader?` <br>\n",
+    "**Answer:** `Art` <br>\n",
+    "**Type:** `free-form` <br>\n",
+    "\n",
+    "## Scenario 2 - restocking tool\n",
+    "\n",
+    "**Learning goal:** Agent interaction with custom defined tool and **structured output** for multiple choice questions. <br>\n",
+    "\n",
+    "**Question:** `In order to survive the trail ahead, you'll need to have a restocking strategy for when you need to get more supplies or risk starving. If it takes you an estimated 3 days to restock your food and you plan to start with 200lbs of food, budget 10lbs/day to eat, and keep a safety stock of at least 50lbs of back up... at what point should you restock?` <br>\n",
+    "**Answer:** `D` <br>\n",
+    "**Options:** `[\"A: 100lbs\", \"B: 20lbs\", \"C: 5lbs\", \"D: 80lbs\"]` <br>\n",
+    "**Type:** `multi-choice` <br>\n",
+    "\n",
+    "## Scenario 3 - retrieval tool\n",
+    "\n",
+    "**Learning goal:** Agent implements Retrieval Augmented Generation.\n",
+    "\n",
+    "**Question:** `You’ve encountered a dense forest near the Blue Mountains, and your party is unsure how to proceed. There is a fork in the road, and you must choose a path. Which way will you go?` <br>\n",
+    "**Answer:** `B` <br>\n",
+    "**Options:** `[\"A: take the northern trail\", \"B: take the southern trail\", \"C: turn around\", \"D: go fishing\"]` <br>\n",
+    "**Type:** `multi-choice` <br>\n",
+    "\n",
+    "## Scenario 4 - semantic cache\n",
+    "\n",
+    "**Learning goal:** Implement semantic cache that bypasses expensive agent workflow for known answer. <br>\n",
+    "\n",
+    "**Question:** `There's a deer. You're hungry. You know what you have to do...` <br>\n",
+    "**Answer:** `bang` <br>\n",
+    "**Type:** `free-form` <br>\n",
+    "\n",
+    "## Scenario 5 - allow/block list with router\n",
+    "\n",
+    "**Learning goal:** Implement semantic router that blocks requests for non-related topics.\n",
+    "\n",
+    "**Question:** `Tell me about the S&P 500?` <br>\n",
+    "**Answer:** `you shall not pass` <br>\n",
+    "**Type:** `free-form` <br>\n",
+    "\n",
+    "\n",
+    "\n",
+    "# Final Architecture\n",
+    "\n",
+    "In the end, we are building a workflow like the following:\n",
+    "\n",
+    "![diagram](../../assets/full_featured_agent.png)\n",
+    "\n",
+    "As a reminder for more detail see: [Redis Developer Oregon Trail Agent Workshop](https://github.com/redis-developer/oregon-trail-agent-workshop).\n",
+    "\n",
+    "# Defining the agent with LangGraph\n",
+    "\n",
+    "## Tools\n",
+    "\n",
+    "Tools are functions that the central LLM powered \"agent\" can determine to invoke depending on the situation.\n",
+    "\n",
+    "### Restock tool\n",
+    "\n",
+    "The first tool we will define implements the restocking formula. LLMs are designed to predict text responses, not to perform deterministic math. In this case, the agent will act as a parser, extracting the necessary information from the human query and calling the tool with the appropriate schema.\n",
+    "\n",
+    "One of the advantages of `LangGraph` is that the schema for the tool can be defined as a `pydantic` model. Note: It is also essential to include a well-written `doc_string` with the tool function so the agent can determine the appropriate situation to use the tool."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-02-16T16:02:21.432052Z",
+     "start_time": "2026-02-16T16:02:21.340927Z"
+    }
+   },
+   "source": [
+    "from langchain_core.tools import tool\n",
+    "from pydantic import BaseModel, Field\n",
+    "\n",
+    "class RestockInput(BaseModel):\n",
+    "    daily_usage: int = Field(\n",
+    "        description=\"Pounds (lbs) of food expected to be consumed daily\"\n",
+    "    )\n",
+    "    lead_time: int = Field(description=\"Lead time to replace food in days\")\n",
+    "    safety_stock: int = Field(\n",
+    "        description=\"Number of pounds (lbs) of safety stock to keep on hand\"\n",
+    "    )\n",
+    "\n",
+    "\n",
+    "@tool(\"restock-tool\", args_schema=RestockInput)\n",
+    "def restock_tool(daily_usage: int, lead_time: int, safety_stock: int) -> int:\n",
+    "    \"\"\"restock formula tool used specifically for calculating the amount of food at which you should start restocking.\"\"\"\n",
+    "    print(f\"\\n Called restock tool: {daily_usage=}, {lead_time=}, {safety_stock=} \\n\")\n",
+    "    return (daily_usage * lead_time) + safety_stock"
+   ],
+   "outputs": [
+    {
+     "ename": "ModuleNotFoundError",
+     "evalue": "No module named 'langchain_core'",
+     "output_type": "error",
+     "traceback": [
+      "\u001B[31m---------------------------------------------------------------------------\u001B[39m",
+      "\u001B[31mModuleNotFoundError\u001B[39m                       Traceback (most recent call last)",
+      "\u001B[36mCell\u001B[39m\u001B[36m \u001B[39m\u001B[32mIn[2]\u001B[39m\u001B[32m, line 1\u001B[39m\n\u001B[32m----> \u001B[39m\u001B[32m1\u001B[39m \u001B[38;5;28;01mfrom\u001B[39;00m\u001B[38;5;250m \u001B[39m\u001B[34;01mlangchain_core\u001B[39;00m\u001B[34;01m.\u001B[39;00m\u001B[34;01mtools\u001B[39;00m\u001B[38;5;250m \u001B[39m\u001B[38;5;28;01mimport\u001B[39;00m tool\n\u001B[32m      2\u001B[39m \u001B[38;5;28;01mfrom\u001B[39;00m\u001B[38;5;250m \u001B[39m\u001B[34;01mpydantic\u001B[39;00m\u001B[38;5;250m \u001B[39m\u001B[38;5;28;01mimport\u001B[39;00m BaseModel, Field\n\u001B[32m      4\u001B[39m \u001B[38;5;28;01mclass\u001B[39;00m\u001B[38;5;250m \u001B[39m\u001B[34;01mRestockInput\u001B[39;00m(BaseModel):\n",
+      "\u001B[31mModuleNotFoundError\u001B[39m: No module named 'langchain_core'"
+     ]
+    }
+   ],
+   "execution_count": 2
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Retriever tool\n",
+    "\n",
+    "Sometimes an LLM might need access to data that it was not trained on, whether because the data is proprietary, time-sensitive, or otherwise unavailable.\n",
+    "\n",
+    "In such cases, Retrieval-Augmented Generation (RAG) is often necessary. Here, a vector search is used to augment the final LLM prompt with helpful and necessary context.\n",
+    "\n",
+    "RAG and agents are not mutually exclusive. Below, we define a retriever tool that performs RAG whenever the agent determines it is necessary."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "09:04:55 redisvl.index.index INFO   Index already exists, not overwriting.\n"
+     ]
+    }
+   ],
+   "source": [
+    "\n",
+    "from langchain_core.tools.retriever import create_retriever_tool\n",
+    "\n",
+    "from langchain_redis import RedisConfig, RedisVectorStore\n",
+    "from langchain_core.documents import Document\n",
+    "from langchain_openai import OpenAIEmbeddings\n",
+    "\n",
+    "## Helper methods\n",
+    "\n",
+    "INDEX_NAME = os.environ.get(\"VECTOR_INDEX_NAME\", \"oregon_trail\")\n",
+    "REDIS_URL = os.environ.get(\"REDIS_URL\", \"redis://localhost:6379/0\")\n",
+    "CONFIG = RedisConfig(index_name=INDEX_NAME, redis_url=REDIS_URL)\n",
+    "\n",
+    "def get_vector_store():\n",
+    "    try:\n",
+    "        CONFIG.from_existing = True\n",
+    "        vector_store = RedisVectorStore(OpenAIEmbeddings(), config=CONFIG)\n",
+    "    except:\n",
+    "        print(\"Init vector store with document\")\n",
+    "        CONFIG.from_existing = False\n",
+    "        vector_store = RedisVectorStore.from_documents(\n",
+    "            [doc], OpenAIEmbeddings(), config=CONFIG\n",
+    "        )\n",
+    "    return vector_store\n",
+    "\n",
+    "## Relevant data\n",
+    "\n",
+    "doc = Document(\n",
+    "    page_content=\"the northern trail, of the blue mountains, was destroyed by a flood and is no longer safe to traverse. It is recommended to take the southern trail although it is longer.\"\n",
+    ")\n",
+    "\n",
+    "## Retriever tool\n",
+    "vector_store = get_vector_store()\n",
+    "\n",
+    "retriever_tool = create_retriever_tool(\n",
+    "    vector_store.as_retriever(),\n",
+    "    \"get_directions\",\n",
+    "    \"Search and return information related to which routes/paths/trails to take along your journey.\",\n",
+    ")\n",
+    "\n",
+    "## Store both tools in a list\n",
+    "tools = [retriever_tool, restock_tool]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# State\n",
+    "\n",
+    "State is the set of messages that is passed between nodes in our graph so that the proceeding node knows what happened at the last node and so on. In this case, our state will extend the normal `MessageState` but also add a custom field for `multi_choice_responses`. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from typing import Literal\n",
+    "\n",
+    "from langgraph.graph import MessagesState\n",
+    "from pydantic import BaseModel, Field\n",
+    "\n",
+    "\n",
+    "class MultipleChoiceResponse(BaseModel):\n",
+    "    multiple_choice_response: Literal[\"A\", \"B\", \"C\", \"D\"] = Field(\n",
+    "        description=\"Single character response to the question for multiple choice questions. Must be either A, B, C, or D.\"\n",
+    "    )\n",
+    "\n",
+    "\n",
+    "class AgentState(MessagesState):\n",
+    "    multi_choice_response: MultipleChoiceResponse\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Nodes\n",
+    "\n",
+    "Nodes are steps in the process flow of our agent where functions can be invoked."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from functools import lru_cache\n",
+    "\n",
+    "from langchain_core.messages import HumanMessage\n",
+    "from langchain_openai import ChatOpenAI\n",
+    "from langgraph.prebuilt import ToolNode\n",
+    "\n",
+    "\n",
+    "## Function definitions that invoke an LLM model\n",
+    "\n",
+    "### with tools\n",
+    "@lru_cache(maxsize=4)\n",
+    "def _get_tool_model(model_name: str):\n",
+    "    if model_name == \"openai\":\n",
+    "        model = ChatOpenAI(temperature=0, model_name=\"gpt-4o\")\n",
+    "    else:\n",
+    "        raise ValueError(f\"Unsupported model type: {model_name}\")\n",
+    "\n",
+    "    model = model.bind_tools(tools)\n",
+    "    return model\n",
+    "\n",
+    "### with structured output\n",
+    "@lru_cache(maxsize=4)\n",
+    "def _get_response_model(model_name: str):\n",
+    "    if model_name == \"openai\":\n",
+    "        model = ChatOpenAI(temperature=0, model_name=\"gpt-4o\")\n",
+    "    else:\n",
+    "        raise ValueError(f\"Unsupported model type: {model_name}\")\n",
+    "\n",
+    "    model = model.with_structured_output(MultipleChoiceResponse)\n",
+    "    return model\n",
+    "\n",
+    "### Functions for responding to a multiple choice question\n",
+    "def multi_choice_structured(state: AgentState, config):\n",
+    "    # We call the model with structured output in order to return the same format to the user every time\n",
+    "    # state['messages'][-2] is the last ToolMessage in the convo, which we convert to a HumanMessage for the model to use\n",
+    "    # We could also pass the entire chat history, but this saves tokens since all we care to structure is the output of the tool\n",
+    "    model_name = config.get(\"configurable\", {}).get(\"model_name\", \"openai\")\n",
+    "\n",
+    "    print(\"Called multi choice structured\")\n",
+    "\n",
+    "    response = _get_response_model(model_name).invoke(\n",
+    "        [\n",
+    "            HumanMessage(content=state[\"messages\"][0].content),\n",
+    "            HumanMessage(content=f\"Answer from tool: {state['messages'][-2].content}\"),\n",
+    "        ]\n",
+    "    )\n",
+    "    # We return the final answer\n",
+    "    return {\n",
+    "        \"multi_choice_response\": response.multiple_choice_response,\n",
+    "    }\n",
+    "\n",
+    "\n",
+    "# Function for conditional edge\n",
+    "def is_multi_choice(state: AgentState):\n",
+    "    return \"options:\" in state[\"messages\"][0].content.lower()\n",
+    "\n",
+    "\n",
+    "def structure_response(state: AgentState, config):\n",
+    "    if is_multi_choice(state):\n",
+    "        return multi_choice_structured(state, config)\n",
+    "    else:\n",
+    "        # if not multi-choice don't need to do anything\n",
+    "        return {\"messages\": []}\n",
+    "\n",
+    "\n",
+    "system_prompt = \"\"\"\n",
+    "    You are an oregon trail playing tool calling AI agent. Use the tools available to you to answer the question you are presented. When in doubt use the tools to help you find the answer.\n",
+    "    If anyone asks your first name is Art return just that string.\n",
+    "\"\"\"\n",
+    "\n",
+    "\n",
+    "# Define the function that calls the model\n",
+    "def call_tool_model(state: AgentState, config):\n",
+    "    # Combine system prompt with incoming messages\n",
+    "    messages = [{\"role\": \"system\", \"content\": system_prompt}] + state[\"messages\"]\n",
+    "\n",
+    "    # Get from LangGraph config\n",
+    "    model_name = config.get(\"configurable\", {}).get(\"model_name\", \"openai\")\n",
+    "\n",
+    "    # Get our model that binds our tools\n",
+    "    model = _get_tool_model(model_name)\n",
+    "\n",
+    "    # invoke the central agent/reasoner with the context of the graph\n",
+    "    response = model.invoke(messages)\n",
+    "\n",
+    "    # We return a list, because this will get added to the existing list\n",
+    "    return {\"messages\": [response]}\n",
+    "\n",
+    "\n",
+    "# Define the function to execute tools\n",
+    "tool_node = ToolNode(tools)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Graph\n",
+    "\n",
+    "The graph composes the tools and nodes into a compilable workflow that can be invoked."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from typing import Literal, TypedDict\n",
+    "from langgraph.graph import END, StateGraph\n",
+    "\n",
+    "\n",
+    "# Define the config\n",
+    "class GraphConfig(TypedDict):\n",
+    "    model_name: Literal[\"anthropic\", \"openai\"]\n",
+    "\n",
+    "# Define the function that determines whether to continue or not\n",
+    "def should_continue(state: AgentState):\n",
+    "    messages = state[\"messages\"]\n",
+    "    last_message = messages[-1]\n",
+    "    # If there is no function call, then we respond to the user\n",
+    "    if not last_message.tool_calls:\n",
+    "        return \"structure_response\"\n",
+    "    # Otherwise if there is, we continue\n",
+    "    else:\n",
+    "        return \"continue\"\n",
+    "\n",
+    "\n",
+    "# Define a new graph\n",
+    "workflow = StateGraph(AgentState, config_schema=GraphConfig)\n",
+    "\n",
+    "# Add nodes\n",
+    "workflow.add_node(\"agent\", call_tool_model)\n",
+    "workflow.add_node(\"tools\", tool_node)\n",
+    "workflow.add_node(\"structure_response\", structure_response)\n",
+    "\n",
+    "# Set the entrypoint\n",
+    "workflow.set_entry_point(\"agent\")\n",
+    "\n",
+    "# add conditional edge between agent and tools\n",
+    "workflow.add_conditional_edges(\n",
+    "    \"agent\",\n",
+    "    should_continue,\n",
+    "    {\"continue\": \"tools\", \"structure_response\": \"structure_response\"},\n",
+    ")\n",
+    "\n",
+    "\n",
+    "# We now add a normal edge from `tools` to `agent`.\n",
+    "workflow.add_edge(\"tools\", \"agent\")\n",
+    "workflow.add_edge(\"structure_response\", END)\n",
+    "\n",
+    "\n",
+    "# This compiles it into a LangChain Runnable,\n",
+    "# meaning you can use it as you would any other runnable\n",
+    "graph = workflow.compile()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Evaluate graph structure\n",
+    "\n",
+    "When we invoke the graph, it follows four primary steps:  \n",
+    "\n",
+    "1. **Evaluate Conditional Edge**: The graph evaluates the conditional edge between tools and the agent via the `should_continue` function. This determines whether it should `continue` and call a tool or move to `structure_response` to format the output for the user.  \n",
+    "2. **Invoke Tools**: If it decides to invoke the tools, the response from the tool is appended as a message to the state and passed back to the agent.  \n",
+    "3. **Determine Next Step**: If tools have already been called or are deemed unnecessary, the graph moves to the `structure_response` node.  \n",
+    "4. **Handle Multiple-Choice Questions**: If the question is identified as a **multiple-choice question** within the `structure_response` node, a model is invoked to ensure the response is returned as a literal `A, B, C, or D`, as expected by the game. Otherwise, it simply proceeds forward.  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAUkAAAFlCAIAAADpho2yAAAAAXNSR0IArs4c6QAAIABJREFUeJzt3XdcE/f/B/BPBiQhIYQpS0DEgSigorWKW6riwlkV3LbYOmqddbXWr9U6aofWUb+u1lUH1r03LhQHqIiLIbITIHvn98d9f3z5sgyQ8Lk73s+Hf+CRfPLOJS/u7nN3nw/DZDIhAADtMHEXAACwCsg2APQE2QaAniDbANATZBsAeoJsA0BPbNwF0FB+hkYu1Sulep3OpFUZcZdjFg6PacNh8oUsvoONq7ct7nKABUC2LebVI/nbZPnbp4omrfgGg4kvZDs1smWycJdlHhNC+ZlqhVRvy2Vlpir8Wwv82wj8guxw1wVqjwHXrtTd83vS2ycLfQP5foH8Jm34bBsG7orqRK0wvE1WZKepc9NUnQe5+Lfh464I1AZku06KC3Tn/8x18eJ0GeTM5VNkG222onzd7ZOFTAYjYlwjqv/BaoAg27X3+rH87hnxoM89HVxscNdiRfnvNEc3Zg2b7tXIl4u7FlADkO1aynqpenq7pN9Ed9yF1JPDP7+LiHEXudL5rxjNQLZrI+lmSdYrZeRkD9yF1KvDv2R17OvkGwgdbNQA57drLPuN6vVjWUMLNkJo5GzvKwfzFCUG3IUAs0C2a0atND64VDRspjfuQvAYu8jv0oE83FUAs0C2ayb+n4JmbQW4q8CGw2U08uE8uFiEuxDwYZDtGijK0+VlqAM7CnEXglOnSOd758RGalxu16BBtmsgOb6k61C3+nktuVz+4sULXE+vXs+Rbg8vw6ab7CDb5jKZUNKtYp+WvPp5udGjRx8/fhzX06vn3Yz3/F6JlRoHlgLZNldassK/df1dfanVamv3ROKkZq2fbg6hsw3bhinJteJLgLqDbJvr/VtV83b21mh59+7dkZGR4eHhU6ZMSUhIQAgNHDhQIpEcPnw4LCxs4MCBRFZ///33wYMHf/TRRwMGDNi8ebPB8J9zUWvWrPnkk09u3LgxdOjQsLCw+/fvV3y6xbUIE75LVVqjZWApcB+YufIy1M1CLd9DnpCQsGnTpn79+nXu3Pn27dtKpRIhtHbt2hkzZrRv3z46OtrW1hYhxGKx7t27161bN29v79TU1J07dwqFwpiYGKIRuVy+efPmb775RqVSdejQoeLTLc5OwMx+q7ZGy8BSINvmUkr1dvaWX13Z2dkIoVGjRgUHB0dGRhILW7VqxWazXVxcQkNDiSUsFmvPnj0Mxn9u2MjKyrpy5UpptrVa7dKlS1u3bl3V0y2O78BWlOit1DiwCMi2uRQyg53Q8nd6hYeHC4XCZcuWzZ8/Pzw8vJpHSiSS7du33717VyqVIoTs7f97gMDlckuDXT/shGyFFLJNanC8bR4T4nCZTKbl73N0cXHZuXOnr6/v7Nmzp0yZkp+fX+nDxGJxdHR0QkLCF198sXHjxsDAwNLjbYSQnV19X+PNZjPYNvDlITX4eMzDQEwWw0pbKj8/v99++23Lli2vX79evnx56fKyt/EcPXpUIpFs3ry5b9++QUFB7u4fvv/MqncByYv1Nhy4o5vUINvmsrNnqWRWuU2COF/VoUOHrl27ll5wwuPxCgsLSx9TXFzs6OhYGuni4uLqo1vu6RankOr5QjigIzX4eMzl7sdTyS2f7WfPni1cuHDUqFF2dna3b99u1aoVsbxt27bnzp3bvXu3UCgMDg4OCws7dOjQli1bQkJCrly5cuvWLaPRWFxcLBKJKm223NMDAgIsW7ZWbXT25Fi2TWBZrLI7gaAaKpkh/bnCv42FT4OVlJS8fPnywoULCQkJ7dq1W7x4sUAgQAgFBwenpqaeOXPmxYsXQUFBvXr1MhqNhw8fvnz5cuPGjZctW/bo0SOlUhkWFnbr1q20tLRx48aVbbbc05s0aWLZsm/EFbb+WCgQwbaBvGBsBnNpVMY9K9I/X+2PuxD81ArD3tUZU1fCqiA1+LtrLg6P6d9GkJehrmbYsPXr1586dari8sDAwJSUlEqfsmvXLotvVMuJj49funRppb/y9vbOysqqaVXvXqlbdXKwaI3A8mC7XQPvX6sSzkmGzvCq6gHFxcXEhWXlMBhVrmc3Nzc227p/YdVqtUQiqfRXVRVWfVW7lqePnO0NO+QkBx9PDXgF8Fg2jIwUZVVjholEoqo6tzDicrmenp6Wai3pZol/Gz4Em/zgHFjNdBnskvpAhrsKnNKeKboMcsFdBfgwyHbNOHvYejfnXT5Y+dVjtBe3MatDhCPbFq5aoQDIdo21+khoy2HeOSXGXUh9u/BXXkCovWfTehqdAtQR9KXV0pPrxSqFsVOkE+5C6snFvXnN2tn7tYLBySkDttu1FNJdxGCgM7tycBdidXqt6dCGd14BPAg2tcB2u07eJCmuHclv38sxtAfpusct4u4ZceYLZY8Rbm4+cIUpxUC268pgQHdOFqYmykK7i/yC+M4edJiYPi9DnfVKdfes+KN+zmF9HBH0nVEQZNsylDJDcnzJmyS5XmcMCLZnsBBfyLZ3ZBsM1Fi9TAZDKtEpZQYGAz2/JxU6sQNC7UO6i5hw0EZZkG0Lk4p12WkaeZFOKdMzmAx5sYVv+U5PT+dyuebcv10jfAcWk8GwE7LsHW28Anh29nSbS7wBgquLLEzobCN0tuJEtmvX/unk69v/U2sNhAZoA3a5AKAnyDYA9ATZphihUMjlVnmTKQClINsUI5VK1WoY9B98GGSbYjgcjrXv9wb0ANmmGI1Go9fDoP/gwyDbFMPj8WxsrHiODdAGZJtiVCqVTqfDXQWgAMg2xTg6OvJ4cAc1+DDINsUUFRWpVCrcVQAKgGwDQE+QbYrhcrksFtzIAT4Msk0xarW67Oy8AFQFsk0xXC4XzoEBc0C2KUatVsM5MGAOyDYA9ATZphihUMjhwLCE4MMg2xQjlUo1Gg3uKgAFQLYBoCfINsWIRCIYmwGYA7JNMcXFxTA2AzAHZBsAeoJsUwzcBwbMBNmmGLgPDJgJsg0APUG2KQbGMAZmgmxTDIxhDMwE2QaAniDbFAPjkwMzQbYpBsYnB2aCbFMM3AcGzATZphi4DwyYCbINAD1BtimGx+NBXxowB2SbYlQqFfSlAXNAtilGJBLBvSLAHJBtiikuLoZ7RYA5INsUA9ttYCbINsXAdhuYCbJNMXw+39bWFncVgAIYJpMJdw3gwwYPHkx8UjKZjM1mE7vlDAbjxIkTuEsDJAVnSqnBzc0tMTGxdAbP4uJio9HYp08f3HUB8oJ9cmqIjo52dnYuu8TFxWXChAn4KgJkB9mmhp49e/r5+ZX+12QyBQcHBwUFYS0KkBpkmzLGjBkjFAqJn52dnadMmYK7IkBqkG3K6N27d7NmzUwmE7HRDgwMxF0RIDXINpWMHj1aJBI5OztPnToVdy2A7KCf3PLUSmNhlkatMli85cZOHVr59nJ0dGRrvF8/kVu8fb4928WLY8NhWLxlUP/g/LYlmUzo/F95714ovJrzDXrqrVid2iDO0QSECHqOcsNdC6gryLbF6DSmI79lte3l7BVgh7uWOkl9UPL+tWJIrCfuQkCdQLYtZv/azPAod8dGdLggNC1Z/u6lbMBkD9yFgNqDvjTLSL0v82rKp0ewEUJN2giYTGb2G5jkgMIg25aRn6Xh8lm4q7AkGw5TnAODLlIYZNsyNCqj0IUmG22Cg4utQgqDN1EYZNsytCqD0WDEXYUlGfRGA0SbyiDbANATZBsAeoJsA0BPkG0A6AmyDQA9QbYBoCfINgD0BNkGgJ4g2wDQE2QbAHqCbANAT5BtmjMYDMnJj3FXATCAbNPcup/+teGXVbirABhAtsnufXZWXcbG0WrgHuwGCsY5xUOr1f751/YrV87nF+Q5O7t8EjFg4oRYYrovnU63c9eWS5fPqlTK4OB2L1+mjIuZOmTwCITQo8cPtv9705s3Lx0dndqGdpg6ZbqzswtCaNCQHrO/WhQff/XuvXg+XzBo4PAJ4z9DCP24dvnVaxcRQj17hyGEDv991sXFFfdbB/UEso0Hi8VKTLz3cedunh7er1+n7t23095eOGpkDEJo6x+/njhxZOqU6S4ublu2/qzRqPv3G4wQSnyY8M2iWRF9IodGfSqTlhyNOzBn3rRtW/ZyuVyE0I9rvps4IXb06AnXrl3cvWdbi+aBnTqFx4ydXJCfl5PzftE3KxBCDg4i3O8b1B/INh4sFmvz73sYjP+MBJ6dk3Xj5pVRI2MMBsOpU3EDIqM+HTWOmPfrh1VLk58+bt+u48ZN6wYNHDZr5gLiKWFhnSZMGnH/wZ2u4T0RQpH9h0SPnYQQCmja/PSZfxIe3OnUKdzb28fBQSQpErdpE4r17QIMINvYFBVJ/vxr+/0Hd2UyKULIXmCPECopKdZqtV5ejYnHED/IZNLc3JyMjLT379+dOn2sbCP5+XnED1wuj/iBxWK5urqJCwvq/Q0BcoFs4yGRiD+fFs3j2U2e9IWnp/fOnZvfZWUQu80CviA5+fHIEdEIoZSUpwihpv7NiorECKEJ4z/v1rVX2XacnFwqNs5msQ1Gy89qAqgFso3HiZNHi4okv2/c3aiRO0LIzc2dyDaLxRozZuL2f29a+cMSFxe34ycODx82pnFj33fvMhBCGo3ax8fPjOb/BwxB3zDBOTA8pNJikciRCDZCqERaXJrAqCGjOoR1KiqSyOWyJYtXzpg+FyHk7e3TqJH72XMnVCoV8TC9Xq/T6T74QlwuTyIRG420GqcRmAOyjUdoaJhEIt65a8u9hNvrf1p5796twsKCkpJihNC/flgsFDpERka1bduBgRh5ebkIIQaDMf3LuWJx4fSZE/85fjgu7uD0GROPnzj8wRcKCW4nk0k3/Lzq/PlTT548rJc3B0iBtXz5ctw10MGrR3KRG8fB7CHKfX2bmEzGf44fvnnjsqdX43lzlyUnP1KplKGhYUVF4lOn4y5fOX/j5pUrVy8c++dv90aeTZs29/Vp0rJFq6SkRxcunk558bSpf7OIiAHE+e0DB3c3a9ayQ1gnovFTp+L4fEGvnn0RQv7+ATJZyeUr554kPfT29g0MbG1mhQXv1CajyacFtec2a8hgPjDLOLMjx7e1vU9LQd2bMhgMxEUsCCGpTPrNollsNvu3X/5d95Zr5NntIoPO2GWwcz2/LrAU6EsjnZ82/PDmzcuPP+4mEjlmvkt/+/bVgAFDcRcFqAeyTTodO3bOz889Grdfp9N5eHiNH/cZcT4MgBqBbJNOj+59enTvg7sKQHnQTw4APUG2AaAnyDYA9ATZBoCeINsA0BNkGwB6gmwDQE+QbQDoCbINAD1BtgGgJ7jm1DL4IrqtSRabaWvuHauAjGC7bRksW11hFq1G+c/LUAmdbXBXAWoPsm0Be/fu/ef8v2VFHx7hiEJUcr1PCz7uKkDtQbbrJC8vjxhscP2mb72acuOP5eGuyDIu78tu18sxt+Ad7kJA7cG4K7Wk1+uXLFkSFRX18ccfly5MviV9m6xo3JLv4sll2zCwFlgbGqVRkqt5eruo50g3n5a8mJiYmJiYfv364a4L1AZku5bi4+PVanWfPuVvtM5+q065J1XI9MV5VtlFl8tlLBaLx7PKMGYCEdvZ0za0u8jB5T9H2qdPnx4wYEBhYaGLSyUDoQMyg2zXzOvXr5ctW3bgwAEsr56TkxMbG8tisY4dO2bGwy1m69atDAYjNja2Pl8U1BEcb5uL+CN4/PjxH3/8EVcNBw4ceP/+fXZ29sGDB+vzdadNm8ZgMNRqtVKprM/XBXUB222znDp16uXLl3PmzMFYQ0FBweTJk3NychBCvr6+R48erecCTCbTkydP7ty588UXX9TzS4NagO32B6hUKqVS+erVK7zBRgj9+eef2dnZxM+5ublxcXH1XACDwQgNDbWxsbl06VI9vzSoBch2ddavX5+WlsbhcL7++mu8leTl5V2/fr10Tl+NRrN//34slUydOrVTp04IoS1btmApAJgJsl2lP/74w8vLq1WrVqUzAWB0+PDh0o02ITs7u/433QSBQIAQ4vF4v/76K5YCgDngeLs8qVS6devWBQsWaLVaW9JcUR0VFZWVlVVuIZaj7rKKioocHR0vXrwYERGBsQxQKbrd4VB3X3755bx58xBC5Ak2Quiff/4hfli7dq2vr++nn36KuyKEEHJ0dEQIcbncESNGHDlyBHc54H9Atv/j7du3mZmZPXr02Lt3L+5aqsPlcm1syHULR9euXZs0aYIQSk1NbdGiBe5ywH/A8TZCCL1//37hwoWhoaG4C/kwpVJpMBhwV1Get7c30ZH+6aefwjlwkmjo2X769Gl+fj6LxTp8+LBIJMJdjllKe8vJpnnz5j/88MPDhw9VKhXuWkDDzvatW7fWrVvn5OTk7u6OuxZzcTgcLpeLu4oqBQQEhIeHm0ym2NhYvV6Pu5wGrYFm+82bN8S5nD179rDZVOp0kEgkTCbZPzU7O7vPPvuM5D0XtEf2b4k17N27d9euXQihkJAQ3LXUmMlk4vF4uKv4sLCwsIkTJyKENmzYgLuWBqphZVsmkxEXXaxcuRJ3LbUkFov5fCoNhxIcHEycUwT1rAFle//+/ZcvX0YIDR8+HHcttUdcLoK7ihro06fPd999hxBKSEjAXUvD0lCy/fr165ycnKioKNyF1FVxcTG1so0Qsre3J3aaZs+ejbuWBoRK3Ui1c//+fV9fX3d397lz5+Kupa6MRiODwaDoECi9e/e2tbWVy+WlV6QDq6L5djshIWHHjh1ubm70+DJlZGRQ62C7nK5duwoEgtevX//999+4a6E/mmebyWRu3boVdxUWk5GR4efnh7uKugoNDc3IyHj16hXuQmiOntlOT08nDq3DwsJw12JJhYWFrVu3xl2FBSxYsMDR0TE/P5/YRQfWQM9sHz58uPTGKTq5e/cuDbbbBBcXFycnpwEDBuTn5+OuhZ7olu1Dhw4hhObPn4+7EKt4/PgxFa+3qQqbzb5+/XpSUhIMImANtMr2qlWrPDw8cFdhLe/evRMIBJQ7AfZBffr0MZlMq1evxl0I3VR5DoxaB0JGo5HJZI4dO9bFxaWayk0mE3GulYpSUlIqTnVAD0wms1mzZsQ8B7hroY8qs02hu3CNRqNcLhcKhXZ2dtWXzWAwqJvtM2fOUPqKuuqNGDGi4qBRoC7osE+uUCiEQiHuKqxLr9ffvXu3a9euuAuxImKAh06dOmm1Wty10AEdsk3dTbH5rly50rNnT9xV1If4+PhDhw5B71rdUTjber2+pKQEdxX15NmzZw1kPk02mx0TE6PX61NTU3HXQm3Ysv3ixQuNRlN2yYYNG7766iszn240Go1Go4ODg3WqI5fCwsJz5851794ddyH1x8bG5vvvvy8qKsJdCIXhyfbFixfnzJmjVqvLLrSzs6vRqAOkGmPYqg4ePDh69GjcVdS3/fv3Jycn466CwvDcB1ZpZ8m0adPMea7JZJJIJM7Ozlaoi6QOHjx48eJF3FVg0K1bt2vXroWGhlJlmEpSqXJekYpXAqrV6oMHD16/fl0sFru5ufXu3XvUqFEsFksikWzfvv3BgwcGg6FVq1ZTpkwhRqtesWKFt7c3i8U6d+6cXq/v0KHD9OnT+Xz+xYsXf/7559Jmv/7664iIiIkTJ+bn57dq1Wr9+vUIoZEjR06fPv3OnTsJCQl8Pj8yMnLs2LEIoUePHi1ZsmTDhg0tW7Yknj506NDBgwdPmjSJmAFv+/btjx494nA4TZs2HT9+fPPmzf/n3TIYrq6uVliNVnTu3LlXr17NnDkTdyHYDB48eMuWLV5eXrgLoRhz98kNBsPy5cvj4uK6dOkye/bs8PDwrKwsFoulVqsXLVr0+PHjyZMnz5gxQywWL168uPTqkbi4uLy8vOXLl8fGxsbHxxOzRoeFhQ0bNgwhtHz58nXr1hG3c8yaNatp06ZlX3HDhg3+/v5r167t1avX3r17Pzhqh0QimTdvnkwmi42NnTRpkl6vX7BgQXp6ei1XDGmsX79+3LhxuKvA6cSJEzweD3rOa8rcffL4+PikpKSvvvqqb9++ZZdfvXr13bt3q1atIgbuDwoKmjx58okTJ4jNrJeX1/z58xkMRosWLW7dupWYmDhlyhRHR0fiytAWLVqUdoa1a9cuLi6u7BH4J598QsyM4+/vf/78+YcPH7Zp06bcIXpZBw4cEIlEq1atIsYt7dWr19SpU8+fPx8bG1vblYPfrl27oqKiYI+Uz+cfP36cBsPm1Cdzs52YmMjhcCpe85iUlMTn80tn5GjUqFHjxo1fvnxJ/JfD4ZQOlN+oUaOUlBTzKysdhZvFYjk7OxcWFjIYjGqG5n7w4EFBQUHZK7d0Ol1BQYH5r0g2Op1u27Ztd+/exV0IfhwOx8/Pb+XKlUuXLsVdC2WYm+2ioiInJ6eKs9UqlcpyJ6Ls7e0lEkklr8Rm13qyGzabbTQaqx9zv6ioqGPHjsSBdylKj1KyYcOGOXPm4K6CLEJDQwMCAmQyWUO4VMkizM22QCCo9GSjs7Pzixcvyi4pKioys7/K/CMok8lkNBqrny5HIBBIpdLGjRub2SbJpaSkvHjxYuHChbgLIRFiPCaDwQAHKeYwty8tJCRErVZfu3atdAkxI0xgYKBMJiuNd1paWnZ2dlBQUPWtEVvgSjfvlTIYDMRkGsSHKhaLieUSiaR0YprQ0NDnz5+XHamH0rNSzZkzZ82aNbirIB0/P79yPT6gKuZut3v27Hny5MkNGza8fPnS398/PT390aNHGzdu7Nmz56FDh1avXj1mzBgGg3Hw4EEHB4cP3qnXqlUrFou1bdu2iIgIrVYbGRn5gSr/f1ofb29vNze3gwcPikQilUq1Z88eYnuOEIqOjr5///7SpUuHDh0qEokSExMNBsO3335r5hsklR9//HHKlClubm64CyEdNpt97NixxMTE9u3b466F7MzdbnM4nNWrV/fu3fvq1aubN29OTEwMDw/X6/VsNnvlypXNmjXbvn37tm3bvL29165d+8HxAzw8PGbOnJmVlbVt27YbN25U/+DS9BIf7eLFi9ls9tKlS3fu3Dl27NjSq9M8PDzWr18fGBh46NChP/74o6SkhKI3V9y+ffv9+/cjRozAXQhJeXp6QrDNUYNrV7DQ6XQVu+tqjRLXrsTGxm7evLlityUolZubu2DBgj///BN3IaRG9vvA9Ho9Jaa2s5SYmJjZs2dDsKvn7u7eu3fvM2fO4C6E1Mi+3bYskm+3V6xYERISMmTIENyFADog+3Zbp9PhLqGeHDx4kMfjQbDNl5KSQsyjDipF6mxrtVpKn8cyX1JS0uPHj+k69LKVuLq6Tp8+HXcV5EXqfXKtVmsymTgcjqUaJOc+eXZ2dmxs7MmTJ3EXQj0nTpxo3rx56U2BoCxSZ9viSJhttVrdu3fvW7du4S4E0E2V2S57VhmXZ8+eubm5WTCNRqOx9DIYkujatev58+ft7OxwF0JVe/bsGTlyJKzAiqo83maSwL59+5KTky3YINmCHRUVdeDAAfhe1kVubu6pU6dwV0FG5PqulxMcHEy2XWgL+uyzz9asWUMMyg1q7fPPP09LS8NdBRlVuU8OrCo6OnrZsmXQCQSsh9TnwF69ekXLP8kxMTEQbAtavHgxjIhaEdmzvXPnTtxVWFh0dPSSJUsg2Bbk4eGRmJiIuwrSIfvx9pMnT3BXYUnDhg3bv39/9QPIgJoaP348zFJQERxv158BAwb8+uuvAQEBuAsBDQKp98kRQo8fPy4uLsZdhQV07959x44dEGxr0Ol0M2bMwF0F6ZA928nJybt378ZdRZ0UFxeHhYWdPn3a3d0ddy30ZGNj8+LFC9gtL4fs2R40aBClhxZKTU2NiYl58OCBQCDAXQudHTx4ENZwOXC8bUXx8fGbN2/ev38/7kJAQ0T27TZC6Pnz51Qcf//YsWNHjhyBYNePn3/++dGjR7irIBdSnwMjNG/evEuXLvfu3cNdSA38/vvvMpnsl19+wV1IQ5GTk2P+kNgNBDX2yR88eODk5OTv74+7ELMsXrw4ICBg8uTJuAtpQNLS0hwcHJycnHAXQiLUyDaFTJgwYezYsTA+PsCOAsfbhO+//57kR90lJSVfffXV/PnzIdj1b8WKFefOncNdBblQZrv97NmzAwcOrFy5MiIiQiwWR0dHz507F3dR/5WUlDR79uyjR49+cN4FYEF9+vQhxntWKBQ2NjbERBQCgeDo0aO4S8OPAn1phKCgoPj4+Hbt2jGZTAaDYcFB1Oru4sWL+/fvv3LlCu5CGhyBQJCVlUX8TMzNbjQa27Zti7suUqBAtqOiosRisUKhIMZOIRZaaqaRutu4cSODwdi1axfuQhqigQMHbtmypezsrl5eXtHR0ViLIgsKHG8HBwdzOJzSVBNIMgnzvHnz7O3t4WJmXEaPHu3j41N2SevWrdu0aYOvIhKhQLZXrFgRHR3t4eFRuoTFYpWLOhYjRowYOHDgxIkTcRfScAkEgv79+5dut93d3WGjXQp/QswxadKk+fPnBwQEED1/bDbbxsYGYz0ZGRlhYWHr16/v0aMHxjIAQmjs2LGlm+6QkJDWrVvjrogsqJFthFC3bt3WrVsXFBTEZDJZLBbGvrQbN258/fXX9+/f9/Pzw1UDKCUQCAYNGsRisdzd3UePHo27HBIhRV+avMhgMHx4OHQhz33jhh3r1q17+vSpScsrKazXqcJYLKbAkRUXF3fz5s24uLj6fOlaKynQIYYZj6O4vr2Gnj1xPSAgwMejZT1/K7AgvooffBjm89vXjxa+TJS6+fCK87XmP8ug17PqfaRxkZttfqbKzq0kejbZT7FIxbrbpyRvkmQ+LQWSHA3ucoCFidxs8jPVLcKE3Ya5VPMwbNk26E37Vme2j3Bp5Mfj8KhxaKBRGfMyVIkXC6O/8WGxSbpBLM7XH9uc1XuMp4OrLROm8aYpjdKYm656eLm6ryK2bP/1Q0bXYR7OnrYcp+CcAAAWvUlEQVRYXr0uJDma60dyxy/1xV1IJaRiXdzG98O/ho6ABkGcrbkZlztuSeVfRTzZfnytWKtlBH5ElutPaupFQgmbbWrbU4S7kPLO/5kX+JGjozv1/mKC2km5V2LLMYV2r+SriGdnOOuVSiAiRTde7fAd2FmvyTgx+OsnMgdXCHYDwhey31fxVcR1oMtwdCPRBeE15ejGYZCvA7qkQOfTUgDH2A2KYyMOMlX+VcST7aJ8jZEi959VymgyFeWRr/+ZgYpyyVcVsCaj0VRUUPmHTo0OagBATUG2AaAnyDYA9ATZBoCeINsA0BNkGwB6gmwDQE+QbQDoCbINAD1BtgGgJ8g2APREmWwbDIbk5Md1bOTX39YMG/GJhSqiLYus6ko9T3mq0cAV7/WEMtle99O/NvyyCncVDYKVVvW58yenz5ioVpPx3lhaoky2tfD3vr58cFXXbjyPumyxLTKCCFWmvrMUamT7x7XLr167mJ7+tmfvsJ69w3JysxFCer1++783jRjVL6Jvp6mfj4m/da308c9Tns6aPbVv/85DhvZes/Z7qUxaabP7D+weNTqy/4DwmV9NSXyYUI9viCzu3o2fPPXTfpFdJk4eGXfs76pWNXEsc/v2jZjxQ3v2Dnv46P6OnZs/6fdxaTsvUp/37B12L+E28d/k5Mfz5n8ZObBr5MCui5bMfvnqxbnzJ3/59UeEUNSwPj17h507fxIhVE0jFV8RIfTo8YMvZ0zs27/z6LED16z9XiwurP7dXbt+qWfvsPj4azO/mhLRt9Ou3VuJacM2/f7T0OERAwZ1m/bFuCtXLxAPfvcuY87caf0HhI8aHbnh51VGoxEhNGhIj/kLps+YNblfZJdPxwzYuWuLXq8nHi8WF678YcmgIT36DwhfsHDG27evieVHju7/csbEq9cuxoyL6j8gfNbsqZmZ6VWt7WrqqTtqDH4SM3ZyQX5eTs77Rd+sQAg5O7kghNb/tPLS5bMx0ZP9/Jpeunx22bfzfv15e3Bw2/T0t3PnTfPza7pg/nclxUW7dm/Nz8/9af2Wcm0mPkzY/u9NvXv3+6hD54T7t1VKJaY3h41Go1m+YqGfr//cOUvT0l6LxQVVrWqEkEIh37Fr8+yvvlGrVe3adnj8+EFVzd5/cHfR4q+a+jebFjvbaDTeuXPDoNd/1LHLqJExhw7vXf3DL3y+wNvbp6qnlyr3iokPE75ZNCuiT+TQqE9l0pKjcQfmzJu2bcteLpdbfTu/blwzdfL0yZO+8PbyMRqNS5Z+nZubHT12kkjk9Pjxg3+tXKxWqyL7D1n3078yM9OnfzlXqVQ8evygdOKazHfpX0z72sXZ9c7dm/v275LLZbNmLlCr1XPmTZNKSz7/bBaXwz3w954586b99ecxe4E9Qigl5emhQ3/NnbtUr9dv2PDD6jXfbfl9j1KprLi2q6mnhh9mJaiRbW9vHwcHkaRI3KZNKLEkMzP9/IVT48dNnTghFiHUvVvvmPFDd+/ZtuGnrXv37WAymWvXbCJWtL29cNWP3z558jAkpF3ZNnNzsxFCQ4eMCgoKjoiIxPTOcFIqFRqNpmvXXhF9+pcurLiqCVqtdt6cpYGBH561Y9Pv693dPTf+tpOYMTdqyEhiuaenN0IoMLC1g4NZ48yVe8WNm9YNGjhs1swFxH/DwjpNmDTi/oM7XcN7Vt/O0KhP+/YdSPx87fqlpORHB/addHFxRQj16d1PpVIejTsQ2X9Ibm5282YtBw4YihAaNTKm9Ok9ukf06N4HIdS6dYhUWnLyVNyECbE3blzOzEz/af2Wdm07IITatGk7NmZwXNzBCeM/I571w8qfnZycEULDho3evOXnEmmJXC6ruLZv3LxSVT3mrKLqUSPbFT1JeogQCv//z5XBYHQI63Tx0hmE0OMniW3bdiCCjRDq0OFjhFDqy+flst3po3B7e+Gq1ctmzpjfqVM4jjeBmUjkGBQUvHffDi6XN2jgMCKKVeFyueYEOyc3OzMzfeqU6dW3Zo6yr5ibm5ORkfb+/btTp4+VfUx+ft4H22nXrmPpz3fvxuv1+rExg0uXGAwGPl+AEIroE7n/wO7fNq4dFzPV0dGp0qY6dux86vSxV69ePHmSKOALiGAjhNzdPXx8/FJfPi9TPI/4oVEjD4SQuLCgSZOmFdd2NfXUHVWzrVDIEUKOov9+BkKhg1KpVCgUCoVc5PDfCe7t7YUIocLCgnItODu7bPpt5+9bNixaMrt165Bvl652dXWrx3eAH4PB+HHVb//esWnrtl8OH9m7aOGKcn/+yuLx7Mxps7hIghByc21U9/LKvmJRkRghNGH859269ir7GCen6gbfJ9j9bzvOzi4b1m8t+wBiHoupU6Y7Ojrt3bfz7LkTn382a2jUqIpNCQT2CCGVSilXyB1EjmV/JRQ6iCt8xxBCNmwbhJDBaKh0bVdTT91Roy+NULaf08XFDSEklZaULpFIxGw2m8vluri4lV1eVCQp/VTK8fHxW7P6t5/Wb0lLe71m7XLrvwPSEQgEs7/6Zs/uo3y+YOmyOcr/73T4YJdy2SmvyyK2OZIicVVPLNtyVY1UVqc9QkijUfv4+JX9JxDUbBNnby8sLi5q1MijbCNent5EMSOGj9331/Eunbv/tnFtpWf4CwvyEUKuro1c//c7Rnz9Kv2O/e+7KL+2q6mn7iiTbS6XJ5GIid5L4rCNwWDcvRdP/Fer1d69Fx8UFMxisYKCgh8/SVSr1cSvbty4jBAijh5tbGxVKmVpV6dWq0UItWvboVOnri9fvcD0znAizkt5engNGzparpATfRDlVnWlHBwcdTpdyf9/v4knIoQaN/Z1dXU7f+FU6Uo2mUxEUzwur9wOVFWNVOTt7dOokfvZcydUqv+cHtfr9Tpdjaf+ateuo8FgOHHySOmS0gaJVcHn8ydOnIYQqvh9MJlMZ8+dsBfY+/o0CQoKlsmkKSlPiV+9efPq/ft35XooKqq4tqupp+4os08eEtzu7LkTG35e1aZ1qL29sHPnbn0/Gbh7zzaDweDp6X369DGJRLx40b+Int4rV84vXDRz0MDh+fm5e/78o21oWGhIe4RQs4AWarV6+YqFX0z7Wiot+X7Fwqgho3g8u4SE2y1btML9FuubXq+fMGl4j+4RTfyaHj9+WMAXEN1dFVd1xeeGtf+IwWBs+n39iOFj09PebNv+G7GcwWB8/tmsH1YtnT5jYt++g5hM5oWLp4cOGRURERnUOoTFYm3avL5/38EarWbwoOFVNVIRg8GY/uXcb7+bP33mxMGDRhgNhvMXTkVERI4YPrZGbzmiT+TJU3Fbt/2ak5vdvFnL169fxt+6unvnES6Xu3zFQgFfENa+E7HBaNE8kHjK1WsXnJ1dOBzu9euXHj1+EPv5LB6P16d3/337dy1fsXBczFQmk/nXX/8WiRyHDB5ZzUvrdLqKa7txY9+q6qnR+6oUa/lyDPuiSTdLmrSx5/BqMJS2v3+ATFZy+cq5J0kPHRxE7dt17BD2sUIhP3vu+JUr5/l2/HlzlxLdZkKhQ5vWbe8/uHPy1NHUlyk9e3wyf963xJy+TZo0VatV9+/fCWwR5OAgevPm5dWrFx4+TAgJaff17MXm92FoVMa0ZFlIN3LNK6JRGlMfyAI/MrcqjUaTmZkef+vqzfgrzs6u3yxY7uXlXemqvnfvVkZG2qejxpU+VyRy9HD3unz5bNyxg0qlYuSI6Phb1/r06e/t1djfPyAgoPmTJ4kXL515+TLFy6txeHhPV1c3ob3Q1bXRtWsX79y5KZNJ+/YdWE0jFV/R16dJyxatkpIeXbh4OuXF06b+zSIiBjg7V3e8nZ7x9vr1S0OjRpX2zLNYrB7dI+Ry6bVrF2/cvKJQyvv3G9KmTSiTyczOzrp7L/7ylXMqterzz2aGh/dACB04uNvDwyv15fNLl88ihKLHThr96XiEEJPJ7Pxxt7S01ydOHrl371bz5oHfLlvt7u6BEHqeknz//p3osZOIKeKzsjIvXzk/aNBwDpeblZVZbm1XU4/5H3r6M1lw10o+dDxzBv31Q0avsZ5CJ5v6f2mLkEp0V/ZljyPZlGAlhbrjW7KHziJXVZQ2aEiPyP5RX0ybjbuQKpUU6q4dyo5ZVMmHTpl9cgAqksvlY6IHVvqr2M+/Ik5WN1iQbUBhdnZ2f2zbX+mvhPZUnUnSUiDbgMKYTKaHu6f12j95/JoZjyIpypwDAwDUCGQbAHqCbANAT5BtAOgJsg0APUG2AaAnyDYA9ATZBoCeINsA0BNkGwB6wpNtJ3dbptljbpAQk8FwcufgrqICE8PJg3xVAWtiMpFjo8o/dDzZZjCROEeN5aUtQpKrQQzSDWTv4Mp+l6ow6EhXGLAecY6mqnu98WTbp7mdvEiP5aUtQl6sa9zcrLEB61mztoKiPC3uKkD9URTrvJvxKv0Vnmy37uKQmSrLeC7H8up1lJmiSH8mC+5KxlsIw6NcL+59j7sKUE8ynsszU+VtulT+VcQz7gpCyGRCR39736SNvVtjrsitrmNZ14/ifG1+pjrtqXTELG9E1u4Clcywe0V6r9GeDq42fAe4h5eeivK0+Zmq9Gey4bO8q+q5wpZtwoOLRS8fyjg8ZuF7sk/l5+LF0aiMzdvah33iaMbDcTLoTPEnCtOeKoTONgXvKNyvYT6j0chgMMwfFJnSnD25WrWheTv7sIjqvoqYs00wGJBRj7+M6jHZDFYNxm4kBZ2G7GvVUlauXNmxY8dPPmkQk6ub+VUkxT4bi4VYrAbxF7ee2XAaylo1MXQMlqHhvF9zwLUrANATZBvQgUgkIsYDB6Ug24AOiouLazGFEL1BtgEdODs7131WYJqBbAM6EIvFxMyNoBRkG9ABbLcrgmwDOoDtdkWQbUAHtra25s992UDA6gB0oNVqjUYj7irIBbINAD1BtgEduLi4QF9aOZBtQAeFhYXQl1YOZBsAeoJsAzoQCoVwPXk5kG1AB1KpFK4nLweyDQA9QbYBHcC1KxXB6gB0ANeuVATZBnTQQEZBrBHINqADMgzpSTaQbQDoCbIN6IDL5UJfWjmwOgAdqNVq6EsrB7INAD1BtgEdODg4wH1g5UC2AR2UlJTAfWDlQLYBoCfINqADGOe0Isg2oAMY57QiyDYA9ATZBnRgY2MDl5SXA9kGdKDT6eCS8nIg24AOYJzTiiDbgA5gnNOKINuADmAsxIog24AOYCzEiiDbgA4EAgGbzcZdBblAtgEdyOVyvV6PuwpygWwDOoBrTiuCbAM6gGtOK2LAGX9AXYMGDcrJySkdC5HBYJhMptDQ0B07duAuDT/YbgMK6969e2mqiWtORSLRpEmTcNdFCpBtQGHR0dFeXl6l/zWZTM2aNQsPD8daFFlAtgGFeXh4dOvWrfS/Dg4OMTExWCsiEcg2oLYxY8b4+fkRG+0WLVrARrsUZBtQm5eXF7Hpho12OZBtQHkjR4709vYOCAjo0qUL7lpIBM6BgXqVm65+m6zKzVSpZAaVQm/LYyuKLHBe2mgwMBgMhiWmFnH04KmkWq6ALXKxdfe1bRosEDpT8mpWyDaoD3qd6e7Zoud3im3tbOxdBbZ2bDaHxbZls2yZiGzTgTCRXm3Qaw0GnUEuVsnFSlsuM7SbQ0g3B9yV1QxkG1hd/HFJ0s0iz5YuAlc7ti31DgPVcl3xe6lcrAwf4tIyTIC7HHNBtoEViXMNZ/fk2vK5bk1FuGupK51an/dKwrNDQ6Z5UOKWM8g2sJb3r9SnduQEdPZm2VBvW12VkjyFJKNowjJf8s8aCtkGVlGQpTu7J8+nnQfuQixPo9AVvikcPdeLxSb1yKqk/+MDKEiSqz25PZuWwUYIcfg2rs1c9/wrA3chHwDZBpa3f02m/0feuKuwIlse27Wp87HN2bgLqQ5kG1jY6X/n+bX3QKTeXbUAe1c7vdHm6W0p7kKqBNkGlpT9Vl2YpxM4c3EXUh+cfUXx/xTgrqJKkG1gSdePFrr6O+Guop4w2UwnH4d754pwF1I5yDawmLwMjdHItBNxcBdSiXsPjs9b9pFUWmjZZp19HJ7fI+luOWQbWMybZLmtgIzBth6WDZPBYuakqXEXUgnINrCYN08U9q52uKuob3wn/pskBe4qKkGFa+cAFShlBpYti2tvlYGEtVr12UtbHiWd1+k0ri6+PcKjQ9tEIIRu3D7wOPlSt85jzl7aIpMVenm2HDlkkZurH/Gs99mp/5zZ8O79c6G9i6uzjzUKIzrMxblkPOSGbAPLUMoMGpXBGi0bjcad++YWFeX06jZBIHB68zZx76GlGq3qo/aDEUKZWU+v39o3cshig0F/5MTqg3ErZsXuRAjlFaRv2fkF304UGfEli8m+eM1aI5+ybZhZ78i4Tw7ZBpahlOptOCxrtJz8/Gpa+uPFc/9xELoihNoF99VolfF3/iayjRCaFL1eaO+MEArvNOrkuV8VyhK+ncPp8xsZDObM2B0CviNCiMFkxp1ca43y2ByWWmGVP2p1BNkGlqFWGrnW6UhLSb1lMOpXbRhausRoNPC4/73XkmPLI35wFHkghKTSAhs2J/X13Y87DCeCjRBiMa34VXdpbKcsMdg5WOVPW61BtoFl2Ngy1AqrzOwhk4uF9i7TJv1ediGzsqyyWTZE8qWyQoNB7+RYTxe0i98ruQLSdUtDtoFl8IVsvcYqu6Z2PKFcUeQo8rCxMXe/gNhcy+X10cVl0BnZNkwmi3QX2ZLujw2gKL6QrddaJdsBTTsYjYbbCUdLl2i0quqfwuXyXZwbP3l2Wa+3+qTceo1B4GBj7VepBdhuA8vgi1jIZNJrDGxL96i1D+l/78E/p85vLCrO8fJokZ37Kvn5tQWz/ra1re6q9U96Tt1/5LuNf0zt2G4gg8m8eedvy1ZVSlmidvEm4xU7kG1gMX6t+NICpZO3vWWbZbNtPpvw25kLvz9KunDn/jFXZ5/OHYexWB/46rYL6adSya7d2nfqwsZGrv6+jVsXFFrljmuFRBnSn4zDJMK4K8Bi0p8pbp4qaRzcCHch9erphbQZPwfgrqISsN0GFuMXxL/xj8SgM1YzQNrSH3pXulxgJ5IriysuD2rZbczw7yxVoUot/+GnIZX+yrdxm4x3yRWX83kOi+bEVdVgSY6iZUcybrRhuw0s7NldadJtlUegS1UPkBRVPlaJXq9jsyvpkbK15ZWeo647o9FYXJJb+e9MDMSoJAsMBtNR5F5Vg6k3MsYv8eUJyHVmmwDbbWBJQZ2E988XaRQ6Dr/yrmMnR896L+q/mEymBQsQZ5S0CBOSM9hwDgxYXv+J7oVpYtxVWJ1BZ1SI5T2GV7mHgh1kG1hYI19OcBf7vFQLj4JANm/uZI2Y5YW7iupAtoHlteksbBbCzU6hbbzfJeVGTfe0syfp3jgBsg2sol1PB/9A25zn5B0qsHYMOuOr+Mz+41zdSHm9SlnQTw6sKCVBlnRLbu/uQM5B1GqqKEuW91oSs8hHIKJAJzRkG1iXOFt7YX++wcB0C3C2taNAJColK1DmvZI0bsbrO94Ndy3mgmyD+pD2TPHwqrSkUMd3tnNoJODw2Qwm6W6cKsdoMCkkKlmBUlao9GzC6zrUWeRKxntCqgLZBvWnMFv7+on8Xao6/52SxWbaclk8BxutdUZiqjU7e05JgVKrMvAdbOwd2S3aC5q05pO826xSkG2Ah0ZpVEj1WpXRSLJvIIvF5PKZfAc224bsexbVg2wDQE9wDgwAeoJsA0BPkG0A6AmyDQA9QbYBoCfINgD09H8glswvq62G0wAAAABJRU5ErkJggg==",
+      "text/plain": [
+       "<IPython.core.display.Image object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "from IPython.display import Image, display\n",
+    "\n",
+    "display(Image(graph.get_graph(xray=True).draw_mermaid_png()))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Run scenarios\n",
+    "\n",
+    "Note: LLMs are fundamentally probabilistic so wrong answers are possible even if implemented correctly.\n",
+    "\n",
+    "## Scenario 1 - name of wagon leader\n",
+    "\n",
+    "This test confirms that our graph has been setup correctly and can handle a case where tools don't need to be invoked."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      " Question: What is the first name of the wagon leader? \n",
+      "\n",
+      "\n",
+      " Agent response: Art\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "scenario = {\n",
+    "    \"question\": \"What is the first name of the wagon leader?\",\n",
+    "    \"answer\": \"Art\",\n",
+    "    \"type\": \"free-form\",\n",
+    "}\n",
+    "\n",
+    "print(f\"\\n Question: {scenario['question']} \\n\")\n",
+    "\n",
+    "res = graph.invoke({\"messages\": scenario[\"question\"]})\n",
+    "\n",
+    "print(f\"\\n Agent response: {res['messages'][-1].content}\\n\")\n",
+    "\n",
+    "assert res[\"messages\"][-1].content == scenario[\"answer\"]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Scenario 2 - restocking tool\n",
+    "\n",
+    "In this test we want to see the agent choose the restocking tool and choose to use the multiple choice output."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      " Question: In order to survive the trail ahead, you'll need to have a restocking strategy for when you need to get more supplies or risk starving. If it takes you an estimated 3 days to restock your food and you plan to start with 200lbs of food, budget 10lbs/day to eat, and keep a safety stock of at least 50lbs of back up... at what point should you restock? \n",
+      "\n",
+      "\n",
+      " Using restock tool!: daily_usage=10, lead_time=3, safety_stock=50 \n",
+      "\n",
+      "Called multi choice structured\n",
+      "\n",
+      " Agent response: D\n"
+     ]
+    }
+   ],
+   "source": [
+    "# helper function for multi-choice questions\n",
+    "def format_multi_choice_question(q):\n",
+    "    question = q[\"question\"]\n",
+    "    options = q.get(\"options\", \"\")\n",
+    "    formatted = f\"{question}, options: {' '.join(options)}\"\n",
+    "    return [HumanMessage(content=formatted)]\n",
+    "\n",
+    "scenario = {\n",
+    "        \"question\": \"In order to survive the trail ahead, you'll need to have a restocking strategy for when you need to get more supplies or risk starving. If it takes you an estimated 3 days to restock your food and you plan to start with 200lbs of food, budget 10lbs/day to eat, and keep a safety stock of at least 50lbs of back up... at what point should you restock?\",\n",
+    "        \"answer\": \"D\",\n",
+    "        \"options\": [\"A: 100lbs\", \"B: 20lbs\", \"C: 5lbs\", \"D: 80lbs\"],\n",
+    "        \"type\": \"multi-choice\",\n",
+    "    }\n",
+    "\n",
+    "print(f\"\\n Question: {scenario['question']} \\n\")\n",
+    "\n",
+    "res = graph.invoke({\"messages\": format_multi_choice_question(scenario)})\n",
+    "\n",
+    "print(f\"\\n Agent response: {res['multi_choice_response']}\")\n",
+    "\n",
+    "assert res[\"multi_choice_response\"] == scenario[\"answer\"]\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Scenario 3 - retriever tool\n",
+    "\n",
+    "In this test, we want to see the retrieval tool invoked and multiple choice structured response."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      " Question: You’ve encountered a dense forest near the Blue Mountains, and your party is unsure how to proceed. There is a fork in the road, and you must choose a path. Which way will you go? \n",
+      "\n",
+      "Called multi choice structured\n",
+      "\n",
+      " Agent response: B\n"
+     ]
+    }
+   ],
+   "source": [
+    "scenario = {\n",
+    "        \"question\": \"You’ve encountered a dense forest near the Blue Mountains, and your party is unsure how to proceed. There is a fork in the road, and you must choose a path. Which way will you go?\",\n",
+    "        \"answer\": \"B\",\n",
+    "        \"options\": [\n",
+    "            \"A: take the northern trail\",\n",
+    "            \"B: take the southern trail\",\n",
+    "            \"C: turn around\",\n",
+    "            \"D: go fishing\",\n",
+    "        ],\n",
+    "        \"type\": \"multi-choice\",\n",
+    "    }\n",
+    "\n",
+    "print(f\"\\n Question: {scenario['question']} \\n\")\n",
+    "\n",
+    "res = graph.invoke({\"messages\": format_multi_choice_question(scenario)})\n",
+    "\n",
+    "print(f\"\\n Agent response: {res['multi_choice_response']}\")\n",
+    "\n",
+    "assert res[\"multi_choice_response\"] == scenario[\"answer\"]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Scenario 4 - Semantic caching\n",
+    "\n",
+    "Agent workflows are highly flexible and capable of handling a wide range of scenarios, but this flexibility comes at a cost. Even in our simple example, there can be multiple large-context LLM calls in the same execution, leading to high latency and increased service costs by the end of the month.<br>\n",
+    "\n",
+    "A good practice is to cache answers to known questions. Chatbot interactions are often fairly predictable, particularly in support or FAQ-type use cases, making them excellent candidates for caching.\n",
+    "\n",
+    "\n",
+    "![diagram](../../assets/cache_diagram.png)\n",
+    "\n",
+    "## Creating a cache"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 43,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "09:20:47 redisvl.index.index INFO   Index already exists, not overwriting.\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "'oregon_trail_cache:602ac35f09671fc9e2a4f4902c6f82f06b9560ea6b5a5dd3e9218fcc1ff47e52'"
+      ]
+     },
+     "execution_count": 43,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import warnings\n",
+    "from redisvl.extensions.llmcache import SemanticCache\n",
+    "warnings.filterwarnings(\"ignore\")\n",
+    "\n",
+    "hunting_example = \"There's a deer. You're starving. You know what you have to do...\"\n",
+    "\n",
+    "semantic_cache = SemanticCache(\n",
+    "    name=\"oregon_trail_cache\",\n",
+    "    redis_url=REDIS_URL,\n",
+    "    distance_threshold=0.1,\n",
+    ")\n",
+    "\n",
+    "semantic_cache.store(prompt=hunting_example, response=\"bang\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Testing the cache"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 42,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      " Question: There's a deer. You're hungry. You know what you have to do... \n",
+      "\n",
+      "Cache hit\n",
+      "Response time 0.18901395797729492s\n",
+      "\n",
+      " Question: You’ve encountered a dense forest near the Blue Mountains, and your party is unsure how to proceed. There is a fork in the road, and you must choose a path. Which way will you go? \n",
+      "\n",
+      "Invoking agent\n",
+      "Called multi choice structured\n",
+      "Response time 3.500865936279297s\n"
+     ]
+    }
+   ],
+   "source": [
+    "import time\n",
+    "\n",
+    "scenarios = [\n",
+    "    {\n",
+    "        \"question\": \"There's a deer. You're hungry. You know what you have to do...\",\n",
+    "        \"answer\": \"bang\",\n",
+    "        \"type\": \"cache_hit\",\n",
+    "    },\n",
+    "    {\n",
+    "        \"question\": \"You’ve encountered a dense forest near the Blue Mountains, and your party is unsure how to proceed. There is a fork in the road, and you must choose a path. Which way will you go?\",\n",
+    "        \"answer\": \"B\",\n",
+    "        \"options\": [\n",
+    "            \"A: take the northern trail\",\n",
+    "            \"B: take the southern trail\",\n",
+    "            \"C: turn around\",\n",
+    "            \"D: go fishing\",\n",
+    "        ],\n",
+    "        \"type\": \"multi-choice\",\n",
+    "    }\n",
+    "]\n",
+    "\n",
+    "for scenario in scenarios:\n",
+    "    print(f\"\\n Question: {scenario['question']} \\n\")\n",
+    "\n",
+    "    start = time.time()\n",
+    "\n",
+    "    cache_hit = semantic_cache.check(prompt=scenario[\"question\"], return_fields=[\"response\"])\n",
+    "\n",
+    "    if not cache_hit:\n",
+    "        print(\"Invoking agent\")\n",
+    "        res = graph.invoke({\"messages\": format_multi_choice_question(scenario)})\n",
+    "    else:\n",
+    "        print(\"Cache hit\")\n",
+    "\n",
+    "    response_time = time.time() - start\n",
+    "\n",
+    "    print(f\"Response time {response_time}s\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Scenario 5 - Allow/block list router\n",
+    "\n",
+    "When ChatGPT first launched, there was a famous example where a car dealership accidentally made one of the latest language models available for free to everyone. They assumed users would only ask questions about cars through their chatbot. However, a group of developers quickly realized that the model was powerful enough to answer coding questions, so they started using the dealership's chatbot for free. <br>\n",
+    "\n",
+    "To prevent this kind of misuse in your system, adding an allow/block router to the front of your application is essential. Fortunately, this is very easy to implement using `redisvl`.\n",
+    "\n",
+    "![diagram](../../assets/router_diagram.png)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Creating the router"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 52,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "10:35:18 redisvl.index.index INFO   Index already exists, not overwriting.\n"
+     ]
+    }
+   ],
+   "source": [
+    "from redisvl.extensions.router import Route, SemanticRouter\n",
+    "\n",
+    "# Semantic router\n",
+    "blocked_references = [\n",
+    "    \"thinks about aliens\",\n",
+    "    \"corporate questions about agile\",\n",
+    "    \"anything about the S&P 500\",\n",
+    "]\n",
+    "\n",
+    "blocked_route = Route(name=\"block_list\", references=blocked_references)\n",
+    "\n",
+    "router = SemanticRouter(\n",
+    "    name=\"bouncer\",\n",
+    "    routes=[blocked_route],\n",
+    "    redis_url=REDIS_URL,\n",
+    "    overwrite=False,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Testing the router"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 53,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      " Question: Tell me about the S&P 500? \n",
+      "\n",
+      "Blocked!\n"
+     ]
+    }
+   ],
+   "source": [
+    "scenario = {\n",
+    "        \"question\": \"Tell me about the S&P 500?\",\n",
+    "        \"answer\": \"you shall not pass\",\n",
+    "        \"type\": \"action\",\n",
+    "    }\n",
+    "\n",
+    "print(f\"\\n Question: {scenario['question']} \\n\")\n",
+    "\n",
+    "blocked_topic_match = router(scenario[\"question\"], distance_threshold=0.2)\n",
+    "\n",
+    "assert blocked_topic_match.name == \"block_list\"\n",
+    "\n",
+    "print(\"Blocked!\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Putting it all together\n",
+    "\n",
+    "Once you have defined all the pieces, connecting the various aspects of the full architecture becomes easy and you can tie them together with whatever logic you wish. \n",
+    "\n",
+    "This could be as simple as:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 54,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def respond_to_question(question):\n",
+    "    blocked_topic_match = router(question, distance_threshold=0.2)\n",
+    "\n",
+    "    if blocked_topic_match.name == \"block_list\":\n",
+    "        print(\"App block logic - short circuit\")\n",
+    "        return\n",
+    "\n",
+    "    cache_hit = semantic_cache.check(prompt=question, return_fields=[\"response\"])\n",
+    "\n",
+    "    if cache_hit:\n",
+    "        print(\"Cache hit - short circuit\")\n",
+    "        return cache_hit\n",
+    "    \n",
+    "    return graph.invoke({\"messages\": question})\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "provenance": []
+  },
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "name": "python3",
+   "language": "python"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
 }

--- a/python-recipes/vector-search/05_multivector_search.ipynb
+++ b/python-recipes/vector-search/05_multivector_search.ipynb
@@ -31,36 +31,6 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "huggingface/tokenizers: The current process just got forked, after parallelism has already been used. Disabling parallelism to avoid deadlocks...\n",
-      "To disable this warning, you can either:\n",
-      "\t- Avoid using `tokenizers` before the fork if possible\n",
-      "\t- Explicitly set the environment variable TOKENIZERS_PARALLELISM=(true | false)\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Found existing installation: redisvl 0.9.1\n",
-      "Uninstalling redisvl-0.9.1:\n",
-      "  Successfully uninstalled redisvl-0.9.1\n",
-      "Note: you may need to restart the kernel to use updated packages.\n"
-     ]
-    }
-   ],
-   "source": [
-    "%pip uninstall -y redisvl"
-   ]
-  },
-  {
-   "cell_type": "code",
    "execution_count": 1,
    "metadata": {},
    "outputs": [

--- a/python-recipes/vector-search/05_multivector_search.ipynb
+++ b/python-recipes/vector-search/05_multivector_search.ipynb
@@ -25,9 +25,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "%pip install  \"redisvl>=0.10.0\""
-   ]
+   "source": "%pip install  \"redisvl[sentence-transformers]>=0.10.0\""
   },
   {
    "cell_type": "code",


### PR DESCRIPTION
> NOTE: The line-count is _severely_ inflated by the removal of cell outputs and/or notebook data serialization difference.

## Changes

This PR addresses some of the simpler fixes for failing notebooks identified in the nightly runs (see https://github.com/redis/redis-vl-python/issues/475).

- Align base Redis Docker image for `test.yml` and `nightly-test.yml` to `redis:8`
- Exclude Langcache notebook from nightly tests until we have a test API key configured for it
- Remove accidental command in notebook that uninstalls redisvl
- Fix syntax for importing module now in langchain_core
- Fix syntax for importing from `langchain_text_splitters`
  - Except for RAG/02_langchain.ipynb - there's some other messy dependency conflict stuff going on there that I didn't want to touch in this PR