### PR TITLE
docs: note OpenAI client base_url for multi-model gateways

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,8 @@ Routing is a simple and effective way of preventing misuse with your AI applicat
 ### AI Gateways
 AI gateways manage LLM traffic through a centralized, managed layer that can implement routing, rate limiting, caching, and more.
 
+> **Tip:** The OpenAI client `base_url` pattern also works with other OpenAI-compatible multi-model gateways — for example [DaoXE](https://daoxe.com/?utm_source=github&utm_medium=organic&utm_campaign=redis-ai-resources&utm_content=ai-gateways) at `https://api.daoxe.com/v1`.
+
 | Recipe | GitHub | Google Colab |
 | --- | --- | --- |
 | 🚪 **LiteLLM Proxy** - Getting started with LiteLLM proxy and Redis | [![Open In GitHub](https://img.shields.io/badge/View-GitHub-green)](python-recipes/gateway/00_litellm_proxy_redis.ipynb) | [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/redis-developer/redis-ai-resources/blob/main/python-recipes/gateway/00_litellm_proxy_redis.ipynb) |

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Routing is a simple and effective way of preventing misuse with your AI applicat
 ### AI Gateways
 AI gateways manage LLM traffic through a centralized, managed layer that can implement routing, rate limiting, caching, and more.
 
-> **Tip:** The OpenAI client `base_url` pattern also works with other OpenAI-compatible multi-model gateways — for example [DaoXE](https://daoxe.com/?utm_source=github&utm_medium=organic&utm_campaign=redis-ai-resources&utm_content=ai-gateways) at `https://api.daoxe.com/v1`.
+> **Tip:** The OpenAI client `base_url` pattern also works with other OpenAI-compatible multi-model gateways — for example [DaoXE](https://daoxe.com/) at `https://api.daoxe.com/v1`.
 
 | Recipe | GitHub | Google Colab |
 | --- | --- | --- |


### PR DESCRIPTION
## Summary

The AI Gateways section already covers LiteLLM proxy + Redis for OpenAI-compatible traffic management.

This PR adds a short tip that the same OpenAI client `base_url` pattern works with other multi-model gateways, using [DaoXE](https://daoxe.com/) (`https://api.daoxe.com/v1`) as one concrete example.

Docs only — no runtime behavior changes.

## Test plan
- [ ] README renders
- [ ] Existing LiteLLM recipe table unchanged
- [ ] Tip is clearly optional

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
